### PR TITLE
[codex] UrlTrack V2 monorepo rewrite

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,55 +1,31 @@
-# ── Required ──────────────────────────────────────────────
-SECRET_KEY=change-this-to-64-random-chars
+# Supabase / Postgres
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+DATABASE_URL=
 
-# ── Server ────────────────────────────────────────────────
-SERVER_URL=https://your-domain.com
+# Redis / BullMQ
+REDIS_URL=redis://redis:6379
 
-# ── Database ──────────────────────────────────────────────
-DATABASE_URL=sqlite:///data/ulrtrack.db
+# Public app URLs
+BASE_DOMAIN=http://localhost:3000
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_API_URL=http://localhost:8000
 
-# ── AI Analyst (opzionale) ────────────────────────────────
-# Se vuoto, l'AI Analyst è disabilitato. Gemini free tier funziona.
+# API runtime
+API_HOST=0.0.0.0
+API_PORT=8000
+API_PUBLIC_URL=http://localhost:8000
+API_TRUST_PROXY=false
+API_CACHE_TTL_SECONDS=60
+API_RATE_LIMIT_MAX=120
+VISIT_TOKEN_SECRET=change-this-to-a-64-character-random-secret
+WEBHOOK_SIGNATURE_TOLERANCE_SECONDS=300
+
+# Dashboard runtime
+NEXT_PUBLIC_BASE_DOMAIN=http://localhost:3000
+
+# Optional integrations configured per workspace in the database
+OPENAI_API_KEY=
 GEMINI_API_KEY=
-GEMINI_MODEL=gemini-2.0-flash
-
-# ── Privacy ───────────────────────────────────────────────
-ANONYMIZE_IP=true
-VISIT_RETENTION_DAYS=90
-
-# ── Security ──────────────────────────────────────────────
-TRUST_PROXY_HEADERS=false
-CSP_STRICT=true
-SESSION_COOKIE_SECURE=false
-REQUIRE_VISIT_TOKEN=true
-VISIT_TOKEN_TTL_SECONDS=3600
-
-# ── Gates ─────────────────────────────────────────────────
-REQUIRE_CONSENT=false
-ALLOW_PARTIAL_EMAIL_CAPTURE=false
-CONSENT_TTL_DAYS=180
-
-# ── Features ──────────────────────────────────────────────
-# Maschera l'URL pubblico tramite is.gd (nasconde il tuo server)
-MASK_WITH_ISGD=false
-
-# ── Telegram Alerts (opzionale) ───────────────────────────
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_CHAT_ID=
-WEBHOOK_URL=
-WEBHOOK_SECRET=
-SMART_FOLLOWUP_HOURS=48
-
-# ── Cloudflare Turnstile (opzionale) ──────────────────────
-TURNSTILE_SITE_KEY=
-TURNSTILE_SECRET_KEY=
-
-# ── Rate limiting ─────────────────────────────────────────
-RATE_LIMIT_REDIRECT=60 per minute
-RATE_LIMIT_AUTH=10 per minute
-
-# ── Background worker ─────────────────────────────────────
-SKIP_BACKGROUND_WORKER=false
-
-# ── Malicious IP detection ────────────────────────────────
-MALICIOUS_IP_REFRESH_SECONDS=21600
-MALICIOUS_IP_MIN_COUNT=1000

--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,14 @@ __pycache__/
 venv/
 .venv/
 
+# Node / TypeScript
+node_modules/
+.next/
+dist/
+coverage/
+*.tsbuildinfo
+pnpm-store/
+
 # Database
 *.db
 *.sqlite3

--- a/README.md
+++ b/README.md
@@ -1,284 +1,84 @@
-# UrlTrack
+# UrlTrack V2
 
-UrlTrack is a self-hosted link tracking platform built with Flask. It sits between a public link and its destination, giving you full control over who can access it and deep visibility into what happens after the click.
+UrlTrack V2 is a self-hosted link intelligence platform for marketing teams that need fast redirects, visitor identification, identity graphs, flow-based link rules, webhook automation, and dashboard analytics.
 
-Unlike traditional link shorteners, UrlTrack focuses on context: it helps you understand who is interacting with your links, how, and why.
+This branch introduces the TypeScript monorepo requested for V2:
 
-It is designed for controlled campaigns, demos, internal investigations, and analytical use cases where standard shorteners and basic trackers fall short.
+- `apps/api` - Fastify public API, redirect engine, ThumbmarkJS bounce page, OpenAPI docs at `/api/docs`
+- `apps/dashboard` - Next.js App Router dashboard with Supabase Auth surfaces and React Flow link builder
+- `packages/db` - Prisma schema and Supabase Postgres RLS migration
+- `packages/worker` - BullMQ queues, identity matching, webhook signing and retry utilities
+- `packages/shared` - shared validation, types and scoring defaults
 
-## What UrlTrack does
-
-At its core, UrlTrack sits between a public link and its destination.
-
-A key design choice is the built-in anti-bot and anti-crawler system on both the domain and generated links. This makes the platform resistant to URL expanders and similar automated tools: UrlTrack can return a valid HTTP 200 response without ever exposing or resolving the real destination URL, effectively feeding false or empty information to automated systems.
-
-In practice, this means the final destination remains hidden from many automated inspection tools while still allowing the link to behave normally for intended visitors.
-
-## Anti-bot comparison
-
-### UrlTrack behavior (HTTP 200, destination hidden)
-![codice 200](our.png)
-
-### Comparison with standard tools (final URL exposed)
-![rivelano url finale](others.png)
-
-## Main features
-
-You can protect a link with:
-
-- captcha
-- password
-- email capture
-- country allowlist
-- VPN blocking
-- consent gate
-- schedule windows
-
-After the visitor passes those checks, UrlTrack records the visit and enriches it in the background. From the dashboard you can inspect individual campaigns, trace repeated visitors across links, view device profiles, and monitor leads that emerge from repeated visits.
-
-Depending on configuration, tracking data can include:
-
-- country and geolocation
-- device and browser details
-- fingerprint signals
-- dwell time
-- email capture
-- VPN hints
-- cross-visit correlations
-
-## Why this project exists
-
-Many URL shorteners hide useful statistics behind paid plans and often do not offer the level of flexibility or customization that advanced users need.
-
-UrlTrack was created to address that gap: a self-hosted solution with deep tracking, strong customization potential, and room for further expansion.
-
-It aims to provide a level of control and analytical depth comparable to platforms such as IPLogger or Grabify, while remaining fully customizable and under your own infrastructure.
-
-## Quick start
-
-If you want the least-friction local setup:
+## Local Setup
 
 ```bash
 git clone https://github.com/MN-company/UrlTrack.git
 cd UrlTrack
-./install.sh --run
+cp .env.example .env
+corepack enable
+pnpm install
+pnpm db:migrate
+pnpm dev
 ```
 
-That command will:
+Open:
 
-- create `.env` if missing
-- generate a strong `SECRET_KEY`
-- create `venv/`
-- install Python dependencies
-- run database migrations
-- start the local server
+- Dashboard: `http://localhost:3000`
+- API: `http://localhost:8000/health`
+- OpenAPI docs: `http://localhost:8000/api/docs`
 
-Then open:
-
-- `http://127.0.0.1:8000/`
-- first boot will send you to `http://127.0.0.1:8000/setup`
-
-## Docker mode
-
-If you prefer to run UrlTrack with Docker instead of a local Python environment:
+## Docker
 
 ```bash
-./install.sh --docker --run
-```
-
-That mode prepares `.env`, keeps SQLite data in `server/data/`, and starts the stack with `docker compose up --build`.
-
-If you want Docker without starting immediately:
-
-```bash
-./install.sh --docker
+cp .env.example .env
 docker compose up --build
 ```
 
-The container runs Alembic migrations on boot and then starts Gunicorn on port `8000`.
+The compose stack starts `api`, `dashboard`, `worker`, and `redis`. Postgres is intentionally not included because UrlTrack V2 uses Supabase Postgres.
 
-## Manual setup
+## Required Environment
 
-If you do not want the installer flow:
+```env
+SUPABASE_URL=
+SUPABASE_ANON_KEY=
+SUPABASE_SERVICE_ROLE_KEY=
+DATABASE_URL=
+REDIS_URL=
+NEXT_PUBLIC_SUPABASE_URL=
+NEXT_PUBLIC_SUPABASE_ANON_KEY=
+NEXT_PUBLIC_API_URL=
+BASE_DOMAIN=
+VISIT_TOKEN_SECRET=
+```
+
+## Validation
 
 ```bash
-python3 -m venv venv
-source venv/bin/activate
-pip install -r server/requirements.txt
-cp .env.example .env
-SKIP_BACKGROUND_WORKER=1 ./venv/bin/python -m flask --app server:create_app db upgrade
-./run.sh
+pnpm lint
+pnpm typecheck
+pnpm test
+pnpm build
 ```
 
-At minimum, `.env` should contain:
+## API Shape
 
-```env
-SECRET_KEY=replace-me
-SERVER_URL=http://127.0.0.1:8000
-DATABASE_URL=sqlite:///data/urltrack.db
+Public API responses follow:
+
+```json
+{ "data": {}, "meta": { "page": 1, "per_page": 20, "total": 150 } }
 ```
 
-## First run
+Authentication accepts either `X-Api-Key` or a Supabase Bearer token plus `X-Workspace-Id`.
 
-On a clean database:
+The redirect endpoint `GET /:slug` keeps redirect-side work minimal: it evaluates synchronous access rules, records a visit, serves a tiny ThumbmarkJS bounce page, and queues enrichment work through BullMQ.
 
-1. open `/setup`
-2. create first admin account
-3. save the one-time admin secret shown after setup
-4. sign in to dashboard
-5. optionally enable TOTP or passkeys from security settings
+## Webhooks
 
-That one-time admin secret is only for future admin creation. It is not part of normal login.
-
-## Main areas of the dashboard
-
-### Home
-
-Campaign summary, recent links, recent visits, and fast access to common actions.
-
-### Campaigns
-
-Per-link analytics page with visit charts, referrers, countries, engagement metrics, and a visit log.
-
-### Graph
-
-A visual graph connecting `canvas_hash`, visited slugs, and known emails.
-
-### Leads
-
-A lightweight lead view that groups repeated visits by fingerprint or email so you can inspect history in one place.
-
-### AI Analyst
-
-An assistant view that can reason over visits and search context using commands like `@visit:`, `@hash:`, `@link:`, `@ip:`, and `@email:`.
-
-### Settings
-
-Manage runtime values, domain lists, Telegram credentials, AI model settings, and other operational toggles.
-
-## Optional integrations
-
-None of these are mandatory for basic tracking.
-
-### Gemini
-
-Used by AI Analyst.
-
-Add to `.env`:
-
-```env
-GEMINI_API_KEY=
-GEMINI_MODEL=gemini-2.0-flash
-```
-
-If `GEMINI_API_KEY` is empty, AI features stay visible but generation is effectively disabled.
-
-### Telegram
-
-Used for visit notifications and digests.
-
-1. create a bot with `@BotFather`
-2. send at least one message to the bot
-3. call:
+Outbound webhooks are signed with HMAC-SHA256:
 
 ```text
-https://api.telegram.org/bot<YOUR_TOKEN>/getUpdates
+X-UrlTrack-Signature: sha256=<hash>
 ```
 
-4. copy the chat id into `.env`
-
-```env
-TELEGRAM_BOT_TOKEN=
-TELEGRAM_CHAT_ID=
-```
-
-### Cloudflare Turnstile
-
-Used only if you enable captcha gate on links.
-
-```env
-TURNSTILE_SITE_KEY=
-TURNSTILE_SECRET_KEY=
-```
-
-### is.gd
-
-Optional masking for public links when `MASK_WITH_ISGD=true`. No API key required.
-
-## Docker, Fly.io, Linux deploy
-
-This repo includes deploy assets for a few different styles:
-
-- `Dockerfile`
-- `docker-compose.yml`
-- `fly.toml`
-- `deploy/nginx/ulrtrack.conf`
-- `deploy/systemd/ulrtrack.service`
-- `deploy/fail2ban/...`
-
-For Fly.io, `fly.toml` is already configured for auto-start and auto-stop machines. For plain Linux, use the systemd and nginx files in `deploy/` as starting points, not as magic one-click infrastructure.
-
-## Useful commands
-
-Run migrations:
-
-```bash
-SKIP_BACKGROUND_WORKER=1 ./venv/bin/python -m flask --app server:create_app db upgrade
-```
-
-Create another admin from CLI:
-
-```bash
-python -m server.create_admin
-```
-
-Run local server with repo interpreter:
-
-```bash
-./venv/bin/python -m flask --app server:create_app run --host=127.0.0.1 --port=8000
-```
-
-## Repo structure
-
-- `server/` Flask app, routes, models, worker, templates, static assets
-- `migrations/` Alembic revisions
-- `deploy/` nginx, fail2ban, systemd, helper scripts
-- `tests/` pytest suite
-
-## Troubleshooting
-
-### Root returns 404 or wrong app boots
-
-Usually this means the wrong interpreter is being used or a stale process is still running. Use the repo venv explicitly:
-
-```bash
-pkill -f "flask --app server:create_app run" || true
-./venv/bin/python -m flask --app server:create_app run --host=127.0.0.1 --port=8000
-```
-
-### `flask db` says command not found
-
-Use the repo interpreter, not a global `flask` command:
-
-```bash
-./venv/bin/python -m flask --app server:create_app db upgrade
-```
-
-### Telegram alerts do not arrive
-
-Check the bot token, chat id, and whether the bot has received at least one message from the target chat.
-
-### Docker starts but shows warning from `requests`
-
-If the app still migrates and Gunicorn comes up, that warning is noisy but not fatal. Check:
-
-```bash
-docker compose ps
-docker compose logs --tail=200
-```
-
-## Final note
-
-UrlTrack should be considered software for educational purposes.
-
-It is not intended to identify any individual. The creator disclaims any responsibility connected to the proper or improper use of this tool.
+Retry timing is `30s`, `5min`, `30min`, `2h`, and `24h`. After the fifth failed attempt, the delivery is marked failed and the endpoint can be disabled by the worker.

--- a/apps/api/Dockerfile
+++ b/apps/api/Dockerfile
@@ -1,0 +1,16 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json pnpm-workspace.yaml turbo.json tsconfig.base.json ./
+COPY packages ./packages
+COPY apps/api ./apps/api
+COPY apps/dashboard/package.json ./apps/dashboard/package.json
+
+RUN pnpm install --frozen-lockfile
+
+EXPOSE 8000
+
+CMD ["pnpm", "--filter", "@urltrack/api", "start"]

--- a/apps/api/package.json
+++ b/apps/api/package.json
@@ -1,0 +1,36 @@
+{
+  "name": "@urltrack/api",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "start": "tsx src/index.ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@fastify/cors": "^10.0.2",
+    "@fastify/helmet": "^12.0.1",
+    "@fastify/rate-limit": "^10.2.1",
+    "@fastify/swagger": "^9.4.0",
+    "@fastify/swagger-ui": "^5.2.0",
+    "@prisma/client": "^6.0.1",
+    "@supabase/supabase-js": "^2.47.10",
+    "@urltrack/db": "workspace:*",
+    "@urltrack/shared": "workspace:*",
+    "@urltrack/worker": "workspace:*",
+    "bullmq": "^5.34.0",
+    "fastify": "^5.2.1",
+    "ioredis": "5.10.1",
+    "nanoid": "^5.0.9",
+    "pino": "^9.5.0",
+    "ua-parser-js": "^2.0.0",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/api/src/access-control.ts
+++ b/apps/api/src/access-control.ts
@@ -1,0 +1,98 @@
+import type { FastifyRequest } from "fastify";
+import { UAParser } from "ua-parser-js";
+
+import type { LinkRecord } from "./repositories/types";
+
+type AccessDecision =
+  | { allowed: true; deviceType: "mobile" | "tablet" | "desktop"; destinationUrl: string }
+  | { allowed: false; statusCode: number; reason: string; eventType: string };
+
+function stringArray(value: unknown): string[] {
+  return Array.isArray(value) ? value.filter((item): item is string => typeof item === "string") : [];
+}
+
+function detectDeviceType(userAgent: string): "mobile" | "tablet" | "desktop" {
+  const parser = new UAParser(userAgent);
+  const type = parser.getDevice().type;
+  if (type === "mobile") return "mobile";
+  if (type === "tablet") return "tablet";
+  return "desktop";
+}
+
+function requestCountry(request: FastifyRequest): string | undefined {
+  const header =
+    request.headers["cf-ipcountry"] ??
+    request.headers["x-vercel-ip-country"] ??
+    request.headers["x-urltrack-country"];
+  const value = Array.isArray(header) ? header[0] : header;
+  return typeof value === "string" && value.length === 2 ? value.toUpperCase() : undefined;
+}
+
+function isWithinTimeWindow(config: Record<string, unknown>): boolean {
+  const window = config.time_window;
+  if (!window || typeof window !== "object" || Array.isArray(window)) {
+    return true;
+  }
+  const record = window as Record<string, unknown>;
+  const start = typeof record.start_hour === "number" ? record.start_hour : undefined;
+  const end = typeof record.end_hour === "number" ? record.end_hour : undefined;
+  if (start === undefined || end === undefined) {
+    return true;
+  }
+  const hour = new Date().getUTCHours();
+  return start <= end ? hour >= start && hour < end : hour >= start || hour < end;
+}
+
+export function evaluateAccessControl(link: LinkRecord, request: FastifyRequest): AccessDecision {
+  const config = link.accessControlConfig;
+  const routing = link.routingConfig;
+  const userAgent = request.headers["user-agent"] ?? "";
+  const userAgentString = Array.isArray(userAgent) ? userAgent.join(" ") : userAgent;
+  const deviceType = detectDeviceType(userAgentString);
+
+  if (link.status !== "active") {
+    return { allowed: false, statusCode: 404, reason: "Link is not active.", eventType: "link.blocked" };
+  }
+
+  const expiresAt = typeof config.expires_at === "string" ? new Date(config.expires_at) : undefined;
+  if (expiresAt && Number.isFinite(expiresAt.getTime()) && expiresAt < new Date()) {
+    return { allowed: false, statusCode: 410, reason: "Link expired.", eventType: "link.expired" };
+  }
+
+  const maxClicks = typeof config.max_clicks === "number" ? config.max_clicks : undefined;
+  if (maxClicks !== undefined && link.clickCount >= maxClicks) {
+    return { allowed: false, statusCode: 410, reason: "Link click limit reached.", eventType: "link.expired" };
+  }
+
+  const allowlist = stringArray(config.geo_allowlist).map((country) => country.toUpperCase());
+  if (allowlist.length > 0) {
+    const country = requestCountry(request);
+    if (!country || !allowlist.includes(country)) {
+      return { allowed: false, statusCode: 403, reason: "Country not allowed.", eventType: "link.blocked" };
+    }
+  }
+
+  const allowedDevices = stringArray(config.device_types);
+  if (allowedDevices.length > 0 && !allowedDevices.includes(deviceType)) {
+    return { allowed: false, statusCode: 403, reason: "Device type not allowed.", eventType: "link.blocked" };
+  }
+
+  if (!isWithinTimeWindow(config)) {
+    return { allowed: false, statusCode: 403, reason: "Link is outside the allowed time window.", eventType: "link.blocked" };
+  }
+
+  for (const gate of ["password_gate", "email_gate", "captcha_gate"]) {
+    if (config[gate] === true) {
+      return { allowed: false, statusCode: 401, reason: `${gate.replace("_", " ")} required.`, eventType: "link.blocked" };
+    }
+  }
+
+  let destinationUrl = link.destinationUrl;
+  if (deviceType === "mobile" && typeof routing.ios_url === "string" && /iPhone|iPad|iPod/i.test(userAgentString)) {
+    destinationUrl = routing.ios_url;
+  } else if (deviceType === "mobile" && typeof routing.android_url === "string" && /Android/i.test(userAgentString)) {
+    destinationUrl = routing.android_url;
+  }
+
+  return { allowed: true, deviceType, destinationUrl };
+}

--- a/apps/api/src/auth.ts
+++ b/apps/api/src/auth.ts
@@ -1,0 +1,99 @@
+import { createClient, type SupabaseClient } from "@supabase/supabase-js";
+import type { FastifyReply, FastifyRequest } from "fastify";
+
+import { hashSecret } from "./crypto";
+import { sendError } from "./http";
+import type { AuthenticatedPrincipal, UrlTrackRepository } from "./repositories/types";
+import type { ApiConfig } from "./config";
+
+declare module "fastify" {
+  interface FastifyRequest {
+    principal?: AuthenticatedPrincipal;
+  }
+}
+
+export type AuthContext = {
+  config: ApiConfig;
+  repository: UrlTrackRepository;
+  supabase?: SupabaseClient;
+};
+
+export function createAuthContext(config: ApiConfig, repository: UrlTrackRepository): AuthContext {
+  const supabase =
+    config.SUPABASE_URL && config.SUPABASE_ANON_KEY
+      ? createClient(config.SUPABASE_URL, config.SUPABASE_ANON_KEY, {
+          auth: { persistSession: false }
+        })
+      : undefined;
+
+  return { config, repository, supabase };
+}
+
+export function requireAuth(context: AuthContext) {
+  return async (request: FastifyRequest, reply: FastifyReply) => {
+    const principal = await resolvePrincipal(request, context);
+    if (!principal) {
+      return sendError(reply, 401, "unauthorized", "A valid X-Api-Key or Supabase Bearer token is required.");
+    }
+    request.principal = principal;
+  };
+}
+
+export async function resolvePrincipal(
+  request: FastifyRequest,
+  context: AuthContext
+): Promise<AuthenticatedPrincipal | undefined> {
+  const apiKeyHeader = request.headers["x-api-key"];
+  const apiKey = Array.isArray(apiKeyHeader) ? apiKeyHeader[0] : apiKeyHeader;
+  if (apiKey) {
+    const record = await context.repository.findApiKeyByHash(hashSecret(apiKey));
+    if (!record) {
+      return undefined;
+    }
+    await context.repository.touchApiKey(record.id);
+    return {
+      apiKeyId: record.id,
+      workspaceId: record.workspaceId,
+      scopes: record.scopes
+    };
+  }
+
+  const authorization = request.headers.authorization;
+  const token = authorization?.startsWith("Bearer ") ? authorization.slice("Bearer ".length) : undefined;
+  if (!token || !context.supabase) {
+    return undefined;
+  }
+
+  const workspaceHeader = request.headers["x-workspace-id"];
+  const workspaceId = Array.isArray(workspaceHeader) ? workspaceHeader[0] : workspaceHeader;
+  if (!workspaceId) {
+    return undefined;
+  }
+
+  const { data, error } = await context.supabase.auth.getUser(token);
+  if (error || !data.user) {
+    return undefined;
+  }
+
+  const isMember = await context.repository.isWorkspaceMember(workspaceId, data.user.id);
+  if (!isMember) {
+    return undefined;
+  }
+
+  return {
+    userId: data.user.id,
+    workspaceId,
+    scopes: ["*"]
+  };
+}
+
+export function requireWorkspace(request: FastifyRequest, bodyWorkspaceId?: string): string {
+  const workspaceId = request.principal?.workspaceId;
+  if (!workspaceId) {
+    throw new Error("Missing authenticated workspace.");
+  }
+  if (bodyWorkspaceId && bodyWorkspaceId !== workspaceId) {
+    throw new Error("Payload workspace_id does not match the authenticated workspace.");
+  }
+  return workspaceId;
+}

--- a/apps/api/src/config.ts
+++ b/apps/api/src/config.ts
@@ -1,0 +1,41 @@
+import { z } from "zod";
+
+const devVisitSecret = "dev-only-urltrack-visit-token-secret-change-before-production";
+
+const envSchema = z.object({
+  API_CACHE_TTL_SECONDS: z.coerce.number().int().min(1).default(60),
+  API_HOST: z.string().default("0.0.0.0"),
+  API_PORT: z.coerce.number().int().min(1).max(65_535).default(8000),
+  API_PUBLIC_URL: z.string().url().default("http://localhost:8000"),
+  API_RATE_LIMIT_MAX: z.coerce.number().int().min(1).default(120),
+  API_TRUST_PROXY: z
+    .string()
+    .optional()
+    .transform((value) => value === "true"),
+  BASE_DOMAIN: z.string().url().default("http://localhost:3000"),
+  NODE_ENV: z.string().default("development"),
+  REDIS_URL: z.string().optional(),
+  SUPABASE_ANON_KEY: z.string().optional(),
+  SUPABASE_SERVICE_ROLE_KEY: z.string().optional(),
+  SUPABASE_URL: z.string().url().optional(),
+  URLTRACK_REPOSITORY: z.enum(["prisma", "memory"]).default("prisma"),
+  VISIT_TOKEN_SECRET: z.string().min(32).optional()
+});
+
+export type ApiConfig = z.infer<typeof envSchema> & {
+  visitTokenSecret: string;
+};
+
+export function loadConfig(env: NodeJS.ProcessEnv = process.env): ApiConfig {
+  const parsed = envSchema.parse(env);
+  const visitTokenSecret = parsed.VISIT_TOKEN_SECRET ?? (parsed.NODE_ENV === "production" ? "" : devVisitSecret);
+
+  if (!visitTokenSecret) {
+    throw new Error("VISIT_TOKEN_SECRET must be set in production.");
+  }
+
+  return {
+    ...parsed,
+    visitTokenSecret
+  };
+}

--- a/apps/api/src/crypto.ts
+++ b/apps/api/src/crypto.ts
@@ -1,0 +1,54 @@
+import { createHash, createHmac, randomBytes, timingSafeEqual } from "node:crypto";
+
+export function hashSecret(value: string): string {
+  return createHash("sha256").update(value).digest("hex");
+}
+
+export function safeEqual(first: string, second: string): boolean {
+  const firstBuffer = Buffer.from(first);
+  const secondBuffer = Buffer.from(second);
+  if (firstBuffer.length !== secondBuffer.length) {
+    return false;
+  }
+  return timingSafeEqual(firstBuffer, secondBuffer);
+}
+
+export function createVisitToken(visitId: string, secret: string, ttlSeconds = 3600): string {
+  const payload = {
+    exp: Math.floor(Date.now() / 1000) + ttlSeconds,
+    nonce: randomBytes(12).toString("hex"),
+    visit_id: visitId
+  };
+  const body = Buffer.from(JSON.stringify(payload)).toString("base64url");
+  const signature = createHmac("sha256", secret).update(body).digest("base64url");
+  return `${body}.${signature}`;
+}
+
+export function verifyVisitToken(token: string, secret: string): { visitId: string } | undefined {
+  try {
+    const [body, signature] = token.split(".");
+    if (!body || !signature) {
+      return undefined;
+    }
+
+    const expected = createHmac("sha256", secret).update(body).digest("base64url");
+    if (!safeEqual(signature, expected)) {
+      return undefined;
+    }
+
+    const payload = JSON.parse(Buffer.from(body, "base64url").toString("utf8")) as {
+      exp?: unknown;
+      visit_id?: unknown;
+    };
+    if (typeof payload.exp !== "number" || payload.exp < Math.floor(Date.now() / 1000)) {
+      return undefined;
+    }
+    if (typeof payload.visit_id !== "string") {
+      return undefined;
+    }
+
+    return { visitId: payload.visit_id };
+  } catch {
+    return undefined;
+  }
+}

--- a/apps/api/src/http.ts
+++ b/apps/api/src/http.ts
@@ -1,0 +1,18 @@
+import type { FastifyReply } from "fastify";
+
+import { type ApiErrorEnvelope, toApiEnvelope } from "@urltrack/shared";
+
+export function sendData<T>(reply: FastifyReply, data: T, meta?: Parameters<typeof toApiEnvelope<T>>[1]) {
+  return reply.type("application/json").send(toApiEnvelope(data, meta));
+}
+
+export function sendError(reply: FastifyReply, statusCode: number, code: string, message: string, details?: unknown) {
+  const payload: ApiErrorEnvelope = {
+    error: {
+      code,
+      message,
+      ...(details === undefined ? {} : { details })
+    }
+  };
+  return reply.status(statusCode).type("application/json").send(payload);
+}

--- a/apps/api/src/index.ts
+++ b/apps/api/src/index.ts
@@ -1,0 +1,10 @@
+import { loadConfig } from "./config";
+import { buildServer } from "./server";
+
+const config = loadConfig();
+const app = await buildServer({ config });
+
+await app.listen({
+  host: config.API_HOST,
+  port: config.API_PORT
+});

--- a/apps/api/src/queue.ts
+++ b/apps/api/src/queue.ts
@@ -1,0 +1,19 @@
+import { Queue } from "bullmq";
+import IORedis from "ioredis";
+
+import { QUEUE_NAMES } from "@urltrack/worker";
+
+export type EnqueueEnrichment = (visitId: string) => Promise<void>;
+
+export function createEnrichmentEnqueuer(redisUrl?: string): EnqueueEnrichment {
+  if (!redisUrl) {
+    return async () => undefined;
+  }
+
+  const connection = new IORedis(redisUrl, { maxRetriesPerRequest: null });
+  const queue = new Queue(QUEUE_NAMES.enrichment, { connection });
+
+  return async (visitId: string) => {
+    await queue.add("enrichVisit", { visitId });
+  };
+}

--- a/apps/api/src/redirect-page.ts
+++ b/apps/api/src/redirect-page.ts
@@ -1,0 +1,58 @@
+import { randomBytes } from "node:crypto";
+
+import { escapeHtml } from "@urltrack/shared";
+
+export type RedirectPageInput = {
+  apiBasePath?: string;
+  destinationUrl: string;
+  visitToken: string;
+};
+
+export function buildRedirectPage(input: RedirectPageInput): { html: string; nonce: string } {
+  const nonce = randomBytes(16).toString("base64url");
+  const apiPath = input.apiBasePath ?? "/api/v1/fp";
+  const destinationLiteral = JSON.stringify(input.destinationUrl);
+  const tokenLiteral = JSON.stringify(input.visitToken);
+  const apiPathLiteral = JSON.stringify(apiPath);
+
+  return {
+    nonce,
+    html: `<!doctype html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width,initial-scale=1">
+  <meta http-equiv="refresh" content="2;url=${escapeHtml(input.destinationUrl)}">
+  <title>Redirecting...</title>
+  <style nonce="${nonce}">
+    body{margin:0;background:#0A0A0A;color:#F5F5F5;font-family:system-ui,-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif;display:grid;min-height:100vh;place-items:center}
+    main{width:min(420px,calc(100vw - 32px));border:1px solid #2A2A2A;background:#141414;padding:24px}
+    .bar{height:3px;background:#2A2A2A;overflow:hidden}.bar:before{content:"";display:block;height:100%;width:42%;background:#00C853;animation:load 900ms infinite alternate}
+    p{color:#888888;margin:12px 0 0;font-size:14px}@keyframes load{to{transform:translateX(150%)}}
+  </style>
+</head>
+<body>
+  <main>
+    <div class="bar"></div>
+    <p>Preparing secure redirect...</p>
+    <noscript><p><a href="${escapeHtml(input.destinationUrl)}">Continue</a></p></noscript>
+  </main>
+  <script nonce="${nonce}" type="module">
+    import { getFingerprint } from "https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs/dist/thumbmark.esm.js";
+    const destinationUrl = ${destinationLiteral};
+    const visitToken = ${tokenLiteral};
+    const apiPath = ${apiPathLiteral};
+    try {
+      const thumbmark = await getFingerprint({ experimental: true });
+      const payload = JSON.stringify({ visit_token: visitToken, thumbmark });
+      navigator.sendBeacon(apiPath, new Blob([payload], { type: "application/json" }));
+    } catch {
+      // Fingerprinting is best-effort and must never block the redirect path.
+    } finally {
+      window.location.replace(destinationUrl);
+    }
+  </script>
+</body>
+</html>`
+  };
+}

--- a/apps/api/src/repositories/memory.ts
+++ b/apps/api/src/repositories/memory.ts
@@ -1,0 +1,248 @@
+import { randomUUID } from "node:crypto";
+
+import type {
+  ApiKeyRecord,
+  CampaignRecord,
+  CampaignStats,
+  JsonRecord,
+  LeadRecord,
+  LinkCreateInput,
+  LinkRecord,
+  LinkStats,
+  LinkUpdateInput,
+  ListResult,
+  UrlTrackRepository,
+  VisitCreateInput,
+  VisitRecord,
+  VisitorRecord,
+  WebhookEndpointRecord
+} from "./types";
+import { RepositoryConflictError } from "./types";
+
+const now = () => new Date();
+
+function paginate<T>(items: T[], page: number, perPage: number): ListResult<T> {
+  const start = (page - 1) * perPage;
+  return {
+    items: items.slice(start, start + perPage),
+    total: items.length
+  };
+}
+
+export class InMemoryRepository implements UrlTrackRepository {
+  readonly apiKeys = new Map<string, ApiKeyRecord>();
+  readonly campaigns = new Map<string, CampaignRecord>();
+  readonly links = new Map<string, LinkRecord>();
+  readonly visits = new Map<string, VisitRecord>();
+  readonly visitors = new Map<string, VisitorRecord>();
+  readonly leads = new Map<string, LeadRecord>();
+  readonly webhooks = new Map<string, WebhookEndpointRecord>();
+  readonly workspaceMembers = new Map<string, Set<string>>();
+
+  seedApiKey(record: ApiKeyRecord): void {
+    this.apiKeys.set(record.keyHash, record);
+  }
+
+  seedWorkspaceMember(workspaceId: string, userId: string): void {
+    const members = this.workspaceMembers.get(workspaceId) ?? new Set<string>();
+    members.add(userId);
+    this.workspaceMembers.set(workspaceId, members);
+  }
+
+  async archiveLink(workspaceId: string, id: string): Promise<LinkRecord | undefined> {
+    const link = await this.getLink(workspaceId, id);
+    if (!link) {
+      return undefined;
+    }
+    const archived = { ...link, status: "archived" as const, archivedAt: now(), updatedAt: now() };
+    this.links.set(id, archived);
+    return archived;
+  }
+
+  async createCampaign(input: Omit<CampaignRecord, "id" | "createdAt" | "updatedAt">): Promise<CampaignRecord> {
+    const campaign: CampaignRecord = {
+      ...input,
+      id: randomUUID(),
+      createdAt: now(),
+      updatedAt: now()
+    };
+    this.campaigns.set(campaign.id, campaign);
+    return campaign;
+  }
+
+  async createLink(input: LinkCreateInput): Promise<LinkRecord> {
+    const duplicate = [...this.links.values()].find(
+      (link) => link.workspaceId === input.workspaceId && link.slug === input.slug && link.archivedAt === null
+    );
+    if (duplicate) {
+      throw new RepositoryConflictError(`Slug '${input.slug}' already exists in this workspace.`);
+    }
+
+    const link: LinkRecord = {
+      ...input,
+      id: randomUUID(),
+      clickCount: 0,
+      archivedAt: null,
+      createdAt: now(),
+      updatedAt: now()
+    };
+    this.links.set(link.id, link);
+    return link;
+  }
+
+  async createVisit(input: VisitCreateInput): Promise<VisitRecord> {
+    const visit: VisitRecord = {
+      ...input,
+      id: randomUUID(),
+      visitorId: null,
+      trafficQualityScore: 100,
+      identityConfidenceScore: 0,
+      rawFingerprintJson: {},
+      isBot: input.isBot ?? false,
+      isVpn: input.isVpn ?? false,
+      isDatacenter: input.isDatacenter ?? false,
+      visitTokenHash: input.visitTokenHash ?? null,
+      matchReasons: [],
+      reviewSuggested: false,
+      createdAt: now(),
+      updatedAt: now()
+    };
+    this.visits.set(visit.id, visit);
+
+    const link = this.links.get(input.linkId);
+    if (link) {
+      this.links.set(link.id, { ...link, clickCount: link.clickCount + 1, updatedAt: now() });
+    }
+
+    return visit;
+  }
+
+  async createWebhook(input: Omit<WebhookEndpointRecord, "id" | "createdAt" | "updatedAt">): Promise<WebhookEndpointRecord> {
+    const webhook: WebhookEndpointRecord = {
+      ...input,
+      id: randomUUID(),
+      createdAt: now(),
+      updatedAt: now()
+    };
+    this.webhooks.set(webhook.id, webhook);
+    return webhook;
+  }
+
+  async findApiKeyByHash(keyHash: string): Promise<ApiKeyRecord | undefined> {
+    const record = this.apiKeys.get(keyHash);
+    if (!record || (record.expiresAt && record.expiresAt < now())) {
+      return undefined;
+    }
+    return record;
+  }
+
+  async findLinkBySlug(slug: string): Promise<LinkRecord | undefined> {
+    return [...this.links.values()].find((link) => link.slug === slug && link.status !== "archived");
+  }
+
+  async getCampaignStats(workspaceId: string, campaignId: string): Promise<CampaignStats> {
+    const links = [...this.links.values()].filter((link) => link.workspaceId === workspaceId && link.campaignId === campaignId);
+    const linkIds = new Set(links.map((link) => link.id));
+    const visits = [...this.visits.values()].filter((visit) => linkIds.has(visit.linkId));
+    const leads = [...this.leads.values()].filter((lead) => lead.workspaceId === workspaceId).length;
+    return { links: links.length, visits: visits.length, leads };
+  }
+
+  async getLink(workspaceId: string, id: string): Promise<LinkRecord | undefined> {
+    const link = this.links.get(id);
+    return link?.workspaceId === workspaceId ? link : undefined;
+  }
+
+  async getLinkStats(workspaceId: string, id: string): Promise<LinkStats> {
+    const visits = [...this.visits.values()].filter((visit) => visit.workspaceId === workspaceId && visit.linkId === id);
+    return {
+      total_clicks: visits.length,
+      unique_visitors: new Set(visits.map((visit) => visit.visitorId ?? visit.id)).size,
+      suspicious_clicks: visits.filter((visit) => visit.isBot || visit.isVpn || visit.isDatacenter).length,
+      qr_clicks: visits.filter((visit) => visit.sourceType === "qr").length
+    };
+  }
+
+  async isWorkspaceMember(workspaceId: string, userId: string): Promise<boolean> {
+    return this.workspaceMembers.get(workspaceId)?.has(userId) ?? false;
+  }
+
+  async listCampaigns(workspaceId: string): Promise<CampaignRecord[]> {
+    return [...this.campaigns.values()].filter((campaign) => campaign.workspaceId === workspaceId);
+  }
+
+  async listLeads(workspaceId: string, page: number, perPage: number): Promise<ListResult<LeadRecord>> {
+    return paginate(
+      [...this.leads.values()].filter((lead) => lead.workspaceId === workspaceId),
+      page,
+      perPage
+    );
+  }
+
+  async listLinks(workspaceId: string, page: number, perPage: number): Promise<ListResult<LinkRecord>> {
+    return paginate(
+      [...this.links.values()].filter((link) => link.workspaceId === workspaceId && link.archivedAt === null),
+      page,
+      perPage
+    );
+  }
+
+  async listVisitors(workspaceId: string, page: number, perPage: number): Promise<ListResult<VisitorRecord>> {
+    return paginate(
+      [...this.visitors.values()].filter((visitor) => visitor.workspaceId === workspaceId),
+      page,
+      perPage
+    );
+  }
+
+  async listVisits(workspaceId: string, linkId: string, page: number, perPage: number): Promise<ListResult<VisitRecord>> {
+    return paginate(
+      [...this.visits.values()].filter((visit) => visit.workspaceId === workspaceId && visit.linkId === linkId),
+      page,
+      perPage
+    );
+  }
+
+  async listWebhooks(workspaceId: string): Promise<WebhookEndpointRecord[]> {
+    return [...this.webhooks.values()].filter((webhook) => webhook.workspaceId === workspaceId);
+  }
+
+  async touchApiKey(_id: string): Promise<void> {
+    return;
+  }
+
+  async updateLink(workspaceId: string, id: string, input: LinkUpdateInput): Promise<LinkRecord | undefined> {
+    const existing = await this.getLink(workspaceId, id);
+    if (!existing) {
+      return undefined;
+    }
+    const updated = {
+      ...existing,
+      ...input,
+      updatedAt: now()
+    };
+    this.links.set(id, updated);
+    return updated;
+  }
+
+  async updateVisitFingerprint(visitId: string, rawFingerprintJson: JsonRecord): Promise<VisitRecord | undefined> {
+    const existing = this.visits.get(visitId);
+    if (!existing) {
+      return undefined;
+    }
+    const updated = {
+      ...existing,
+      rawFingerprintJson,
+      updatedAt: now()
+    };
+    this.visits.set(visitId, updated);
+    return updated;
+  }
+
+  async updateVisitTokenHash(visitId: string, tokenHash: string): Promise<void> {
+    const existing = this.visits.get(visitId);
+    if (existing) {
+      this.visits.set(visitId, { ...existing, visitTokenHash: tokenHash, updatedAt: now() });
+    }
+  }
+}

--- a/apps/api/src/repositories/prisma.ts
+++ b/apps/api/src/repositories/prisma.ts
@@ -1,0 +1,419 @@
+import type {
+  ApiKey,
+  Campaign,
+  Lead,
+  Link,
+  Prisma,
+  PrismaClient,
+  Visit,
+  Visitor,
+  WebhookEndpoint
+} from "@prisma/client";
+
+import { prisma as defaultPrisma } from "@urltrack/db";
+
+import type {
+  ApiKeyRecord,
+  CampaignRecord,
+  CampaignStats,
+  JsonRecord,
+  LeadRecord,
+  LinkCreateInput,
+  LinkRecord,
+  LinkStats,
+  LinkUpdateInput,
+  ListResult,
+  UrlTrackRepository,
+  VisitCreateInput,
+  VisitRecord,
+  VisitorRecord,
+  WebhookEndpointRecord
+} from "./types";
+
+function asJsonRecord(value: Prisma.JsonValue): JsonRecord {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as JsonRecord) : {};
+}
+
+function toLinkRecord(link: Link): LinkRecord {
+  return {
+    id: link.id,
+    workspaceId: link.workspaceId,
+    campaignId: link.campaignId,
+    domainId: link.domainId,
+    slug: link.slug,
+    destinationUrl: link.destinationUrl,
+    accessControlConfig: asJsonRecord(link.accessControlConfig),
+    routingConfig: asJsonRecord(link.routingConfig),
+    notificationConfig: asJsonRecord(link.notificationConfig),
+    qrConfig: asJsonRecord(link.qrConfig),
+    flowConfig: asJsonRecord(link.flowConfig),
+    status: link.status,
+    createdBy: link.createdBy,
+    clickCount: link.clickCount,
+    archivedAt: link.archivedAt,
+    createdAt: link.createdAt,
+    updatedAt: link.updatedAt
+  };
+}
+
+function toVisitRecord(visit: Visit): VisitRecord {
+  return {
+    id: visit.id,
+    workspaceId: visit.workspaceId,
+    linkId: visit.linkId,
+    visitorId: visit.visitorId,
+    sourceType: visit.sourceType,
+    trafficQualityScore: visit.trafficQualityScore,
+    identityConfidenceScore: visit.identityConfidenceScore,
+    eventType: visit.eventType,
+    rawFingerprintJson: asJsonRecord(visit.rawFingerprintJson),
+    ip: visit.ip,
+    userAgent: visit.userAgent,
+    referrer: visit.referrer,
+    countryCode: visit.countryCode,
+    deviceType: visit.deviceType,
+    isVpn: visit.isVpn,
+    isBot: visit.isBot,
+    isDatacenter: visit.isDatacenter,
+    visitTokenHash: visit.visitTokenHash,
+    matchReasons: visit.matchReasons,
+    reviewSuggested: visit.reviewSuggested,
+    createdAt: visit.createdAt,
+    updatedAt: visit.updatedAt
+  };
+}
+
+function toCampaignRecord(campaign: Campaign): CampaignRecord {
+  return {
+    id: campaign.id,
+    workspaceId: campaign.workspaceId,
+    name: campaign.name,
+    description: campaign.description,
+    status: campaign.status,
+    goal: campaign.goal,
+    createdAt: campaign.createdAt,
+    updatedAt: campaign.updatedAt
+  };
+}
+
+function toWebhookRecord(webhook: WebhookEndpoint): WebhookEndpointRecord {
+  return {
+    id: webhook.id,
+    workspaceId: webhook.workspaceId,
+    url: webhook.url,
+    secret: webhook.secret,
+    name: webhook.name,
+    enabled: webhook.enabled,
+    events: webhook.events,
+    createdAt: webhook.createdAt,
+    updatedAt: webhook.updatedAt
+  };
+}
+
+function toVisitorRecord(visitor: Visitor): VisitorRecord {
+  return {
+    id: visitor.id,
+    workspaceId: visitor.workspaceId,
+    primaryEmail: visitor.primaryEmail,
+    primaryIp: visitor.primaryIp,
+    primaryCanvasHash: visitor.primaryCanvasHash,
+    primaryFingerprintHash: visitor.primaryFingerprintHash,
+    firstSeen: visitor.firstSeen,
+    lastSeen: visitor.lastSeen,
+    totalVisits: visitor.totalVisits,
+    confidenceScore: visitor.confidenceScore,
+    trafficQualityAverage: visitor.trafficQualityAverage,
+    attributesJson: asJsonRecord(visitor.attributesJson)
+  };
+}
+
+function toLeadRecord(lead: Lead): LeadRecord {
+  return {
+    id: lead.id,
+    workspaceId: lead.workspaceId,
+    visitorId: lead.visitorId,
+    score: lead.score,
+    confidenceScore: lead.confidenceScore,
+    tags: lead.tags,
+    lifecycleStage: lead.lifecycleStage,
+    consentStatus: lead.consentStatus,
+    customFieldsJson: asJsonRecord(lead.customFieldsJson),
+    createdAt: lead.createdAt,
+    updatedAt: lead.updatedAt
+  };
+}
+
+export class PrismaRepository implements UrlTrackRepository {
+  constructor(private readonly db: PrismaClient = defaultPrisma) {}
+
+  async archiveLink(workspaceId: string, id: string): Promise<LinkRecord | undefined> {
+    const existing = await this.getLink(workspaceId, id);
+    if (!existing) {
+      return undefined;
+    }
+    const link = await this.db.link.update({
+      where: { id },
+      data: { archivedAt: new Date(), status: "archived" }
+    });
+    return toLinkRecord(link);
+  }
+
+  async createCampaign(input: Omit<CampaignRecord, "id" | "createdAt" | "updatedAt">): Promise<CampaignRecord> {
+    const campaign = await this.db.campaign.create({
+      data: {
+        workspaceId: input.workspaceId,
+        name: input.name,
+        description: input.description,
+        status: input.status as Campaign["status"],
+        goal: input.goal
+      }
+    });
+    return toCampaignRecord(campaign);
+  }
+
+  async createLink(input: LinkCreateInput): Promise<LinkRecord> {
+    const link = await this.db.link.create({
+      data: {
+        workspaceId: input.workspaceId,
+        campaignId: input.campaignId,
+        domainId: input.domainId,
+        slug: input.slug,
+        destinationUrl: input.destinationUrl,
+        accessControlConfig: input.accessControlConfig as Prisma.InputJsonValue,
+        routingConfig: input.routingConfig as Prisma.InputJsonValue,
+        notificationConfig: input.notificationConfig as Prisma.InputJsonValue,
+        qrConfig: input.qrConfig as Prisma.InputJsonValue,
+        flowConfig: input.flowConfig as Prisma.InputJsonValue,
+        status: input.status,
+        createdBy: input.createdBy
+      }
+    });
+    return toLinkRecord(link);
+  }
+
+  async createVisit(input: VisitCreateInput): Promise<VisitRecord> {
+    const visit = await this.db.visit.create({
+      data: {
+        workspaceId: input.workspaceId,
+        linkId: input.linkId,
+        sourceType: input.sourceType,
+        eventType: input.eventType,
+        ip: input.ip,
+        userAgent: input.userAgent,
+        referrer: input.referrer,
+        countryCode: input.countryCode,
+        deviceType: input.deviceType,
+        isBot: input.isBot ?? false,
+        isVpn: input.isVpn ?? false,
+        isDatacenter: input.isDatacenter ?? false,
+        visitTokenHash: input.visitTokenHash
+      }
+    });
+    await this.db.link.update({
+      where: { id: input.linkId },
+      data: { clickCount: { increment: 1 } }
+    });
+    return toVisitRecord(visit);
+  }
+
+  async createWebhook(input: Omit<WebhookEndpointRecord, "id" | "createdAt" | "updatedAt">): Promise<WebhookEndpointRecord> {
+    const webhook = await this.db.webhookEndpoint.create({
+      data: input
+    });
+    return toWebhookRecord(webhook);
+  }
+
+  async findApiKeyByHash(keyHash: string): Promise<ApiKeyRecord | undefined> {
+    const apiKey = await this.db.apiKey.findUnique({ where: { keyHash } });
+    if (!apiKey || (apiKey.expiresAt && apiKey.expiresAt < new Date())) {
+      return undefined;
+    }
+    return toApiKeyRecord(apiKey);
+  }
+
+  async findLinkBySlug(slug: string): Promise<LinkRecord | undefined> {
+    const link = await this.db.link.findFirst({
+      where: {
+        slug,
+        archivedAt: null
+      }
+    });
+    return link ? toLinkRecord(link) : undefined;
+  }
+
+  async getCampaignStats(workspaceId: string, campaignId: string): Promise<CampaignStats> {
+    const links = await this.db.link.findMany({
+      where: { workspaceId, campaignId },
+      select: { id: true }
+    });
+    const linkIds = links.map((link) => link.id);
+    const [visits, leads] = await Promise.all([
+      this.db.visit.count({ where: { workspaceId, linkId: { in: linkIds } } }),
+      this.db.lead.count({ where: { workspaceId } })
+    ]);
+    return { links: links.length, visits, leads };
+  }
+
+  async getLink(workspaceId: string, id: string): Promise<LinkRecord | undefined> {
+    const link = await this.db.link.findFirst({ where: { id, workspaceId } });
+    return link ? toLinkRecord(link) : undefined;
+  }
+
+  async getLinkStats(workspaceId: string, id: string): Promise<LinkStats> {
+    const [totalClicks, suspiciousClicks, qrClicks, uniqueVisitors] = await Promise.all([
+      this.db.visit.count({ where: { workspaceId, linkId: id } }),
+      this.db.visit.count({
+        where: {
+          workspaceId,
+          linkId: id,
+          OR: [{ isBot: true }, { isVpn: true }, { isDatacenter: true }]
+        }
+      }),
+      this.db.visit.count({ where: { workspaceId, linkId: id, sourceType: "qr" } }),
+      this.db.visit.findMany({
+        where: { workspaceId, linkId: id },
+        distinct: ["visitorId"],
+        select: { visitorId: true }
+      })
+    ]);
+
+    return {
+      total_clicks: totalClicks,
+      unique_visitors: uniqueVisitors.length,
+      suspicious_clicks: suspiciousClicks,
+      qr_clicks: qrClicks
+    };
+  }
+
+  async isWorkspaceMember(workspaceId: string, userId: string): Promise<boolean> {
+    const [ownedWorkspace, teamMember] = await Promise.all([
+      this.db.workspace.findFirst({ where: { id: workspaceId, ownerUserId: userId }, select: { id: true } }),
+      this.db.teamMember.findFirst({ where: { workspaceId, userId }, select: { id: true } })
+    ]);
+    return Boolean(ownedWorkspace || teamMember);
+  }
+
+  async listCampaigns(workspaceId: string): Promise<CampaignRecord[]> {
+    const campaigns = await this.db.campaign.findMany({
+      where: { workspaceId },
+      orderBy: { createdAt: "desc" }
+    });
+    return campaigns.map(toCampaignRecord);
+  }
+
+  async listLeads(workspaceId: string, page: number, perPage: number): Promise<ListResult<LeadRecord>> {
+    const [items, total] = await Promise.all([
+      this.db.lead.findMany({
+        where: { workspaceId },
+        orderBy: { score: "desc" },
+        skip: (page - 1) * perPage,
+        take: perPage
+      }),
+      this.db.lead.count({ where: { workspaceId } })
+    ]);
+    return { items: items.map(toLeadRecord), total };
+  }
+
+  async listLinks(workspaceId: string, page: number, perPage: number): Promise<ListResult<LinkRecord>> {
+    const [items, total] = await Promise.all([
+      this.db.link.findMany({
+        where: { workspaceId, archivedAt: null },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * perPage,
+        take: perPage
+      }),
+      this.db.link.count({ where: { workspaceId, archivedAt: null } })
+    ]);
+    return { items: items.map(toLinkRecord), total };
+  }
+
+  async listVisitors(workspaceId: string, page: number, perPage: number): Promise<ListResult<VisitorRecord>> {
+    const [items, total] = await Promise.all([
+      this.db.visitor.findMany({
+        where: { workspaceId },
+        orderBy: { lastSeen: "desc" },
+        skip: (page - 1) * perPage,
+        take: perPage
+      }),
+      this.db.visitor.count({ where: { workspaceId } })
+    ]);
+    return { items: items.map(toVisitorRecord), total };
+  }
+
+  async listVisits(workspaceId: string, linkId: string, page: number, perPage: number): Promise<ListResult<VisitRecord>> {
+    const [items, total] = await Promise.all([
+      this.db.visit.findMany({
+        where: { workspaceId, linkId },
+        orderBy: { createdAt: "desc" },
+        skip: (page - 1) * perPage,
+        take: perPage
+      }),
+      this.db.visit.count({ where: { workspaceId, linkId } })
+    ]);
+    return { items: items.map(toVisitRecord), total };
+  }
+
+  async listWebhooks(workspaceId: string): Promise<WebhookEndpointRecord[]> {
+    const webhooks = await this.db.webhookEndpoint.findMany({
+      where: { workspaceId },
+      orderBy: { createdAt: "desc" }
+    });
+    return webhooks.map(toWebhookRecord);
+  }
+
+  async touchApiKey(id: string): Promise<void> {
+    await this.db.apiKey.update({
+      where: { id },
+      data: { lastUsedAt: new Date() }
+    });
+  }
+
+  async updateLink(workspaceId: string, id: string, input: LinkUpdateInput): Promise<LinkRecord | undefined> {
+    const existing = await this.getLink(workspaceId, id);
+    if (!existing) {
+      return undefined;
+    }
+
+    const data: Prisma.LinkUncheckedUpdateInput = {};
+    if (input.campaignId !== undefined) data.campaignId = input.campaignId;
+    if (input.domainId !== undefined) data.domainId = input.domainId;
+    if (input.slug !== undefined) data.slug = input.slug;
+    if (input.destinationUrl !== undefined) data.destinationUrl = input.destinationUrl;
+    if (input.accessControlConfig !== undefined) data.accessControlConfig = input.accessControlConfig as Prisma.InputJsonValue;
+    if (input.routingConfig !== undefined) data.routingConfig = input.routingConfig as Prisma.InputJsonValue;
+    if (input.notificationConfig !== undefined) data.notificationConfig = input.notificationConfig as Prisma.InputJsonValue;
+    if (input.qrConfig !== undefined) data.qrConfig = input.qrConfig as Prisma.InputJsonValue;
+    if (input.flowConfig !== undefined) data.flowConfig = input.flowConfig as Prisma.InputJsonValue;
+    if (input.status !== undefined) data.status = input.status;
+
+    const link = await this.db.link.update({ where: { id }, data });
+    return toLinkRecord(link);
+  }
+
+  async updateVisitFingerprint(visitId: string, rawFingerprintJson: JsonRecord): Promise<VisitRecord | undefined> {
+    const visit = await this.db.visit
+      .update({
+        where: { id: visitId },
+        data: { rawFingerprintJson: rawFingerprintJson as Prisma.InputJsonValue }
+      })
+      .catch(() => undefined);
+    return visit ? toVisitRecord(visit) : undefined;
+  }
+
+  async updateVisitTokenHash(visitId: string, tokenHash: string): Promise<void> {
+    await this.db.visit.update({
+      where: { id: visitId },
+      data: { visitTokenHash: tokenHash }
+    });
+  }
+}
+
+function toApiKeyRecord(apiKey: ApiKey): ApiKeyRecord {
+  return {
+    id: apiKey.id,
+    workspaceId: apiKey.workspaceId,
+    keyHash: apiKey.keyHash,
+    scopes: apiKey.scopes,
+    expiresAt: apiKey.expiresAt
+  };
+}

--- a/apps/api/src/repositories/types.ts
+++ b/apps/api/src/repositories/types.ts
@@ -1,0 +1,173 @@
+import type { LinkStatus, SourceType, WebhookEvent } from "@urltrack/shared";
+
+export type JsonRecord = Record<string, unknown>;
+
+export type ListResult<T> = {
+  items: T[];
+  total: number;
+};
+
+export class RepositoryConflictError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RepositoryConflictError";
+  }
+}
+
+export type ApiKeyRecord = {
+  id: string;
+  workspaceId: string;
+  keyHash: string;
+  scopes: string[];
+  expiresAt: Date | null;
+};
+
+export type AuthenticatedPrincipal = {
+  workspaceId: string;
+  userId?: string;
+  apiKeyId?: string;
+  scopes: string[];
+};
+
+export type LinkRecord = {
+  id: string;
+  workspaceId: string;
+  campaignId: string | null;
+  domainId: string | null;
+  slug: string;
+  destinationUrl: string;
+  accessControlConfig: JsonRecord;
+  routingConfig: JsonRecord;
+  notificationConfig: JsonRecord;
+  qrConfig: JsonRecord;
+  flowConfig: JsonRecord;
+  status: LinkStatus;
+  createdBy: string;
+  clickCount: number;
+  archivedAt: Date | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type LinkCreateInput = Omit<LinkRecord, "id" | "clickCount" | "archivedAt" | "createdAt" | "updatedAt">;
+export type LinkUpdateInput = Partial<Omit<LinkCreateInput, "workspaceId" | "createdBy">>;
+
+export type VisitRecord = {
+  id: string;
+  workspaceId: string;
+  linkId: string;
+  visitorId: string | null;
+  sourceType: SourceType;
+  trafficQualityScore: number;
+  identityConfidenceScore: number;
+  eventType: string;
+  rawFingerprintJson: JsonRecord;
+  ip: string | null;
+  userAgent: string | null;
+  referrer: string | null;
+  countryCode: string | null;
+  deviceType: string | null;
+  isVpn: boolean;
+  isBot: boolean;
+  isDatacenter: boolean;
+  visitTokenHash: string | null;
+  matchReasons: string[];
+  reviewSuggested: boolean;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type VisitCreateInput = Pick<
+  VisitRecord,
+  "workspaceId" | "linkId" | "sourceType" | "eventType" | "ip" | "userAgent" | "referrer" | "countryCode" | "deviceType"
+> &
+  Partial<Pick<VisitRecord, "isBot" | "isVpn" | "isDatacenter" | "visitTokenHash">>;
+
+export type CampaignRecord = {
+  id: string;
+  workspaceId: string;
+  name: string;
+  description: string | null;
+  status: string;
+  goal: string | null;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type WebhookEndpointRecord = {
+  id: string;
+  workspaceId: string;
+  url: string;
+  secret: string;
+  name: string;
+  enabled: boolean;
+  events: string[];
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type VisitorRecord = {
+  id: string;
+  workspaceId: string;
+  primaryEmail: string | null;
+  primaryIp: string | null;
+  primaryCanvasHash: string | null;
+  primaryFingerprintHash: string | null;
+  firstSeen: Date;
+  lastSeen: Date;
+  totalVisits: number;
+  confidenceScore: number;
+  trafficQualityAverage: number;
+  attributesJson: JsonRecord;
+};
+
+export type LeadRecord = {
+  id: string;
+  workspaceId: string;
+  visitorId: string | null;
+  score: number;
+  confidenceScore: number;
+  tags: string[];
+  lifecycleStage: string;
+  consentStatus: string;
+  customFieldsJson: JsonRecord;
+  createdAt: Date;
+  updatedAt: Date;
+};
+
+export type LinkStats = {
+  total_clicks: number;
+  unique_visitors: number;
+  suspicious_clicks: number;
+  qr_clicks: number;
+};
+
+export type CampaignStats = {
+  links: number;
+  visits: number;
+  leads: number;
+};
+
+export interface UrlTrackRepository {
+  archiveLink(workspaceId: string, id: string): Promise<LinkRecord | undefined>;
+  createCampaign(input: Omit<CampaignRecord, "id" | "createdAt" | "updatedAt">): Promise<CampaignRecord>;
+  createLink(input: LinkCreateInput): Promise<LinkRecord>;
+  createVisit(input: VisitCreateInput): Promise<VisitRecord>;
+  createWebhook(input: Omit<WebhookEndpointRecord, "id" | "createdAt" | "updatedAt">): Promise<WebhookEndpointRecord>;
+  findApiKeyByHash(keyHash: string): Promise<ApiKeyRecord | undefined>;
+  findLinkBySlug(slug: string): Promise<LinkRecord | undefined>;
+  getCampaignStats(workspaceId: string, campaignId: string): Promise<CampaignStats>;
+  getLink(workspaceId: string, id: string): Promise<LinkRecord | undefined>;
+  getLinkStats(workspaceId: string, id: string): Promise<LinkStats>;
+  isWorkspaceMember(workspaceId: string, userId: string): Promise<boolean>;
+  listCampaigns(workspaceId: string): Promise<CampaignRecord[]>;
+  listLeads(workspaceId: string, page: number, perPage: number): Promise<ListResult<LeadRecord>>;
+  listLinks(workspaceId: string, page: number, perPage: number): Promise<ListResult<LinkRecord>>;
+  listVisitors(workspaceId: string, page: number, perPage: number): Promise<ListResult<VisitorRecord>>;
+  listVisits(workspaceId: string, linkId: string, page: number, perPage: number): Promise<ListResult<VisitRecord>>;
+  listWebhooks(workspaceId: string): Promise<WebhookEndpointRecord[]>;
+  touchApiKey(id: string): Promise<void>;
+  updateLink(workspaceId: string, id: string, input: LinkUpdateInput): Promise<LinkRecord | undefined>;
+  updateVisitFingerprint(visitId: string, rawFingerprintJson: JsonRecord): Promise<VisitRecord | undefined>;
+  updateVisitTokenHash(visitId: string, tokenHash: string): Promise<void>;
+}

--- a/apps/api/src/server.test.ts
+++ b/apps/api/src/server.test.ts
@@ -1,0 +1,128 @@
+import { describe, expect, it } from "vitest";
+
+import { loadConfig } from "./config";
+import { hashSecret } from "./crypto";
+import { InMemoryRepository } from "./repositories/memory";
+import { buildServer } from "./server";
+
+const workspaceId = "00000000-0000-4000-8000-000000000000";
+
+async function testApp() {
+  const repository = new InMemoryRepository();
+  repository.seedApiKey({
+    id: "api-key-1",
+    workspaceId,
+    keyHash: hashSecret("ut_test_key"),
+    scopes: ["*"],
+    expiresAt: null
+  });
+
+  const app = await buildServer({
+    config: loadConfig({
+      NODE_ENV: "test",
+      API_PUBLIC_URL: "http://localhost:8000",
+      BASE_DOMAIN: "http://localhost:3000",
+      URLTRACK_REPOSITORY: "memory",
+      VISIT_TOKEN_SECRET: "test-secret-that-is-long-enough-for-urltrack"
+    }),
+    enqueueEnrichment: async () => undefined,
+    repository
+  });
+
+  return { app, repository };
+}
+
+describe("UrlTrack API", () => {
+  it("creates and lists links with API key auth", async () => {
+    const { app } = await testApp();
+
+    const createResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/links",
+      headers: { "x-api-key": "ut_test_key" },
+      payload: {
+        workspace_id: workspaceId,
+        slug: "launch",
+        destination_url: "example.com/demo"
+      }
+    });
+
+    expect(createResponse.statusCode).toBe(201);
+    expect(createResponse.json().data.destination_url).toBe("https://example.com/demo");
+
+    const listResponse = await app.inject({
+      method: "GET",
+      url: "/api/v1/links",
+      headers: { "x-api-key": "ut_test_key" }
+    });
+    expect(listResponse.statusCode).toBe(200);
+    expect(listResponse.json().meta.total).toBe(1);
+
+    await app.close();
+  });
+
+  it("serves a ThumbmarkJS bounce page and accepts the beacon", async () => {
+    const { app, repository } = await testApp();
+    await repository.createLink({
+      workspaceId,
+      campaignId: null,
+      domainId: null,
+      slug: "abc",
+      destinationUrl: "https://example.com/",
+      accessControlConfig: {},
+      routingConfig: {},
+      notificationConfig: {},
+      qrConfig: {},
+      flowConfig: { nodes: [], edges: [] },
+      status: "active",
+      createdBy: "test"
+    });
+
+    const redirectResponse = await app.inject({
+      method: "GET",
+      url: "/abc",
+      headers: { "user-agent": "Mozilla/5.0" }
+    });
+
+    expect(redirectResponse.statusCode).toBe(200);
+    expect(redirectResponse.headers["content-security-policy"]).toContain("cdn.jsdelivr.net");
+    expect(redirectResponse.body).toContain("@thumbmarkjs/thumbmarkjs");
+    expect(redirectResponse.body).toContain("https://example.com/");
+
+    const visit = [...repository.visits.values()][0];
+    expect(visit).toBeDefined();
+    const token = redirectResponse.body.match(/const visitToken = "([^"]+)"/)?.[1];
+    expect(token).toBeDefined();
+
+    const fpResponse = await app.inject({
+      method: "POST",
+      url: "/api/v1/fp",
+      payload: {
+        visit_token: token,
+        thumbmark: { hash: "thumbmark-hash" }
+      }
+    });
+
+    expect(fpResponse.statusCode).toBe(200);
+    expect(repository.visits.get(visit!.id)?.rawFingerprintJson).toEqual({ hash: "thumbmark-hash" });
+
+    await app.close();
+  });
+
+  it("rejects mismatched workspace IDs", async () => {
+    const { app } = await testApp();
+    const response = await app.inject({
+      method: "POST",
+      url: "/api/v1/links",
+      headers: { "x-api-key": "ut_test_key" },
+      payload: {
+        workspace_id: "11111111-1111-4111-8111-111111111111",
+        slug: "blocked",
+        destination_url: "https://example.com"
+      }
+    });
+
+    expect(response.statusCode).toBe(403);
+    await app.close();
+  });
+});

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -1,0 +1,433 @@
+import { randomBytes } from "node:crypto";
+
+import cors from "@fastify/cors";
+import helmet from "@fastify/helmet";
+import rateLimit from "@fastify/rate-limit";
+import swagger from "@fastify/swagger";
+import swaggerUi from "@fastify/swagger-ui";
+import Fastify, { type FastifyInstance } from "fastify";
+import { ZodError } from "zod";
+
+import {
+  createCampaignSchema,
+  createLinkSchema,
+  createWebhookSchema,
+  fingerprintPayloadSchema,
+  paginationSchema,
+  updateLinkSchema
+} from "@urltrack/shared";
+
+import { evaluateAccessControl } from "./access-control";
+import { createAuthContext, requireAuth, requireWorkspace } from "./auth";
+import type { ApiConfig } from "./config";
+import { createVisitToken, hashSecret, verifyVisitToken } from "./crypto";
+import { sendData, sendError } from "./http";
+import { createEnrichmentEnqueuer, type EnqueueEnrichment } from "./queue";
+import { InMemoryRepository } from "./repositories/memory";
+import { PrismaRepository } from "./repositories/prisma";
+import type {
+  CampaignRecord,
+  LinkRecord,
+  UrlTrackRepository,
+  VisitRecord,
+  WebhookEndpointRecord
+} from "./repositories/types";
+import { RepositoryConflictError } from "./repositories/types";
+import { buildRedirectPage } from "./redirect-page";
+
+export type BuildServerOptions = {
+  config: ApiConfig;
+  enqueueEnrichment?: EnqueueEnrichment;
+  repository?: UrlTrackRepository;
+};
+
+export async function buildServer(options: BuildServerOptions): Promise<FastifyInstance> {
+  const repository =
+    options.repository ??
+    (options.config.URLTRACK_REPOSITORY === "memory" ? new InMemoryRepository() : new PrismaRepository());
+  const enqueueEnrichment = options.enqueueEnrichment ?? createEnrichmentEnqueuer(options.config.REDIS_URL);
+  const authContext = createAuthContext(options.config, repository);
+  const app = Fastify({
+    logger: true,
+    trustProxy: options.config.API_TRUST_PROXY
+  });
+
+  app.addContentTypeParser("text/plain", { parseAs: "string" }, (_request, body, done) => {
+    try {
+      const text = typeof body === "string" ? body : body.toString("utf8");
+      done(null, JSON.parse(text));
+    } catch {
+      done(null, body);
+    }
+  });
+
+  await app.register(helmet, {
+    contentSecurityPolicy: false
+  });
+  await app.register(cors, {
+    credentials: true,
+    origin: [options.config.BASE_DOMAIN, options.config.API_PUBLIC_URL]
+  });
+  await app.register(rateLimit, {
+    max: options.config.API_RATE_LIMIT_MAX,
+    timeWindow: "1 minute"
+  });
+  await app.register(swagger, {
+    openapi: {
+      info: {
+        title: "UrlTrack V2 API",
+        version: "2.0.0"
+      },
+      servers: [{ url: options.config.API_PUBLIC_URL }],
+      components: {
+        securitySchemes: {
+          ApiKeyAuth: { type: "apiKey", in: "header", name: "X-Api-Key" },
+          SupabaseBearer: { type: "http", scheme: "bearer" }
+        }
+      },
+      security: [{ ApiKeyAuth: [] }, { SupabaseBearer: [] }]
+    }
+  });
+  await app.register(swaggerUi, {
+    routePrefix: "/api/docs"
+  });
+
+  const auth = requireAuth(authContext);
+
+  app.get("/health", { schema: { hide: true } }, async (_request, reply) => sendData(reply, { ok: true }));
+
+  app.post("/api/v1/links", { preHandler: auth, schema: { tags: ["links"], summary: "Create link" } }, async (request, reply) => {
+    try {
+      const parsed = createLinkSchema.parse(request.body);
+      const workspaceId = requireWorkspace(request, parsed.workspace_id);
+      const link = await repository.createLink({
+        workspaceId,
+        campaignId: parsed.campaign_id ?? null,
+        domainId: parsed.domain_id ?? null,
+        slug: parsed.slug,
+        destinationUrl: parsed.destination_url,
+        accessControlConfig: parsed.access_control_config ?? {},
+        routingConfig: parsed.routing_config ?? {},
+        notificationConfig: parsed.notification_config ?? {},
+        qrConfig: parsed.qr_config ?? {},
+        flowConfig: parsed.flow_config ?? { nodes: [], edges: [] },
+        status: parsed.status,
+        createdBy: request.principal?.userId ?? request.principal?.apiKeyId ?? "api"
+      });
+      return sendData(reply.status(201), serializeLink(link));
+    } catch (error) {
+      return handleRouteError(error, reply);
+    }
+  });
+
+  app.get("/api/v1/links", { preHandler: auth, schema: { tags: ["links"], summary: "List links" } }, async (request, reply) => {
+    const { page, per_page: perPage } = paginationSchema.parse(request.query);
+    const workspaceId = requireWorkspace(request);
+    const result = await repository.listLinks(workspaceId, page, perPage);
+    return sendData(reply, result.items.map(serializeLink), { page, per_page: perPage, total: result.total });
+  });
+
+  app.get("/api/v1/links/:id", { preHandler: auth, schema: { tags: ["links"], summary: "Get link" } }, async (request, reply) => {
+    const id = routeParam(request.params, "id");
+    const workspaceId = requireWorkspace(request);
+    const link = await repository.getLink(workspaceId, id);
+    if (!link) {
+      return sendError(reply, 404, "not_found", "Link not found.");
+    }
+    return sendData(reply, serializeLink(link));
+  });
+
+  app.patch("/api/v1/links/:id", { preHandler: auth, schema: { tags: ["links"], summary: "Update link" } }, async (request, reply) => {
+    try {
+      const parsed = updateLinkSchema.parse(request.body);
+      const id = routeParam(request.params, "id");
+      const workspaceId = requireWorkspace(request);
+      const link = await repository.updateLink(workspaceId, id, {
+        campaignId: parsed.campaign_id,
+        domainId: parsed.domain_id,
+        slug: parsed.slug,
+        destinationUrl: parsed.destination_url,
+        accessControlConfig: parsed.access_control_config,
+        routingConfig: parsed.routing_config,
+        notificationConfig: parsed.notification_config,
+        qrConfig: parsed.qr_config,
+        flowConfig: parsed.flow_config,
+        status: parsed.status
+      });
+      if (!link) {
+        return sendError(reply, 404, "not_found", "Link not found.");
+      }
+      return sendData(reply, serializeLink(link));
+    } catch (error) {
+      return handleRouteError(error, reply);
+    }
+  });
+
+  app.delete("/api/v1/links/:id", { preHandler: auth, schema: { tags: ["links"], summary: "Archive link" } }, async (request, reply) => {
+    const id = routeParam(request.params, "id");
+    const workspaceId = requireWorkspace(request);
+    const link = await repository.archiveLink(workspaceId, id);
+    if (!link) {
+      return sendError(reply, 404, "not_found", "Link not found.");
+    }
+    return sendData(reply, serializeLink(link));
+  });
+
+  app.get("/api/v1/links/:id/stats", { preHandler: auth, schema: { tags: ["links"], summary: "Link stats" } }, async (request, reply) => {
+    const id = routeParam(request.params, "id");
+    const workspaceId = requireWorkspace(request);
+    return sendData(reply, await repository.getLinkStats(workspaceId, id));
+  });
+
+  app.get("/api/v1/links/:id/visits", { preHandler: auth, schema: { tags: ["links"], summary: "Link visits" } }, async (request, reply) => {
+    const id = routeParam(request.params, "id");
+    const workspaceId = requireWorkspace(request);
+    const { page, per_page: perPage } = paginationSchema.parse(request.query);
+    const result = await repository.listVisits(workspaceId, id, page, perPage);
+    return sendData(reply, result.items.map(serializeVisit), { page, per_page: perPage, total: result.total });
+  });
+
+  app.get("/api/v1/campaigns", { preHandler: auth, schema: { tags: ["campaigns"], summary: "List campaigns" } }, async (request, reply) => {
+    const workspaceId = requireWorkspace(request);
+    return sendData(reply, (await repository.listCampaigns(workspaceId)).map(serializeCampaign));
+  });
+
+  app.post("/api/v1/campaigns", { preHandler: auth, schema: { tags: ["campaigns"], summary: "Create campaign" } }, async (request, reply) => {
+    try {
+      const parsed = createCampaignSchema.parse(request.body);
+      const workspaceId = requireWorkspace(request, parsed.workspace_id);
+      const campaign = await repository.createCampaign({
+        workspaceId,
+        name: parsed.name,
+        description: parsed.description ?? null,
+        status: parsed.status,
+        goal: parsed.goal ?? null
+      });
+      return sendData(reply.status(201), serializeCampaign(campaign));
+    } catch (error) {
+      return handleRouteError(error, reply);
+    }
+  });
+
+  app.get("/api/v1/campaigns/:id/stats", { preHandler: auth, schema: { tags: ["campaigns"], summary: "Campaign stats" } }, async (request, reply) => {
+    const id = routeParam(request.params, "id");
+    const workspaceId = requireWorkspace(request);
+    return sendData(reply, await repository.getCampaignStats(workspaceId, id));
+  });
+
+  app.get("/api/v1/visitors", { preHandler: auth, schema: { tags: ["visitors"], summary: "List visitors" } }, async (request, reply) => {
+    const workspaceId = requireWorkspace(request);
+    const { page, per_page: perPage } = paginationSchema.parse(request.query);
+    const result = await repository.listVisitors(workspaceId, page, perPage);
+    return sendData(reply, result.items, { page, per_page: perPage, total: result.total });
+  });
+
+  app.get("/api/v1/visitors/:id", { preHandler: auth, schema: { tags: ["visitors"], summary: "Visitor detail" } }, async (_request, reply) => {
+    return sendError(reply, 501, "not_implemented", "Visitor detail is backed by the visitors list in this MVP.");
+  });
+
+  app.get("/api/v1/leads", { preHandler: auth, schema: { tags: ["leads"], summary: "List leads" } }, async (request, reply) => {
+    const workspaceId = requireWorkspace(request);
+    const { page, per_page: perPage } = paginationSchema.parse(request.query);
+    const result = await repository.listLeads(workspaceId, page, perPage);
+    return sendData(reply, result.items, { page, per_page: perPage, total: result.total });
+  });
+
+  app.get("/api/v1/webhooks", { preHandler: auth, schema: { tags: ["webhooks"], summary: "List webhooks" } }, async (request, reply) => {
+    const workspaceId = requireWorkspace(request);
+    return sendData(reply, (await repository.listWebhooks(workspaceId)).map((webhook) => serializeWebhook(webhook, false)));
+  });
+
+  app.post("/api/v1/webhooks", { preHandler: auth, schema: { tags: ["webhooks"], summary: "Register webhook" } }, async (request, reply) => {
+    try {
+      const parsed = createWebhookSchema.parse(request.body);
+      const workspaceId = requireWorkspace(request, parsed.workspace_id);
+      const webhook = await repository.createWebhook({
+        workspaceId,
+        url: parsed.url,
+        name: parsed.name,
+        enabled: parsed.enabled,
+        events: parsed.events,
+        secret: randomBytes(32).toString("hex")
+      });
+      return sendData(reply.status(201), serializeWebhook(webhook, true));
+    } catch (error) {
+      return handleRouteError(error, reply);
+    }
+  });
+
+  app.post(
+    "/api/v1/fp",
+    {
+      config: { rateLimit: { max: 60, timeWindow: "1 minute" } },
+      schema: { security: [], tags: ["fingerprint"], summary: "Receive ThumbmarkJS fingerprint" }
+    },
+    async (request, reply) => {
+      try {
+        const parsed = fingerprintPayloadSchema.parse(request.body);
+        const verified = verifyVisitToken(parsed.visit_token, options.config.visitTokenSecret);
+        if (!verified) {
+          return sendError(reply, 403, "invalid_visit_token", "Visit token is invalid or expired.");
+        }
+        const visit = await repository.updateVisitFingerprint(verified.visitId, parsed.thumbmark);
+        if (!visit) {
+          return sendError(reply, 404, "not_found", "Visit not found.");
+        }
+        await enqueueEnrichment(visit.id);
+        return sendData(reply, { ok: true });
+      } catch (error) {
+        return handleRouteError(error, reply);
+      }
+    }
+  );
+
+  app.get("/:slug", { schema: { security: [], tags: ["redirect"], summary: "Public redirect" } }, async (request, reply) => {
+    const slug = routeParam(request.params, "slug");
+    const link = await repository.findLinkBySlug(slug);
+    if (!link) {
+      return reply.status(404).type("text/plain").send("Not found");
+    }
+
+    const decision = evaluateAccessControl(link, request);
+    const visit = await repository.createVisit({
+      workspaceId: link.workspaceId,
+      linkId: link.id,
+      sourceType: request.url.includes("source=qr") ? "qr" : "link",
+      eventType: decision.allowed ? "visit.created" : decision.eventType,
+      ip: request.ip,
+      userAgent: request.headers["user-agent"]?.toString() ?? null,
+      referrer: request.headers.referer?.toString() ?? null,
+      countryCode: request.headers["cf-ipcountry"]?.toString() ?? null,
+      deviceType: decision.allowed ? decision.deviceType : null
+    });
+
+    if (!decision.allowed) {
+      await enqueueEnrichment(visit.id);
+      return reply
+        .status(decision.statusCode)
+        .type("text/html")
+        .send(`<html><body><h1>${decision.reason}</h1></body></html>`);
+    }
+
+    const visitToken = createVisitToken(visit.id, options.config.visitTokenSecret);
+    await repository.updateVisitTokenHash(visit.id, hashSecret(visitToken));
+    await enqueueEnrichment(visit.id);
+    const page = buildRedirectPage({
+      destinationUrl: decision.destinationUrl,
+      visitToken
+    });
+
+    return reply
+      .header(
+        "content-security-policy",
+        `default-src 'none'; script-src 'nonce-${page.nonce}' https://cdn.jsdelivr.net; style-src 'nonce-${page.nonce}'; connect-src 'self'; img-src 'self' data:; base-uri 'none'; object-src 'none'; frame-ancestors 'none'; form-action 'none'`
+      )
+      .header("cache-control", "no-store")
+      .type("text/html")
+      .send(page.html);
+  });
+
+  app.setErrorHandler((error, _request, reply) => {
+    if (error instanceof ZodError) {
+      return sendError(reply, 400, "validation_error", "Invalid request payload.", error.flatten());
+    }
+    app.log.error(error);
+    return sendError(reply, 500, "internal_error", "Unexpected server error.");
+  });
+
+  return app;
+}
+
+function routeParam(params: unknown, key: string): string {
+  if (!params || typeof params !== "object") {
+    return "";
+  }
+  const value = (params as Record<string, unknown>)[key];
+  return typeof value === "string" ? value : "";
+}
+
+function handleRouteError(error: unknown, reply: Parameters<typeof sendError>[0]) {
+  if (error instanceof ZodError) {
+    return sendError(reply, 400, "validation_error", "Invalid request payload.", error.flatten());
+  }
+  if (error instanceof RepositoryConflictError) {
+    return sendError(reply, 409, "conflict", error.message);
+  }
+  if (error instanceof Error && error.message.includes("workspace_id")) {
+    return sendError(reply, 403, "workspace_mismatch", error.message);
+  }
+  throw error;
+}
+
+function serializeLink(link: LinkRecord) {
+  return {
+    id: link.id,
+    workspace_id: link.workspaceId,
+    campaign_id: link.campaignId,
+    domain_id: link.domainId,
+    slug: link.slug,
+    destination_url: link.destinationUrl,
+    access_control_config: link.accessControlConfig,
+    routing_config: link.routingConfig,
+    notification_config: link.notificationConfig,
+    qr_config: link.qrConfig,
+    flow_config: link.flowConfig,
+    status: link.status,
+    click_count: link.clickCount,
+    archived_at: link.archivedAt,
+    created_at: link.createdAt,
+    updated_at: link.updatedAt
+  };
+}
+
+function serializeVisit(visit: VisitRecord) {
+  return {
+    id: visit.id,
+    workspace_id: visit.workspaceId,
+    link_id: visit.linkId,
+    visitor_id: visit.visitorId,
+    source_type: visit.sourceType,
+    traffic_quality_score: visit.trafficQualityScore,
+    identity_confidence_score: visit.identityConfidenceScore,
+    event_type: visit.eventType,
+    raw_fingerprint_json: visit.rawFingerprintJson,
+    ip: visit.ip,
+    user_agent: visit.userAgent,
+    referrer: visit.referrer,
+    country_code: visit.countryCode,
+    device_type: visit.deviceType,
+    is_vpn: visit.isVpn,
+    is_bot: visit.isBot,
+    is_datacenter: visit.isDatacenter,
+    match_reasons: visit.matchReasons,
+    review_suggested: visit.reviewSuggested,
+    created_at: visit.createdAt
+  };
+}
+
+function serializeCampaign(campaign: CampaignRecord) {
+  return {
+    id: campaign.id,
+    workspace_id: campaign.workspaceId,
+    name: campaign.name,
+    description: campaign.description,
+    status: campaign.status,
+    goal: campaign.goal,
+    created_at: campaign.createdAt,
+    updated_at: campaign.updatedAt
+  };
+}
+
+function serializeWebhook(webhook: WebhookEndpointRecord, includeSecret: boolean) {
+  return {
+    id: webhook.id,
+    workspace_id: webhook.workspaceId,
+    url: webhook.url,
+    name: webhook.name,
+    enabled: webhook.enabled,
+    events: webhook.events,
+    created_at: webhook.createdAt,
+    updated_at: webhook.updatedAt,
+    ...(includeSecret ? { secret: webhook.secret } : {})
+  };
+}

--- a/apps/api/tsconfig.json
+++ b/apps/api/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/apps/dashboard/Dockerfile
+++ b/apps/dashboard/Dockerfile
@@ -1,0 +1,23 @@
+FROM node:22-alpine AS deps
+
+WORKDIR /app
+RUN corepack enable
+
+COPY package.json pnpm-workspace.yaml turbo.json tsconfig.base.json ./
+COPY packages ./packages
+COPY apps/dashboard ./apps/dashboard
+COPY apps/api/package.json ./apps/api/package.json
+RUN pnpm install --frozen-lockfile
+
+FROM node:22-alpine AS runner
+
+WORKDIR /app
+ENV NODE_ENV=production
+RUN corepack enable
+
+COPY --from=deps /app ./
+RUN pnpm --filter @urltrack/dashboard build
+
+EXPOSE 3000
+
+CMD ["pnpm", "--filter", "@urltrack/dashboard", "start"]

--- a/apps/dashboard/app/ai-insights/page.tsx
+++ b/apps/dashboard/app/ai-insights/page.tsx
@@ -1,0 +1,48 @@
+import { AppShell } from "@/components/shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+const insights = [
+  ["warning", "Traffic quality drop", "EU paid campaign has a 19% increase in datacenter traffic."],
+  ["critical", "Lead cluster conflict", "Two high-value leads share Thumbmark but conflict on email domain."],
+  ["info", "Returning visitor pattern", "QR booth traffic converts after the third return visit."]
+] as const;
+
+export default function AIInsightsPage() {
+  return (
+    <AppShell>
+      <div className="mb-5">
+        <h1 className="font-display text-3xl">AI Insights</h1>
+        <p className="mt-1 text-sm text-muted">Workspace anomaly and lead ranking feed</p>
+      </div>
+
+      <section className="grid gap-4 xl:grid-cols-[0.85fr_1.15fr]">
+        <div className="space-y-3">
+          {insights.map(([tone, title, summary]) => (
+            <Card key={title} className="p-4">
+              <div className="mb-3 flex items-center justify-between gap-3">
+                <h2 className="font-display text-lg">{title}</h2>
+                <Badge tone={tone}>{tone}</Badge>
+              </div>
+              <p className="text-sm text-muted">{summary}</p>
+              <div className="mt-4">
+                <Button type="button" tone="ghost">Dismiss</Button>
+              </div>
+            </Card>
+          ))}
+        </div>
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Ask Workspace</h2>
+          <textarea
+            className="mt-4 min-h-40 w-full resize-none rounded-ui border border-border bg-obsidian p-3 text-sm outline-none focus:border-live"
+            defaultValue="Which links are creating high-confidence leads from Italy this week?"
+          />
+          <div className="mt-3 flex justify-end">
+            <Button type="button" tone="primary">Run</Button>
+          </div>
+        </Card>
+      </section>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/app/analytics/page.tsx
+++ b/apps/dashboard/app/analytics/page.tsx
@@ -1,0 +1,56 @@
+import { AppShell } from "@/components/shell";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+const bars = [48, 58, 44, 72, 81, 67, 92, 88, 76, 84, 96, 91];
+
+export default function AnalyticsPage() {
+  return (
+    <AppShell>
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl">Analytics</h1>
+          <p className="mt-1 text-sm text-muted">Campaign and link performance</p>
+        </div>
+        <div className="flex gap-2">
+          <Badge tone="neutral">Last 30 days</Badge>
+          <Badge tone="info">CSV ready</Badge>
+        </div>
+      </div>
+
+      <section className="grid gap-4 xl:grid-cols-[1.35fr_0.65fr]">
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Clicks Over Time</h2>
+          <div className="mt-6 flex h-72 items-end gap-2">
+            {bars.map((bar, index) => (
+              <div key={index} className="flex flex-1 flex-col items-center gap-2">
+                <div className="w-full rounded-sm bg-live" style={{ height: `${bar}%` }} />
+                <span className="font-mono text-[10px] text-muted">{index + 1}</span>
+              </div>
+            ))}
+          </div>
+        </Card>
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Device Breakdown</h2>
+          <div className="mt-6 space-y-4">
+            {[
+              ["Desktop", 52, "bg-live"],
+              ["Mobile", 39, "bg-signal"],
+              ["Tablet", 9, "bg-accent"]
+            ].map(([label, value, color]) => (
+              <div key={label as string}>
+                <div className="mb-2 flex justify-between text-sm">
+                  <span className="text-muted">{label as string}</span>
+                  <span className="font-mono">{value as number}%</span>
+                </div>
+                <div className="h-2 rounded-full bg-raised">
+                  <div className={`${color as string} h-2 rounded-full`} style={{ width: `${value as number}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </section>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/app/api-webhooks/page.tsx
+++ b/apps/dashboard/app/api-webhooks/page.tsx
@@ -1,0 +1,15 @@
+import { SectionPage } from "@/components/section-page";
+
+export default function ApiWebhooksPage() {
+  return (
+    <SectionPage
+      title="API & Webhooks"
+      subtitle="API keys and outbound delivery"
+      rows={[
+        ["n8n_pipeline", "active", "visit.created, lead.updated"],
+        ["crm_sync", "active", "HMAC signed"],
+        ["legacy_listener", "paused", "5 retries failed"]
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/app/auth/actions.ts
+++ b/apps/dashboard/app/auth/actions.ts
@@ -1,0 +1,34 @@
+"use server";
+
+import { redirect } from "next/navigation";
+
+import { createSupabaseServerClient } from "@/lib/supabase/server";
+
+export async function signIn(formData: FormData) {
+  const supabase = await createSupabaseServerClient();
+  const email = String(formData.get("email") ?? "");
+  const password = String(formData.get("password") ?? "");
+  const { error } = await supabase.auth.signInWithPassword({ email, password });
+  if (error) {
+    redirect("/auth/login?error=1");
+  }
+  redirect("/");
+}
+
+export async function signUp(formData: FormData) {
+  const supabase = await createSupabaseServerClient();
+  const email = String(formData.get("email") ?? "");
+  const password = String(formData.get("password") ?? "");
+  const { error } = await supabase.auth.signUp({ email, password });
+  if (error) {
+    redirect("/auth/signup?error=1");
+  }
+  redirect("/onboarding");
+}
+
+export async function resetPassword(formData: FormData) {
+  const supabase = await createSupabaseServerClient();
+  const email = String(formData.get("email") ?? "");
+  await supabase.auth.resetPasswordForEmail(email);
+  redirect("/auth/login?reset=1");
+}

--- a/apps/dashboard/app/auth/login/page.tsx
+++ b/apps/dashboard/app/auth/login/page.tsx
@@ -1,0 +1,31 @@
+import Link from "next/link";
+
+import { AuthPanel } from "@/components/auth-panel";
+import { Button } from "@/components/ui/button";
+
+import { signIn } from "../actions";
+
+export default function LoginPage() {
+  return (
+    <AuthPanel
+      title="Login"
+      footer={
+        <>
+          <Link href="/auth/signup" className="text-live">
+            Create account
+          </Link>{" "}
+          ·{" "}
+          <Link href="/auth/reset-password" className="text-live">
+            Reset password
+          </Link>
+        </>
+      }
+    >
+      <form action={signIn} className="space-y-3">
+        <input className="h-10 w-full rounded-ui border border-border bg-obsidian px-3 outline-none focus:border-live" name="email" type="email" placeholder="email" required />
+        <input className="h-10 w-full rounded-ui border border-border bg-obsidian px-3 outline-none focus:border-live" name="password" type="password" placeholder="password" required />
+        <Button type="submit" tone="primary" className="w-full">Login</Button>
+      </form>
+    </AuthPanel>
+  );
+}

--- a/apps/dashboard/app/auth/reset-password/page.tsx
+++ b/apps/dashboard/app/auth/reset-password/page.tsx
@@ -1,0 +1,17 @@
+import Link from "next/link";
+
+import { AuthPanel } from "@/components/auth-panel";
+import { Button } from "@/components/ui/button";
+
+import { resetPassword } from "../actions";
+
+export default function ResetPasswordPage() {
+  return (
+    <AuthPanel title="Reset Password" footer={<Link href="/auth/login" className="text-live">Back to login</Link>}>
+      <form action={resetPassword} className="space-y-3">
+        <input className="h-10 w-full rounded-ui border border-border bg-obsidian px-3 outline-none focus:border-live" name="email" type="email" placeholder="email" required />
+        <Button type="submit" tone="primary" className="w-full">Send Link</Button>
+      </form>
+    </AuthPanel>
+  );
+}

--- a/apps/dashboard/app/auth/signup/page.tsx
+++ b/apps/dashboard/app/auth/signup/page.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+
+import { AuthPanel } from "@/components/auth-panel";
+import { Button } from "@/components/ui/button";
+
+import { signUp } from "../actions";
+
+export default function SignupPage() {
+  return (
+    <AuthPanel title="Signup" footer={<Link href="/auth/login" className="text-live">Back to login</Link>}>
+      <form action={signUp} className="space-y-3">
+        <input className="h-10 w-full rounded-ui border border-border bg-obsidian px-3 outline-none focus:border-live" name="email" type="email" placeholder="email" required />
+        <input className="h-10 w-full rounded-ui border border-border bg-obsidian px-3 outline-none focus:border-live" name="password" type="password" placeholder="password" minLength={8} required />
+        <Button type="submit" tone="primary" className="w-full">Create</Button>
+      </form>
+    </AuthPanel>
+  );
+}

--- a/apps/dashboard/app/campaigns/page.tsx
+++ b/apps/dashboard/app/campaigns/page.tsx
@@ -1,0 +1,15 @@
+import { SectionPage } from "@/components/section-page";
+
+export default function CampaignsPage() {
+  return (
+    <SectionPage
+      title="Campaigns"
+      subtitle="Workspace campaign groups"
+      rows={[
+        ["summer_launch", "active", "4 links · 12.4K visits"],
+        ["booth_qr", "active", "2 links · 1.2K scans"],
+        ["investor_followup", "paused", "reviewing traffic quality"]
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/app/domains/page.tsx
+++ b/apps/dashboard/app/domains/page.tsx
@@ -1,0 +1,15 @@
+import { SectionPage } from "@/components/section-page";
+
+export default function DomainsPage() {
+  return (
+    <SectionPage
+      title="Domains"
+      subtitle="Workspace routing and SSL status"
+      rows={[
+        ["go.example.com", "verified", "SSL active"],
+        ["qr.example.com", "verified", "SSL active"],
+        ["fallback.example.net", "pending", "DNS check required"]
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/app/globals.css
+++ b/apps/dashboard/app/globals.css
@@ -1,0 +1,49 @@
+@import "@xyflow/react/dist/style.css";
+
+@tailwind base;
+@tailwind components;
+@tailwind utilities;
+
+:root {
+  color-scheme: dark;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+html,
+body {
+  min-height: 100%;
+}
+
+body {
+  margin: 0;
+  background: #0a0a0a;
+  color: #f5f5f5;
+  font-family: var(--font-body), sans-serif;
+}
+
+a {
+  color: inherit;
+  text-decoration: none;
+}
+
+button,
+input,
+select,
+textarea {
+  font: inherit;
+}
+
+.react-flow__node {
+  border-radius: 8px;
+  border: 1px solid #2a2a2a;
+  background: #141414;
+  color: #f5f5f5;
+  font-family: var(--font-body), sans-serif;
+}
+
+.react-flow__handle {
+  background: #00c853;
+}

--- a/apps/dashboard/app/identity-graph/page.tsx
+++ b/apps/dashboard/app/identity-graph/page.tsx
@@ -1,0 +1,16 @@
+import { SectionPage } from "@/components/section-page";
+
+export default function IdentityGraphPage() {
+  return (
+    <SectionPage
+      title="Identity Graph"
+      subtitle="Visitor, signal and lead relationships"
+      badge="graph"
+      rows={[
+        ["visitor_91ad", "active", "5 signals · 4 visits"],
+        ["canvas_c4a0", "verified", "linked to 3 visitors"],
+        ["email_b3f1", "active", "lead owner signal"]
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/app/layout.tsx
+++ b/apps/dashboard/app/layout.tsx
@@ -1,0 +1,32 @@
+import type { Metadata } from "next";
+import { DM_Sans, JetBrains_Mono, Syne } from "next/font/google";
+
+import "./globals.css";
+
+const display = Syne({
+  subsets: ["latin"],
+  variable: "--font-display"
+});
+
+const body = DM_Sans({
+  subsets: ["latin"],
+  variable: "--font-body"
+});
+
+const mono = JetBrains_Mono({
+  subsets: ["latin"],
+  variable: "--font-mono"
+});
+
+export const metadata: Metadata = {
+  title: "UrlTrack",
+  description: "Self-hosted link intelligence and visitor identification."
+};
+
+export default function RootLayout({ children }: Readonly<{ children: React.ReactNode }>) {
+  return (
+    <html lang="en">
+      <body className={`${display.variable} ${body.variable} ${mono.variable}`}>{children}</body>
+    </html>
+  );
+}

--- a/apps/dashboard/app/leads/page.tsx
+++ b/apps/dashboard/app/leads/page.tsx
@@ -1,0 +1,15 @@
+import { SectionPage } from "@/components/section-page";
+
+export default function LeadsPage() {
+  return (
+    <SectionPage
+      title="Leads"
+      subtitle="High-confidence identified visitors"
+      rows={[
+        ["lead_91ad", "active", "score 86 · demo, returning"],
+        ["lead_c47a", "active", "score 73 · email captured"],
+        ["lead_70be", "review", "score 58 · identity conflict"]
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/app/links/[id]/page.tsx
+++ b/apps/dashboard/app/links/[id]/page.tsx
@@ -1,0 +1,89 @@
+import { BarChart3, ExternalLink, QrCode, Settings, Users } from "lucide-react";
+
+import { FlowBuilder } from "@/components/flow-builder";
+import { AppShell } from "@/components/shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+const metrics = [
+  { label: "Clicks", value: "12,480", Icon: BarChart3 },
+  { label: "Visitors", value: "4,912", Icon: Users },
+  { label: "QR Scans", value: "1,204", Icon: QrCode },
+  { label: "Identity", value: "74%", Icon: Users }
+];
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function LinkDetailPage({ params }: PageProps) {
+  const { id } = await params;
+
+  return (
+    <AppShell>
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <div className="mb-2 flex flex-wrap items-center gap-2">
+            <h1 className="font-display text-3xl">/{id}</h1>
+            <Badge tone="live">active</Badge>
+          </div>
+          <p className="font-mono text-sm text-muted">https://example.com/campaign/launch</p>
+        </div>
+        <div className="flex gap-2">
+          <Button type="button">
+            <ExternalLink className="size-4" aria-hidden="true" />
+            Open
+          </Button>
+          <Button type="button" tone="primary">
+            <Settings className="size-4" aria-hidden="true" />
+            Save
+          </Button>
+        </div>
+      </div>
+
+      <div className="mb-4 grid gap-3 md:grid-cols-4">
+        {metrics.map(({ label, value, Icon }) => (
+          <Card key={label} className="p-4">
+            <div className="flex items-center justify-between text-muted">
+              <span className="text-sm">{label}</span>
+              <Icon className="size-4" aria-hidden="true" />
+            </div>
+            <div className="mt-2 font-display text-2xl">{value}</div>
+          </Card>
+        ))}
+      </div>
+
+      <section className="grid gap-4 xl:grid-cols-[1.3fr_0.7fr]">
+        <div>
+          <div className="mb-3 flex items-center justify-between">
+            <h2 className="font-display text-xl">Flow Builder</h2>
+            <Badge tone="info">React Flow</Badge>
+          </div>
+          <FlowBuilder />
+        </div>
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Visits</h2>
+          <div className="mt-4 space-y-3">
+            {[
+              ["vis_81f2", "Desktop", "US", "82%", "Clean"],
+              ["vis_62aa", "Mobile", "IT", "58%", "Review"],
+              ["vis_0ad1", "Desktop", "DE", "91%", "Clean"],
+              ["vis_f9c4", "Tablet", "FR", "34%", "VPN"]
+            ].map(([visit, device, country, confidence, quality]) => (
+              <div key={visit} className="grid grid-cols-[1fr_auto] gap-2 border-b border-border pb-3 last:border-0">
+                <div>
+                  <div className="font-mono text-sm">{visit}</div>
+                  <div className="mt-1 text-xs text-muted">
+                    {device} · {country} · {confidence}
+                  </div>
+                </div>
+                <Badge tone={quality === "Clean" ? "live" : quality === "VPN" ? "critical" : "warning"}>{quality}</Badge>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </section>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/app/notifications/page.tsx
+++ b/apps/dashboard/app/notifications/page.tsx
@@ -1,0 +1,15 @@
+import { SectionPage } from "@/components/section-page";
+
+export default function NotificationsPage() {
+  return (
+    <SectionPage
+      title="Notifications"
+      subtitle="Telegram, email and threshold rules"
+      rows={[
+        ["high_value_lead", "active", "lead.score_changed > 75"],
+        ["suspicious_cluster", "active", "suspicious.detected"],
+        ["qr_spike", "paused", "qr.scanned > baseline"]
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/app/onboarding/page.tsx
+++ b/apps/dashboard/app/onboarding/page.tsx
@@ -1,0 +1,26 @@
+import { AppShell } from "@/components/shell";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export default function OnboardingPage() {
+  return (
+    <AppShell>
+      <div className="mx-auto max-w-2xl">
+        <h1 className="font-display text-3xl">Create Workspace</h1>
+        <Card className="mt-5 p-5">
+          <form className="space-y-4">
+            <label className="block">
+              <span className="text-sm text-muted">Workspace name</span>
+              <input className="mt-2 h-10 w-full rounded-ui border border-border bg-obsidian px-3 outline-none focus:border-live" name="name" defaultValue="MN Ops" />
+            </label>
+            <label className="block">
+              <span className="text-sm text-muted">Slug</span>
+              <input className="mt-2 h-10 w-full rounded-ui border border-border bg-obsidian px-3 font-mono outline-none focus:border-live" name="slug" defaultValue="mn-ops" />
+            </label>
+            <Button type="submit" tone="primary">Create Workspace</Button>
+          </form>
+        </Card>
+      </div>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/app/page.tsx
+++ b/apps/dashboard/app/page.tsx
@@ -1,0 +1,98 @@
+import { ActivityFeed } from "@/components/activity-feed";
+import { MetricCard } from "@/components/metric-card";
+import { AppShell } from "@/components/shell";
+import { TrafficQuality } from "@/components/traffic-quality";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+const topLinks = [
+  { slug: "/launch", clicks: 2840, identity: 76, quality: "Clean" },
+  { slug: "/founder-note", clicks: 1660, identity: 63, quality: "Review" },
+  { slug: "/qr-booth", clicks: 940, identity: 81, quality: "Clean" },
+  { slug: "/investor-demo", clicks: 681, identity: 58, quality: "Review" },
+  { slug: "/safe-offer", clicks: 432, identity: 71, quality: "Clean" }
+];
+
+export default function DashboardPage() {
+  return (
+    <AppShell>
+      <div className="mb-5 flex flex-wrap items-end justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl">Dashboard</h1>
+          <p className="mt-1 text-sm text-muted">Workspace signal summary</p>
+        </div>
+        <Badge tone="live">sub-50ms redirect target</Badge>
+      </div>
+
+      <section className="grid gap-3 md:grid-cols-2 xl:grid-cols-5">
+        <MetricCard label="Clicks Today" value={18420} delta={12} series={[18, 22, 19, 28, 34, 39, 43]} />
+        <MetricCard label="Unique Visitors" value={6210} delta={9} series={[8, 12, 16, 22, 20, 31, 36]} tone="info" />
+        <MetricCard label="Active Links" value={128} delta={4} series={[22, 22, 24, 24, 27, 29, 31]} />
+        <MetricCard label="Leads Captured" value={914} delta={17} series={[9, 11, 14, 18, 21, 25, 29]} tone="info" />
+        <MetricCard label="Suspicious %" value={11} delta={-6} series={[22, 19, 18, 14, 13, 12, 11]} tone="warning" />
+      </section>
+
+      <section className="mt-4 grid gap-4 xl:grid-cols-[1.35fr_0.65fr]">
+        <Card className="p-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-lg">Top Links</h2>
+            <span className="font-mono text-xs text-muted">last 24h</span>
+          </div>
+          <div className="overflow-x-auto">
+            <table className="w-full min-w-[620px] border-collapse text-sm">
+              <thead className="text-left text-muted">
+                <tr className="border-b border-border">
+                  <th className="py-2 font-normal">Slug</th>
+                  <th className="py-2 font-normal">Clicks</th>
+                  <th className="py-2 font-normal">Identity</th>
+                  <th className="py-2 font-normal">Quality</th>
+                </tr>
+              </thead>
+              <tbody>
+                {topLinks.map((link) => (
+                  <tr key={link.slug} className="border-b border-border last:border-0">
+                    <td className="py-3 font-mono">{link.slug}</td>
+                    <td className="py-3">{link.clicks.toLocaleString()}</td>
+                    <td className="py-3">
+                      <div className="flex items-center gap-2">
+                        <div className="h-2 w-28 rounded-full bg-raised">
+                          <div className="h-2 rounded-full bg-live" style={{ width: `${link.identity}%` }} />
+                        </div>
+                        <span className="font-mono text-xs">{link.identity}%</span>
+                      </div>
+                    </td>
+                    <td className="py-3">
+                      <Badge tone={link.quality === "Clean" ? "live" : "warning"}>{link.quality}</Badge>
+                    </td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        </Card>
+
+        <TrafficQuality />
+      </section>
+
+      <section className="mt-4 grid gap-4 xl:grid-cols-[0.8fr_1.2fr]">
+        <ActivityFeed />
+        <Card className="p-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-lg">Top Countries</h2>
+            <span className="font-mono text-xs text-muted">geo edge sample</span>
+          </div>
+          <div className="grid gap-3 sm:grid-cols-2">
+            {["US", "IT", "DE", "FR", "GB", "BR"].map((country, index) => (
+              <div key={country} className="flex items-center gap-3">
+                <span className="w-8 font-mono text-sm">{country}</span>
+                <div className="h-2 flex-1 rounded-full bg-raised">
+                  <div className="h-2 rounded-full bg-signal" style={{ width: `${92 - index * 11}%` }} />
+                </div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </section>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/app/qr/page.tsx
+++ b/apps/dashboard/app/qr/page.tsx
@@ -1,0 +1,15 @@
+import { SectionPage } from "@/components/section-page";
+
+export default function QRPage() {
+  return (
+    <SectionPage
+      title="QR Codes"
+      subtitle="QR assets and scan analytics"
+      rows={[
+        ["qr_booth_h", "active", "H correction · SVG"],
+        ["qr_launch_green", "active", "M correction · PNG"],
+        ["qr_safe_offer", "paused", "awaiting logo upload"]
+      ]}
+    />
+  );
+}

--- a/apps/dashboard/app/settings/page.tsx
+++ b/apps/dashboard/app/settings/page.tsx
@@ -1,0 +1,56 @@
+import { defaultWorkspaceSettings } from "@urltrack/shared";
+
+import { AppShell } from "@/components/shell";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card } from "@/components/ui/card";
+
+export default function SettingsPage() {
+  const traffic = defaultWorkspaceSettings.scoring.traffic_quality;
+  const lead = defaultWorkspaceSettings.scoring.lead_score;
+
+  return (
+    <AppShell>
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl">Settings</h1>
+          <p className="mt-1 text-sm text-muted">Workspace scoring and integrations</p>
+        </div>
+        <Button type="button" tone="primary">Save</Button>
+      </div>
+
+      <section className="grid gap-4 xl:grid-cols-2">
+        <Card className="p-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-xl">Traffic Quality</h2>
+            <Badge tone="warning">penalties</Badge>
+          </div>
+          {Object.entries(traffic).map(([key, value]) => (
+            <label key={key} className="mb-4 block last:mb-0">
+              <div className="mb-2 flex justify-between text-sm">
+                <span className="text-muted">{key}</span>
+                <span className="font-mono">{value}</span>
+              </div>
+              <input className="w-full accent-live" type="range" min="-100" max="100" defaultValue={value} />
+            </label>
+          ))}
+        </Card>
+        <Card className="p-4">
+          <div className="mb-4 flex items-center justify-between">
+            <h2 className="font-display text-xl">Lead Score</h2>
+            <Badge tone="live">bonuses</Badge>
+          </div>
+          {Object.entries(lead).map(([key, value]) => (
+            <label key={key} className="mb-4 block last:mb-0">
+              <div className="mb-2 flex justify-between text-sm">
+                <span className="text-muted">{key}</span>
+                <span className="font-mono">{value}</span>
+              </div>
+              <input className="w-full accent-live" type="number" defaultValue={value} />
+            </label>
+          ))}
+        </Card>
+      </section>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/app/visitors/[id]/page.tsx
+++ b/apps/dashboard/app/visitors/[id]/page.tsx
@@ -1,0 +1,104 @@
+import { GitBranch, Mail, Monitor, ShieldCheck } from "lucide-react";
+
+import { AppShell } from "@/components/shell";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+const signals = [
+  { Icon: Mail, type: "email_hash", value: "b3f1...a81", weight: 40 },
+  { Icon: Monitor, type: "thumbmark_hash", value: "91ad...ef2", weight: 15 },
+  { Icon: GitBranch, type: "canvas_webgl", value: "c4a0...019", weight: 30 },
+  { Icon: ShieldCheck, type: "webrtc_ip", value: "10.0...hash", weight: 10 }
+];
+
+type PageProps = {
+  params: Promise<{ id: string }>;
+};
+
+export default async function VisitorDetailPage({ params }: PageProps) {
+  const { id } = await params;
+
+  return (
+    <AppShell>
+      <div className="mb-5 flex flex-wrap items-start justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl">visitor_{id}</h1>
+          <p className="mt-1 font-mono text-sm text-muted">first_seen 2026-05-28 · last_seen 2026-06-01</p>
+        </div>
+        <Badge tone="live">confidence 81%</Badge>
+      </div>
+
+      <section className="grid gap-4 xl:grid-cols-[0.85fr_1.15fr]">
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Identity Signals</h2>
+          <div className="mt-4 space-y-3">
+            {signals.map(({ Icon, type, value, weight }) => (
+              <div key={type} className="grid grid-cols-[auto_1fr_auto] items-center gap-3 border-b border-border pb-3 last:border-0">
+                <Icon className="size-4 text-live" aria-hidden="true" />
+                <div>
+                  <div className="font-mono text-sm">{type}</div>
+                  <div className="mt-1 font-mono text-xs text-muted">{value}</div>
+                </div>
+                <Badge tone="info">+{weight}</Badge>
+              </div>
+            ))}
+          </div>
+        </Card>
+
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Visit Timeline</h2>
+          <div className="mt-4 space-y-4">
+            {["/launch", "/pricing", "/qr-booth", "/investor-demo"].map((slug, index) => (
+              <div key={slug} className="grid grid-cols-[88px_1fr_auto] items-center gap-3">
+                <span className="font-mono text-xs text-muted">10:{42 - index * 7}</span>
+                <div className="h-px bg-border" />
+                <Badge tone={index === 1 ? "warning" : "live"}>{slug}</Badge>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </section>
+
+      <section className="mt-4 grid gap-4 xl:grid-cols-2">
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Identity Graph</h2>
+          <div className="mt-4 grid h-72 place-items-center rounded-ui border border-border bg-obsidian">
+            <div className="relative size-56">
+              <div className="absolute left-20 top-20 grid size-16 place-items-center rounded-full border border-live bg-live/10 font-mono text-xs">
+                visitor
+              </div>
+              {["email", "fp", "ip", "lead"].map((node, index) => (
+                <div
+                  key={node}
+                  className="absolute grid size-14 place-items-center rounded-full border border-border bg-raised font-mono text-xs text-muted"
+                  style={{
+                    left: `${index % 2 === 0 ? 0 : 164}px`,
+                    top: `${index < 2 ? 0 : 164}px`
+                  }}
+                >
+                  {node}
+                </div>
+              ))}
+            </div>
+          </div>
+        </Card>
+        <Card className="p-4">
+          <h2 className="font-display text-xl">Lead Profile</h2>
+          <div className="mt-4 grid gap-3 sm:grid-cols-2">
+            {[
+              ["Score", "86"],
+              ["Stage", "qualified"],
+              ["Consent", "captured"],
+              ["Tags", "demo, returning"]
+            ].map(([label, value]) => (
+              <div key={label} className="rounded-ui border border-border bg-raised p-3">
+                <div className="text-xs text-muted">{label}</div>
+                <div className="mt-1 font-mono text-sm">{value}</div>
+              </div>
+            ))}
+          </div>
+        </Card>
+      </section>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/components/activity-feed.tsx
+++ b/apps/dashboard/components/activity-feed.tsx
@@ -1,0 +1,31 @@
+import { Badge } from "./ui/badge";
+import { Card } from "./ui/card";
+
+const events = [
+  { label: "visitor.identified", meta: "tm_91ad... matched ws lead", tone: "live" as const },
+  { label: "suspicious.detected", meta: "VPN cluster on /demo-brief", tone: "warning" as const },
+  { label: "lead.score_changed", meta: "lead_4c2 moved to 82", tone: "info" as const },
+  { label: "webhook.delivered", meta: "n8n outbound 204", tone: "neutral" as const }
+];
+
+export function ActivityFeed() {
+  return (
+    <Card className="p-4">
+      <div className="mb-4 flex items-center justify-between">
+        <h2 className="font-display text-lg">Realtime Feed</h2>
+        <Badge tone="live">streaming</Badge>
+      </div>
+      <div className="space-y-3">
+        {events.map((event) => (
+          <div key={event.label} className="flex items-start justify-between gap-4 border-b border-border pb-3 last:border-0 last:pb-0">
+            <div>
+              <div className="font-mono text-sm">{event.label}</div>
+              <div className="mt-1 text-sm text-muted">{event.meta}</div>
+            </div>
+            <Badge tone={event.tone}>{event.tone}</Badge>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/apps/dashboard/components/auth-panel.tsx
+++ b/apps/dashboard/components/auth-panel.tsx
@@ -1,0 +1,29 @@
+import { Network } from "lucide-react";
+import Link from "next/link";
+
+import { Card } from "@/components/ui/card";
+
+export function AuthPanel({ children, title, footer }: { children: React.ReactNode; title: string; footer: React.ReactNode }) {
+  return (
+    <main className="grid min-h-screen place-items-center bg-obsidian px-4 py-8 text-ink">
+      <div className="w-full max-w-md">
+        <div className="mb-5 flex items-center gap-3">
+          <div className="grid size-10 place-items-center rounded-ui border border-live/50 bg-live/10">
+            <Network className="size-5 text-live" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="font-display text-xl">UrlTrack</div>
+            <Link href="/" className="font-mono text-xs text-muted">
+              INTEL OPS
+            </Link>
+          </div>
+        </div>
+        <Card className="p-5">
+          <h1 className="font-display text-2xl">{title}</h1>
+          <div className="mt-5">{children}</div>
+        </Card>
+        <div className="mt-4 text-sm text-muted">{footer}</div>
+      </div>
+    </main>
+  );
+}

--- a/apps/dashboard/components/flow-builder.tsx
+++ b/apps/dashboard/components/flow-builder.tsx
@@ -1,0 +1,64 @@
+"use client";
+
+import { Background, Controls, Handle, Position, ReactFlow, type Edge, type Node, type NodeProps } from "@xyflow/react";
+import { GitBranch, Lock, Mail, MousePointer2, ShieldAlert, Split, Webhook } from "lucide-react";
+import { useMemo } from "react";
+
+type FlowNodeData = {
+  label: string;
+  kind: "trigger" | "condition" | "action" | "split" | "end";
+};
+
+const nodes: Node<FlowNodeData>[] = [
+  { id: "trigger", type: "urltrack", position: { x: 0, y: 80 }, data: { label: "Link Click", kind: "trigger" } },
+  { id: "quality", type: "urltrack", position: { x: 240, y: 0 }, data: { label: "Traffic Quality > 65", kind: "condition" } },
+  { id: "split", type: "urltrack", position: { x: 500, y: 80 }, data: { label: "A/B Split", kind: "split" } },
+  { id: "redirect", type: "urltrack", position: { x: 760, y: 0 }, data: { label: "Redirect URL", kind: "action" } },
+  { id: "gate", type: "urltrack", position: { x: 760, y: 170 }, data: { label: "Email Gate", kind: "action" } },
+  { id: "end", type: "urltrack", position: { x: 1020, y: 80 }, data: { label: "Lead Created", kind: "end" } }
+];
+
+const edges: Edge[] = [
+  { id: "trigger-quality", source: "trigger", target: "quality" },
+  { id: "quality-split", source: "quality", target: "split" },
+  { id: "split-redirect", source: "split", target: "redirect", label: "70%" },
+  { id: "split-gate", source: "split", target: "gate", label: "30%" },
+  { id: "redirect-end", source: "redirect", target: "end" },
+  { id: "gate-end", source: "gate", target: "end" }
+];
+
+const icons = {
+  action: Webhook,
+  condition: ShieldAlert,
+  end: Lock,
+  split: Split,
+  trigger: MousePointer2
+};
+
+function FlowNode({ data }: NodeProps<Node<FlowNodeData>>) {
+  const Icon = icons[data.kind] ?? GitBranch;
+  return (
+    <div className="min-w-44 rounded-ui border border-border bg-panel px-3 py-2 shadow-xl shadow-black/20">
+      <Handle type="target" position={Position.Left} />
+      <div className="flex items-center gap-2">
+        <Icon className="size-4 text-live" aria-hidden="true" />
+        <span className="text-xs uppercase text-muted">{data.kind}</span>
+      </div>
+      <div className="mt-2 text-sm">{data.label}</div>
+      <Handle type="source" position={Position.Right} />
+    </div>
+  );
+}
+
+export function FlowBuilder() {
+  const nodeTypes = useMemo(() => ({ urltrack: FlowNode }), []);
+
+  return (
+    <div className="h-[480px] overflow-hidden rounded-ui border border-border bg-obsidian">
+      <ReactFlow nodes={nodes} edges={edges} nodeTypes={nodeTypes} fitView proOptions={{ hideAttribution: true }}>
+        <Background color="#2A2A2A" />
+        <Controls showInteractive={false} />
+      </ReactFlow>
+    </div>
+  );
+}

--- a/apps/dashboard/components/metric-card.tsx
+++ b/apps/dashboard/components/metric-card.tsx
@@ -1,0 +1,48 @@
+import { ArrowDownRight, ArrowUpRight } from "lucide-react";
+
+import { formatCompactNumber } from "@/lib/format";
+import { cn } from "@/lib/utils";
+
+import { Card } from "./ui/card";
+
+type MetricCardProps = {
+  label: string;
+  value: number;
+  delta: number;
+  series: number[];
+  tone?: "live" | "warning" | "info";
+};
+
+export function MetricCard({ label, value, delta, series, tone = "live" }: MetricCardProps) {
+  const max = Math.max(...series, 1);
+  const isPositive = delta >= 0;
+
+  return (
+    <Card className="p-4">
+      <div className="flex items-start justify-between gap-3">
+        <div>
+          <div className="text-sm text-muted">{label}</div>
+          <div className="mt-2 font-display text-3xl">{formatCompactNumber(value)}</div>
+        </div>
+        <div
+          className={cn(
+            "inline-flex items-center gap-1 rounded-ui border px-2 py-1 font-mono text-xs",
+            isPositive ? "border-live/40 bg-live/10 text-live" : "border-accent/40 bg-accent/10 text-accent"
+          )}
+        >
+          {isPositive ? <ArrowUpRight className="size-3" /> : <ArrowDownRight className="size-3" />}
+          {Math.abs(delta)}%
+        </div>
+      </div>
+      <div className="mt-4 flex h-10 items-end gap-1">
+        {series.map((point, index) => (
+          <div
+            key={`${label}-${index}`}
+            className={cn("w-full rounded-sm", tone === "warning" ? "bg-accent" : tone === "info" ? "bg-signal" : "bg-live")}
+            style={{ height: `${Math.max(12, (point / max) * 100)}%` }}
+          />
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/apps/dashboard/components/section-page.tsx
+++ b/apps/dashboard/components/section-page.tsx
@@ -1,0 +1,48 @@
+import { AppShell } from "@/components/shell";
+import { Badge } from "@/components/ui/badge";
+import { Card } from "@/components/ui/card";
+
+type SectionPageProps = {
+  title: string;
+  subtitle: string;
+  badge?: string;
+  rows: Array<[string, string, string]>;
+};
+
+export function SectionPage({ title, subtitle, badge = "workspace", rows }: SectionPageProps) {
+  return (
+    <AppShell>
+      <div className="mb-5 flex flex-wrap items-center justify-between gap-4">
+        <div>
+          <h1 className="font-display text-3xl">{title}</h1>
+          <p className="mt-1 text-sm text-muted">{subtitle}</p>
+        </div>
+        <Badge tone="info">{badge}</Badge>
+      </div>
+      <Card className="p-4">
+        <div className="overflow-x-auto">
+          <table className="w-full min-w-[620px] border-collapse text-sm">
+            <thead className="text-left text-muted">
+              <tr className="border-b border-border">
+                <th className="py-2 font-normal">Name</th>
+                <th className="py-2 font-normal">Status</th>
+                <th className="py-2 font-normal">Signal</th>
+              </tr>
+            </thead>
+            <tbody>
+              {rows.map(([name, status, signal]) => (
+                <tr key={name} className="border-b border-border last:border-0">
+                  <td className="py-3 font-mono">{name}</td>
+                  <td className="py-3">
+                    <Badge tone={status === "active" || status === "verified" ? "live" : "warning"}>{status}</Badge>
+                  </td>
+                  <td className="py-3 text-muted">{signal}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      </Card>
+    </AppShell>
+  );
+}

--- a/apps/dashboard/components/shell.tsx
+++ b/apps/dashboard/components/shell.tsx
@@ -1,0 +1,81 @@
+import {
+  Activity,
+  Bell,
+  Bot,
+  ChartNoAxesCombined,
+  CircleDot,
+  GitBranch,
+  Globe,
+  Home,
+  KeyRound,
+  Link2,
+  Network,
+  QrCode,
+  Settings,
+  Target,
+  Users
+} from "lucide-react";
+import Link from "next/link";
+
+const navItems = [
+  { href: "/", icon: Home, label: "Dashboard" },
+  { href: "/campaigns", icon: Target, label: "Campaigns" },
+  { href: "/links/demo", icon: Link2, label: "Links" },
+  { href: "/qr", icon: QrCode, label: "QR Codes" },
+  { href: "/visitors/demo", icon: Users, label: "Visitors" },
+  { href: "/leads", icon: CircleDot, label: "Leads" },
+  { href: "/analytics", icon: ChartNoAxesCombined, label: "Analytics" },
+  { href: "/identity-graph", icon: GitBranch, label: "Identity Graph" },
+  { href: "/ai-insights", icon: Bot, label: "AI Insights" },
+  { href: "/notifications", icon: Bell, label: "Notifications" },
+  { href: "/domains", icon: Globe, label: "Domains" },
+  { href: "/api-webhooks", icon: KeyRound, label: "API & Webhooks" },
+  { href: "/settings", icon: Settings, label: "Settings" }
+] as const;
+
+export function AppShell({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="min-h-screen bg-obsidian text-ink">
+      <aside className="fixed inset-y-0 left-0 hidden w-64 border-r border-border bg-panel/95 xl:block">
+        <div className="flex h-16 items-center gap-3 border-b border-border px-5">
+          <div className="grid size-9 place-items-center rounded-ui border border-live/50 bg-live/10">
+            <Network className="size-5 text-live" aria-hidden="true" />
+          </div>
+          <div>
+            <div className="font-display text-lg">UrlTrack</div>
+            <div className="font-mono text-[11px] text-muted">INTEL OPS</div>
+          </div>
+        </div>
+        <nav className="space-y-1 px-3 py-4">
+          {navItems.map((item) => (
+            <Link
+              key={item.href}
+              href={item.href}
+              className="flex h-9 items-center gap-3 rounded-ui px-3 text-sm text-muted transition hover:bg-raised hover:text-ink"
+            >
+              <item.icon className="size-4" aria-hidden="true" />
+              <span>{item.label}</span>
+            </Link>
+          ))}
+        </nav>
+      </aside>
+
+      <div className="xl:pl-64">
+        <header className="sticky top-0 z-20 flex h-16 items-center justify-between border-b border-border bg-obsidian/90 px-4 backdrop-blur md:px-6">
+          <div className="flex items-center gap-3 xl:hidden">
+            <Network className="size-5 text-live" aria-hidden="true" />
+            <span className="font-display text-lg">UrlTrack</span>
+          </div>
+          <div className="hidden items-center gap-2 font-mono text-xs text-muted xl:flex">
+            <Activity className="size-4 text-live" aria-hidden="true" />
+            <span>LIVE SIGNAL</span>
+          </div>
+          <div className="flex items-center gap-2">
+            <span className="rounded-ui border border-border bg-panel px-3 py-1 font-mono text-xs text-muted">ws_mn_ops</span>
+          </div>
+        </header>
+        <main className="mx-auto w-full max-w-7xl px-4 py-5 md:px-6">{children}</main>
+      </div>
+    </div>
+  );
+}

--- a/apps/dashboard/components/traffic-quality.tsx
+++ b/apps/dashboard/components/traffic-quality.tsx
@@ -1,0 +1,28 @@
+import { Card } from "./ui/card";
+
+const rows = [
+  { label: "Clean", value: 72, color: "bg-live" },
+  { label: "Review", value: 18, color: "bg-accent" },
+  { label: "Blocked", value: 10, color: "bg-red-400" }
+];
+
+export function TrafficQuality() {
+  return (
+    <Card className="p-4">
+      <h2 className="font-display text-lg">Traffic Quality</h2>
+      <div className="mt-4 space-y-4">
+        {rows.map((row) => (
+          <div key={row.label}>
+            <div className="mb-2 flex items-center justify-between text-sm">
+              <span className="text-muted">{row.label}</span>
+              <span className="font-mono">{row.value}%</span>
+            </div>
+            <div className="h-2 rounded-full bg-raised">
+              <div className={`${row.color} h-2 rounded-full`} style={{ width: `${row.value}%` }} />
+            </div>
+          </div>
+        ))}
+      </div>
+    </Card>
+  );
+}

--- a/apps/dashboard/components/ui/badge.tsx
+++ b/apps/dashboard/components/ui/badge.tsx
@@ -1,0 +1,18 @@
+import { cn } from "@/lib/utils";
+
+type BadgeProps = {
+  children: React.ReactNode;
+  tone?: "live" | "warning" | "info" | "neutral" | "critical";
+};
+
+const tones = {
+  critical: "border-red-500/40 bg-red-500/10 text-red-200",
+  info: "border-signal/40 bg-signal/10 text-signal",
+  live: "border-live/40 bg-live/10 text-live",
+  neutral: "border-border bg-raised text-muted",
+  warning: "border-accent/40 bg-accent/10 text-accent"
+};
+
+export function Badge({ children, tone = "neutral" }: BadgeProps) {
+  return <span className={cn("inline-flex items-center rounded-ui border px-2 py-1 text-xs", tones[tone])}>{children}</span>;
+}

--- a/apps/dashboard/components/ui/button.tsx
+++ b/apps/dashboard/components/ui/button.tsx
@@ -1,0 +1,24 @@
+import { cn } from "@/lib/utils";
+
+type ButtonProps = React.ButtonHTMLAttributes<HTMLButtonElement> & {
+  tone?: "primary" | "secondary" | "ghost";
+};
+
+const tones = {
+  ghost: "border-transparent text-muted hover:text-ink",
+  primary: "border-live bg-live text-black hover:bg-live/90",
+  secondary: "border-border bg-raised text-ink hover:border-live/60"
+};
+
+export function Button({ className, tone = "secondary", ...props }: ButtonProps) {
+  return (
+    <button
+      className={cn(
+        "inline-flex h-9 items-center justify-center gap-2 rounded-ui border px-3 text-sm transition disabled:cursor-not-allowed disabled:opacity-50",
+        tones[tone],
+        className
+      )}
+      {...props}
+    />
+  );
+}

--- a/apps/dashboard/components/ui/card.tsx
+++ b/apps/dashboard/components/ui/card.tsx
@@ -1,0 +1,5 @@
+import { cn } from "@/lib/utils";
+
+export function Card({ className, ...props }: React.HTMLAttributes<HTMLDivElement>) {
+  return <div className={cn("rounded-ui border border-border bg-panel", className)} {...props} />;
+}

--- a/apps/dashboard/lib/format.test.ts
+++ b/apps/dashboard/lib/format.test.ts
@@ -1,0 +1,10 @@
+import { describe, expect, it } from "vitest";
+
+import { formatCompactNumber, formatPercent } from "./format";
+
+describe("format helpers", () => {
+  it("formats compact numbers and percentages", () => {
+    expect(formatCompactNumber(12500)).toBe("12.5K");
+    expect(formatPercent(42.4)).toBe("42%");
+  });
+});

--- a/apps/dashboard/lib/format.ts
+++ b/apps/dashboard/lib/format.ts
@@ -1,0 +1,10 @@
+export function formatCompactNumber(value: number): string {
+  return new Intl.NumberFormat("en", {
+    notation: "compact",
+    maximumFractionDigits: 1
+  }).format(value);
+}
+
+export function formatPercent(value: number): string {
+  return `${Math.round(value)}%`;
+}

--- a/apps/dashboard/lib/supabase/server.ts
+++ b/apps/dashboard/lib/supabase/server.ts
@@ -1,0 +1,25 @@
+import { createServerClient, type CookieOptions } from "@supabase/ssr";
+import { cookies } from "next/headers";
+
+export async function createSupabaseServerClient() {
+  const cookieStore = await cookies();
+  const supabaseUrl = process.env.NEXT_PUBLIC_SUPABASE_URL;
+  const supabaseAnonKey = process.env.NEXT_PUBLIC_SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    throw new Error("Supabase public environment variables are required.");
+  }
+
+  return createServerClient(supabaseUrl, supabaseAnonKey, {
+    cookies: {
+      getAll() {
+        return cookieStore.getAll();
+      },
+      setAll(cookiesToSet: Array<{ name: string; value: string; options: CookieOptions }>) {
+        for (const cookie of cookiesToSet) {
+          cookieStore.set(cookie.name, cookie.value, cookie.options);
+        }
+      }
+    }
+  });
+}

--- a/apps/dashboard/lib/utils.ts
+++ b/apps/dashboard/lib/utils.ts
@@ -1,0 +1,6 @@
+import { clsx, type ClassValue } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export function cn(...inputs: ClassValue[]) {
+  return twMerge(clsx(inputs));
+}

--- a/apps/dashboard/next-env.d.ts
+++ b/apps/dashboard/next-env.d.ts
@@ -1,0 +1,6 @@
+/// <reference types="next" />
+/// <reference types="next/image-types/global" />
+import "./.next/dev/types/routes.d.ts";
+
+// NOTE: This file should not be edited
+// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.

--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -1,0 +1,22 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  devIndicators: false,
+  output: "standalone",
+  poweredByHeader: false,
+  transpilePackages: ["@urltrack/shared"],
+  async headers() {
+    return [
+      {
+        source: "/(.*)",
+        headers: [
+          { key: "X-Content-Type-Options", value: "nosniff" },
+          { key: "X-Frame-Options", value: "DENY" },
+          { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+          { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" }
+        ]
+      }
+    ];
+  }
+};
+
+export default nextConfig;

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "@urltrack/dashboard",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "build": "next build",
+    "dev": "next dev -p 3000",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "start": "next start -p 3000",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@supabase/ssr": "^0.5.2",
+    "@supabase/supabase-js": "^2.47.10",
+    "@urltrack/shared": "workspace:*",
+    "@xyflow/react": "^12.3.6",
+    "class-variance-authority": "^0.7.1",
+    "clsx": "^2.1.1",
+    "lucide-react": "^0.468.0",
+    "next": "^16.0.7",
+    "qrcode": "^1.5.4",
+    "react": "^19.0.0",
+    "react-dom": "^19.0.0",
+    "recharts": "^2.15.0",
+    "tailwind-merge": "^2.5.5"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "@types/qrcode": "^1.5.5",
+    "@types/react": "^19.0.2",
+    "@types/react-dom": "^19.0.2",
+    "autoprefixer": "^10.4.20",
+    "postcss": "^8.4.49",
+    "tailwindcss": "^3.4.17",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/dashboard/postcss.config.mjs
+++ b/apps/dashboard/postcss.config.mjs
@@ -1,0 +1,6 @@
+export default {
+  plugins: {
+    tailwindcss: {},
+    autoprefixer: {}
+  }
+};

--- a/apps/dashboard/tailwind.config.ts
+++ b/apps/dashboard/tailwind.config.ts
@@ -1,0 +1,32 @@
+import type { Config } from "tailwindcss";
+
+const config: Config = {
+  content: ["./app/**/*.{ts,tsx}", "./components/**/*.{ts,tsx}", "./lib/**/*.{ts,tsx}"],
+  theme: {
+    extend: {
+      colors: {
+        accent: "#FF6D00",
+        border: "#2A2A2A",
+        ink: "#F5F5F5",
+        live: "#00C853",
+        muted: "#888888",
+        obsidian: "#0A0A0A",
+        panel: "#141414",
+        raised: "#1C1C1C",
+        signal: "#3BA7FF",
+        violet: "#A47CFF"
+      },
+      fontFamily: {
+        body: ["var(--font-body)", "sans-serif"],
+        display: ["var(--font-display)", "sans-serif"],
+        mono: ["var(--font-mono)", "monospace"]
+      },
+      borderRadius: {
+        ui: "8px"
+      }
+    }
+  },
+  plugins: []
+};
+
+export default config;

--- a/apps/dashboard/tsconfig.json
+++ b/apps/dashboard/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "allowJs": false,
+    "incremental": true,
+    "jsx": "preserve",
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "paths": {
+      "@/*": ["./*"]
+    },
+    "plugins": [
+      {
+        "name": "next"
+      }
+    ]
+  },
+  "include": ["next-env.d.ts", "**/*.ts", "**/*.tsx", ".next/types/**/*.ts"],
+  "exclude": ["node_modules"]
+}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,11 +1,44 @@
 services:
-  ulrtrack:
-    build: .
-    ports:
-      - "8000:8000"
+  api:
+    build:
+      context: .
+      dockerfile: apps/api/Dockerfile
     env_file:
       - .env
     environment:
-      DATABASE_URL: sqlite:////app/server/data/ulrtrack.db
-    volumes:
-      - ./server/data:/app/server/data
+      API_HOST: 0.0.0.0
+      API_PORT: 8000
+      REDIS_URL: redis://redis:6379
+    ports:
+      - "8000:8000"
+    depends_on:
+      - redis
+
+  dashboard:
+    build:
+      context: .
+      dockerfile: apps/dashboard/Dockerfile
+    env_file:
+      - .env
+    environment:
+      NEXT_PUBLIC_API_URL: http://localhost:8000
+    ports:
+      - "3000:3000"
+    depends_on:
+      - api
+
+  worker:
+    build:
+      context: .
+      dockerfile: packages/worker/Dockerfile
+    env_file:
+      - .env
+    environment:
+      REDIS_URL: redis://redis:6379
+    depends_on:
+      - redis
+
+  redis:
+    image: redis:7-alpine
+    ports:
+      - "6379:6379"

--- a/package.json
+++ b/package.json
@@ -1,0 +1,27 @@
+{
+  "name": "urltrack-v2",
+  "version": "2.0.0",
+  "private": true,
+  "packageManager": "pnpm@11.5.0",
+  "engines": {
+    "node": ">=20.9.0"
+  },
+  "scripts": {
+    "build": "corepack pnpm -r --if-present build",
+    "db:generate": "prisma generate --schema packages/db/prisma/schema.prisma",
+    "db:migrate": "prisma migrate deploy --schema packages/db/prisma/schema.prisma",
+    "dev": "corepack pnpm -r --parallel --if-present dev",
+    "lint": "corepack pnpm -r --if-present lint",
+    "postinstall": "prisma generate --schema packages/db/prisma/schema.prisma",
+    "test": "corepack pnpm -r --if-present test",
+    "typecheck": "corepack pnpm -r --if-present typecheck"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "prisma": "^6.0.1",
+    "tsx": "^4.19.2",
+    "turbo": "^2.3.3",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/db/package.json
+++ b/packages/db/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "@urltrack/db",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "prisma studio --schema prisma/schema.prisma",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@prisma/client": "^6.0.1"
+  },
+  "devDependencies": {
+    "prisma": "^6.0.1",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/db/prisma/migrations/0001_urltrack_v2_init/migration.sql
+++ b/packages/db/prisma/migrations/0001_urltrack_v2_init/migration.sql
@@ -1,0 +1,323 @@
+create extension if not exists pgcrypto;
+
+create type team_role as enum ('owner', 'admin', 'editor', 'analyst', 'viewer');
+create type campaign_status as enum ('draft', 'active', 'paused', 'completed', 'archived');
+create type domain_type as enum ('primary', 'branded', 'fallback');
+create type verification_status as enum ('pending', 'verified', 'failed');
+create type ssl_status as enum ('pending', 'active', 'failed');
+create type link_status as enum ('active', 'paused', 'archived');
+create type source_type as enum ('link', 'qr');
+create type webhook_delivery_status as enum ('pending', 'delivered', 'retrying', 'failed');
+
+create table workspaces (
+  id uuid primary key default gen_random_uuid(),
+  name text not null,
+  slug text not null unique,
+  owner_user_id text not null,
+  settings_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+
+create table team_members (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  user_id text not null,
+  role team_role not null default 'viewer',
+  created_at timestamptz not null default now(),
+  unique (workspace_id, user_id)
+);
+create index team_members_user_id_idx on team_members(user_id);
+
+create table campaigns (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  name text not null,
+  description text,
+  status campaign_status not null default 'draft',
+  goal text,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index campaigns_workspace_id_status_idx on campaigns(workspace_id, status);
+
+create table domains (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  domain text not null,
+  type domain_type not null default 'branded',
+  verification_status verification_status not null default 'pending',
+  ssl_status ssl_status not null default 'pending',
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (workspace_id, domain)
+);
+
+create table links (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  campaign_id uuid references campaigns(id) on delete set null,
+  domain_id uuid references domains(id) on delete set null,
+  slug text not null,
+  destination_url text not null,
+  access_control_config jsonb not null default '{}'::jsonb,
+  routing_config jsonb not null default '{}'::jsonb,
+  notification_config jsonb not null default '{}'::jsonb,
+  qr_config jsonb not null default '{}'::jsonb,
+  flow_config jsonb not null default '{}'::jsonb,
+  status link_status not null default 'active',
+  created_by text not null,
+  click_count integer not null default 0,
+  archived_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now(),
+  unique (workspace_id, slug)
+);
+create index links_workspace_id_status_idx on links(workspace_id, status);
+create index links_campaign_id_idx on links(campaign_id);
+
+create table visitors (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  primary_email text,
+  primary_ip text,
+  primary_canvas_hash text,
+  primary_fingerprint_hash text,
+  first_seen timestamptz not null default now(),
+  last_seen timestamptz not null default now(),
+  total_visits integer not null default 0,
+  confidence_score integer not null default 0,
+  traffic_quality_average integer not null default 100,
+  attributes_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index visitors_workspace_id_primary_email_idx on visitors(workspace_id, primary_email);
+create index visitors_workspace_id_primary_fingerprint_hash_idx on visitors(workspace_id, primary_fingerprint_hash);
+
+create table visits (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  link_id uuid not null references links(id) on delete cascade,
+  visitor_id uuid references visitors(id) on delete set null,
+  source_type source_type not null default 'link',
+  traffic_quality_score integer not null default 100,
+  identity_confidence_score integer not null default 0,
+  event_type text not null default 'visit.created',
+  raw_fingerprint_json jsonb not null default '{}'::jsonb,
+  ip text,
+  user_agent text,
+  referrer text,
+  country_code text,
+  device_type text,
+  is_vpn boolean not null default false,
+  is_bot boolean not null default false,
+  is_datacenter boolean not null default false,
+  visit_token_hash text unique,
+  match_reasons text[] not null default array[]::text[],
+  review_suggested boolean not null default false,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index visits_workspace_id_created_at_idx on visits(workspace_id, created_at);
+create index visits_link_id_created_at_idx on visits(link_id, created_at);
+create index visits_visitor_id_idx on visits(visitor_id);
+
+create table visitor_signals (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  visitor_id uuid not null references visitors(id) on delete cascade,
+  visit_id uuid references visits(id) on delete set null,
+  signal_type text not null,
+  signal_value_hash text not null,
+  confidence_weight integer not null,
+  created_at timestamptz not null default now(),
+  unique (visitor_id, signal_type, signal_value_hash)
+);
+create index visitor_signals_workspace_id_signal_type_idx on visitor_signals(workspace_id, signal_type);
+create index visitor_signals_signal_type_signal_value_hash_idx on visitor_signals(signal_type, signal_value_hash);
+
+create table leads (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  visitor_id uuid references visitors(id) on delete set null,
+  score integer not null default 0,
+  confidence_score integer not null default 0,
+  tags text[] not null default array[]::text[],
+  lifecycle_stage text not null default 'new',
+  consent_status text not null default 'unknown',
+  custom_fields_json jsonb not null default '{}'::jsonb,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index leads_workspace_id_score_idx on leads(workspace_id, score);
+
+create table api_keys (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  key_hash text not null unique,
+  name text not null,
+  scopes text[] not null default array[]::text[],
+  last_used_at timestamptz,
+  expires_at timestamptz,
+  created_at timestamptz not null default now()
+);
+create index api_keys_workspace_id_idx on api_keys(workspace_id);
+
+create table webhook_endpoints (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  url text not null,
+  secret text not null,
+  name text not null,
+  enabled boolean not null default true,
+  events text[] not null default array[]::text[],
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index webhook_endpoints_workspace_id_enabled_idx on webhook_endpoints(workspace_id, enabled);
+
+create table webhook_deliveries (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  endpoint_id uuid not null references webhook_endpoints(id) on delete cascade,
+  event_type text not null,
+  payload_json jsonb not null,
+  status webhook_delivery_status not null default 'pending',
+  response_code integer,
+  attempts integer not null default 0,
+  next_retry_at timestamptz,
+  created_at timestamptz not null default now(),
+  updated_at timestamptz not null default now()
+);
+create index webhook_deliveries_workspace_id_status_idx on webhook_deliveries(workspace_id, status);
+create index webhook_deliveries_endpoint_id_status_idx on webhook_deliveries(endpoint_id, status);
+create index webhook_deliveries_next_retry_at_idx on webhook_deliveries(next_retry_at);
+
+create table notification_rules (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  campaign_id uuid references campaigns(id) on delete cascade,
+  link_id uuid references links(id) on delete cascade,
+  event_type text not null,
+  channel text not null,
+  threshold_config jsonb not null default '{}'::jsonb,
+  enabled boolean not null default true,
+  created_at timestamptz not null default now()
+);
+create index notification_rules_workspace_id_event_type_idx on notification_rules(workspace_id, event_type);
+
+create table ai_insights (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  campaign_id uuid references campaigns(id) on delete set null,
+  link_id uuid references links(id) on delete set null,
+  insight_type text not null,
+  title text not null,
+  summary text not null,
+  severity text not null default 'info',
+  metadata_json jsonb not null default '{}'::jsonb,
+  dismissed_at timestamptz,
+  created_at timestamptz not null default now()
+);
+create index ai_insights_workspace_id_severity_idx on ai_insights(workspace_id, severity);
+
+create table audit_logs (
+  id uuid primary key default gen_random_uuid(),
+  workspace_id uuid not null references workspaces(id) on delete cascade,
+  user_id text,
+  action text not null,
+  entity_type text not null,
+  entity_id text,
+  metadata_json jsonb not null default '{}'::jsonb,
+  ip text,
+  created_at timestamptz not null default now()
+);
+create index audit_logs_workspace_id_created_at_idx on audit_logs(workspace_id, created_at);
+
+create or replace function public.is_workspace_member(target_workspace_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from workspaces
+    where id = target_workspace_id
+      and owner_user_id = auth.uid()::text
+  )
+  or exists (
+    select 1 from team_members
+    where workspace_id = target_workspace_id
+      and user_id = auth.uid()::text
+  );
+$$;
+
+create or replace function public.can_manage_workspace(target_workspace_id uuid)
+returns boolean
+language sql
+stable
+security definer
+set search_path = public
+as $$
+  select exists (
+    select 1 from workspaces
+    where id = target_workspace_id
+      and owner_user_id = auth.uid()::text
+  )
+  or exists (
+    select 1 from team_members
+    where workspace_id = target_workspace_id
+      and user_id = auth.uid()::text
+      and role in ('owner', 'admin', 'editor')
+  );
+$$;
+
+alter table workspaces enable row level security;
+create policy workspaces_select on workspaces
+  for select using (public.is_workspace_member(id));
+create policy workspaces_insert on workspaces
+  for insert with check (owner_user_id = auth.uid()::text);
+create policy workspaces_update on workspaces
+  for update using (public.can_manage_workspace(id))
+  with check (public.can_manage_workspace(id));
+
+alter table team_members enable row level security;
+create policy team_members_select on team_members
+  for select using (public.is_workspace_member(workspace_id));
+create policy team_members_insert on team_members
+  for insert with check (public.can_manage_workspace(workspace_id));
+create policy team_members_update on team_members
+  for update using (public.can_manage_workspace(workspace_id))
+  with check (public.can_manage_workspace(workspace_id));
+create policy team_members_delete on team_members
+  for delete using (public.can_manage_workspace(workspace_id));
+
+do $$
+declare
+  table_name text;
+begin
+  foreach table_name in array array[
+    'campaigns',
+    'domains',
+    'links',
+    'visits',
+    'visitors',
+    'visitor_signals',
+    'leads',
+    'api_keys',
+    'webhook_endpoints',
+    'webhook_deliveries',
+    'notification_rules',
+    'ai_insights',
+    'audit_logs'
+  ]
+  loop
+    execute format('alter table %I enable row level security', table_name);
+    execute format('create policy %I on %I for select using (public.is_workspace_member(workspace_id))', table_name || '_select', table_name);
+    execute format('create policy %I on %I for insert with check (public.can_manage_workspace(workspace_id))', table_name || '_insert', table_name);
+    execute format('create policy %I on %I for update using (public.can_manage_workspace(workspace_id)) with check (public.can_manage_workspace(workspace_id))', table_name || '_update', table_name);
+    execute format('create policy %I on %I for delete using (public.can_manage_workspace(workspace_id))', table_name || '_delete', table_name);
+  end loop;
+end $$;

--- a/packages/db/prisma/schema.prisma
+++ b/packages/db/prisma/schema.prisma
@@ -1,0 +1,399 @@
+generator client {
+  provider = "prisma-client-js"
+}
+
+datasource db {
+  provider = "postgresql"
+  url      = env("DATABASE_URL")
+}
+
+enum TeamRole {
+  owner
+  admin
+  editor
+  analyst
+  viewer
+
+  @@map("team_role")
+}
+
+enum CampaignStatus {
+  draft
+  active
+  paused
+  completed
+  archived
+
+  @@map("campaign_status")
+}
+
+enum DomainType {
+  primary
+  branded
+  fallback
+
+  @@map("domain_type")
+}
+
+enum VerificationStatus {
+  pending
+  verified
+  failed
+
+  @@map("verification_status")
+}
+
+enum SslStatus {
+  pending
+  active
+  failed
+
+  @@map("ssl_status")
+}
+
+enum LinkStatus {
+  active
+  paused
+  archived
+
+  @@map("link_status")
+}
+
+enum SourceType {
+  link
+  qr
+
+  @@map("source_type")
+}
+
+enum WebhookDeliveryStatus {
+  pending
+  delivered
+  retrying
+  failed
+
+  @@map("webhook_delivery_status")
+}
+
+model Workspace {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  name         String
+  slug         String   @unique
+  ownerUserId  String   @map("owner_user_id")
+  settingsJson Json     @default("{}") @map("settings_json")
+  createdAt    DateTime @default(now()) @map("created_at")
+  updatedAt    DateTime @updatedAt @map("updated_at")
+
+  members           TeamMember[]
+  campaigns         Campaign[]
+  domains           Domain[]
+  links             Link[]
+  visits            Visit[]
+  visitors          Visitor[]
+  leads             Lead[]
+  apiKeys           ApiKey[]
+  webhookEndpoints  WebhookEndpoint[]
+  webhookDeliveries WebhookDelivery[]
+  visitorSignals    VisitorSignal[]
+  notificationRules NotificationRule[]
+  aiInsights        AIInsight[]
+  auditLogs         AuditLog[]
+
+  @@map("workspaces")
+}
+
+model TeamMember {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId String    @map("workspace_id") @db.Uuid
+  userId      String    @map("user_id")
+  role        TeamRole  @default(viewer)
+  createdAt   DateTime  @default(now()) @map("created_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@unique([workspaceId, userId])
+  @@index([userId])
+  @@map("team_members")
+}
+
+model Campaign {
+  id          String         @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId String         @map("workspace_id") @db.Uuid
+  name        String
+  description String?
+  status      CampaignStatus @default(draft)
+  goal        String?
+  createdAt   DateTime       @default(now()) @map("created_at")
+  updatedAt   DateTime       @updatedAt @map("updated_at")
+
+  workspace         Workspace          @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  links             Link[]
+  notificationRules NotificationRule[]
+  aiInsights        AIInsight[]
+
+  @@index([workspaceId, status])
+  @@map("campaigns")
+}
+
+model Domain {
+  id                 String             @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId        String             @map("workspace_id") @db.Uuid
+  domain             String
+  type               DomainType         @default(branded)
+  verificationStatus VerificationStatus @default(pending) @map("verification_status")
+  sslStatus          SslStatus          @default(pending) @map("ssl_status")
+  createdAt          DateTime           @default(now()) @map("created_at")
+  updatedAt          DateTime           @updatedAt @map("updated_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  links     Link[]
+
+  @@unique([workspaceId, domain])
+  @@map("domains")
+}
+
+model Link {
+  id                     String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId            String     @map("workspace_id") @db.Uuid
+  campaignId             String?    @map("campaign_id") @db.Uuid
+  domainId               String?    @map("domain_id") @db.Uuid
+  slug                   String
+  destinationUrl         String     @map("destination_url")
+  accessControlConfig    Json       @default("{}") @map("access_control_config")
+  routingConfig          Json       @default("{}") @map("routing_config")
+  notificationConfig     Json       @default("{}") @map("notification_config")
+  qrConfig               Json       @default("{}") @map("qr_config")
+  flowConfig             Json       @default("{}") @map("flow_config")
+  status                 LinkStatus @default(active)
+  createdBy              String     @map("created_by")
+  clickCount             Int        @default(0) @map("click_count")
+  archivedAt             DateTime?  @map("archived_at")
+  createdAt              DateTime   @default(now()) @map("created_at")
+  updatedAt              DateTime   @updatedAt @map("updated_at")
+
+  workspace         Workspace          @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  campaign          Campaign?          @relation(fields: [campaignId], references: [id], onDelete: SetNull)
+  domain            Domain?            @relation(fields: [domainId], references: [id], onDelete: SetNull)
+  visits            Visit[]
+  notificationRules NotificationRule[]
+  aiInsights        AIInsight[]
+
+  @@unique([workspaceId, slug])
+  @@index([workspaceId, status])
+  @@index([campaignId])
+  @@map("links")
+}
+
+model Visit {
+  id                      String     @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId             String     @map("workspace_id") @db.Uuid
+  linkId                  String     @map("link_id") @db.Uuid
+  visitorId               String?    @map("visitor_id") @db.Uuid
+  sourceType              SourceType @default(link) @map("source_type")
+  trafficQualityScore     Int        @default(100) @map("traffic_quality_score")
+  identityConfidenceScore Int        @default(0) @map("identity_confidence_score")
+  eventType               String     @default("visit.created") @map("event_type")
+  rawFingerprintJson      Json       @default("{}") @map("raw_fingerprint_json")
+  ip                      String?    @map("ip")
+  userAgent               String?    @map("user_agent")
+  referrer                String?
+  countryCode             String?    @map("country_code")
+  deviceType              String?    @map("device_type")
+  isVpn                   Boolean    @default(false) @map("is_vpn")
+  isBot                   Boolean    @default(false) @map("is_bot")
+  isDatacenter            Boolean    @default(false) @map("is_datacenter")
+  visitTokenHash          String?    @unique @map("visit_token_hash")
+  matchReasons            String[]   @default([]) @map("match_reasons")
+  reviewSuggested         Boolean    @default(false) @map("review_suggested")
+  createdAt               DateTime   @default(now()) @map("created_at")
+  updatedAt               DateTime   @updatedAt @map("updated_at")
+
+  workspace Workspace       @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  link      Link            @relation(fields: [linkId], references: [id], onDelete: Cascade)
+  visitor   Visitor?        @relation(fields: [visitorId], references: [id], onDelete: SetNull)
+  signals   VisitorSignal[]
+
+  @@index([workspaceId, createdAt])
+  @@index([linkId, createdAt])
+  @@index([visitorId])
+  @@map("visits")
+}
+
+model Visitor {
+  id                    String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId           String    @map("workspace_id") @db.Uuid
+  primaryEmail          String?   @map("primary_email")
+  primaryIp             String?   @map("primary_ip")
+  primaryCanvasHash     String?   @map("primary_canvas_hash")
+  primaryFingerprintHash String?  @map("primary_fingerprint_hash")
+  firstSeen             DateTime  @default(now()) @map("first_seen")
+  lastSeen              DateTime  @default(now()) @map("last_seen")
+  totalVisits           Int       @default(0) @map("total_visits")
+  confidenceScore       Int       @default(0) @map("confidence_score")
+  trafficQualityAverage Int       @default(100) @map("traffic_quality_average")
+  attributesJson        Json      @default("{}") @map("attributes_json")
+  createdAt             DateTime  @default(now()) @map("created_at")
+  updatedAt             DateTime  @updatedAt @map("updated_at")
+
+  workspace Workspace       @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  visits    Visit[]
+  signals   VisitorSignal[]
+  leads     Lead[]
+
+  @@index([workspaceId, primaryEmail])
+  @@index([workspaceId, primaryFingerprintHash])
+  @@map("visitors")
+}
+
+model VisitorSignal {
+  id               String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId      String   @map("workspace_id") @db.Uuid
+  visitorId        String   @map("visitor_id") @db.Uuid
+  visitId          String?  @map("visit_id") @db.Uuid
+  signalType       String   @map("signal_type")
+  signalValueHash  String   @map("signal_value_hash")
+  confidenceWeight Int      @map("confidence_weight")
+  createdAt        DateTime @default(now()) @map("created_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  visitor Visitor @relation(fields: [visitorId], references: [id], onDelete: Cascade)
+  visit   Visit?   @relation(fields: [visitId], references: [id], onDelete: SetNull)
+
+  @@unique([visitorId, signalType, signalValueHash])
+  @@index([workspaceId, signalType])
+  @@index([signalType, signalValueHash])
+  @@map("visitor_signals")
+}
+
+model Lead {
+  id                String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId       String   @map("workspace_id") @db.Uuid
+  visitorId         String?  @map("visitor_id") @db.Uuid
+  score             Int      @default(0)
+  confidenceScore   Int      @default(0) @map("confidence_score")
+  tags              String[] @default([])
+  lifecycleStage    String   @default("new") @map("lifecycle_stage")
+  consentStatus     String   @default("unknown") @map("consent_status")
+  customFieldsJson  Json     @default("{}") @map("custom_fields_json")
+  createdAt         DateTime @default(now()) @map("created_at")
+  updatedAt         DateTime @updatedAt @map("updated_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  visitor   Visitor?  @relation(fields: [visitorId], references: [id], onDelete: SetNull)
+
+  @@index([workspaceId, score])
+  @@map("leads")
+}
+
+model ApiKey {
+  id          String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId String    @map("workspace_id") @db.Uuid
+  keyHash     String    @unique @map("key_hash")
+  name        String
+  scopes      String[]  @default([])
+  lastUsedAt  DateTime? @map("last_used_at")
+  expiresAt   DateTime? @map("expires_at")
+  createdAt   DateTime  @default(now()) @map("created_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId])
+  @@map("api_keys")
+}
+
+model WebhookEndpoint {
+  id          String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId String   @map("workspace_id") @db.Uuid
+  url         String
+  secret      String
+  name        String
+  enabled     Boolean  @default(true)
+  events      String[] @default([])
+  createdAt   DateTime @default(now()) @map("created_at")
+  updatedAt   DateTime @updatedAt @map("updated_at")
+
+  workspace  Workspace         @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  deliveries WebhookDelivery[]
+
+  @@index([workspaceId, enabled])
+  @@map("webhook_endpoints")
+}
+
+model WebhookDelivery {
+  id           String                @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId  String                @map("workspace_id") @db.Uuid
+  endpointId   String                @map("endpoint_id") @db.Uuid
+  eventType    String                @map("event_type")
+  payloadJson  Json                  @map("payload_json")
+  status       WebhookDeliveryStatus @default(pending)
+  responseCode Int?                  @map("response_code")
+  attempts     Int                   @default(0)
+  nextRetryAt  DateTime?             @map("next_retry_at")
+  createdAt    DateTime              @default(now()) @map("created_at")
+  updatedAt    DateTime              @updatedAt @map("updated_at")
+
+  workspace Workspace       @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  endpoint WebhookEndpoint @relation(fields: [endpointId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId, status])
+  @@index([endpointId, status])
+  @@index([nextRetryAt])
+  @@map("webhook_deliveries")
+}
+
+model NotificationRule {
+  id              String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId     String   @map("workspace_id") @db.Uuid
+  campaignId      String?  @map("campaign_id") @db.Uuid
+  linkId          String?  @map("link_id") @db.Uuid
+  eventType       String   @map("event_type")
+  channel         String
+  thresholdConfig Json     @default("{}") @map("threshold_config")
+  enabled         Boolean  @default(true)
+  createdAt       DateTime @default(now()) @map("created_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  campaign  Campaign? @relation(fields: [campaignId], references: [id], onDelete: Cascade)
+  link      Link?     @relation(fields: [linkId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId, eventType])
+  @@map("notification_rules")
+}
+
+model AIInsight {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId  String   @map("workspace_id") @db.Uuid
+  campaignId   String?  @map("campaign_id") @db.Uuid
+  linkId       String?  @map("link_id") @db.Uuid
+  insightType  String   @map("insight_type")
+  title        String
+  summary      String
+  severity     String   @default("info")
+  metadataJson Json     @default("{}") @map("metadata_json")
+  dismissedAt  DateTime? @map("dismissed_at")
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+  campaign  Campaign? @relation(fields: [campaignId], references: [id], onDelete: SetNull)
+  link      Link?     @relation(fields: [linkId], references: [id], onDelete: SetNull)
+
+  @@index([workspaceId, severity])
+  @@map("ai_insights")
+}
+
+model AuditLog {
+  id           String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  workspaceId  String   @map("workspace_id") @db.Uuid
+  userId       String?  @map("user_id")
+  action       String
+  entityType   String   @map("entity_type")
+  entityId     String?  @map("entity_id")
+  metadataJson Json     @default("{}") @map("metadata_json")
+  ip           String?
+  createdAt    DateTime @default(now()) @map("created_at")
+
+  workspace Workspace @relation(fields: [workspaceId], references: [id], onDelete: Cascade)
+
+  @@index([workspaceId, createdAt])
+  @@map("audit_logs")
+}

--- a/packages/db/src/client.ts
+++ b/packages/db/src/client.ts
@@ -1,0 +1,17 @@
+import { PrismaClient } from "@prisma/client";
+
+const globalForPrisma = globalThis as unknown as {
+  prisma?: PrismaClient;
+};
+
+export const prisma =
+  globalForPrisma.prisma ??
+  new PrismaClient({
+    log: process.env.NODE_ENV === "development" ? ["query", "error", "warn"] : ["error"]
+  });
+
+if (process.env.NODE_ENV !== "production") {
+  globalForPrisma.prisma = prisma;
+}
+
+export type DbClient = PrismaClient;

--- a/packages/db/src/index.ts
+++ b/packages/db/src/index.ts
@@ -1,0 +1,1 @@
+export { prisma, type DbClient } from "./client";

--- a/packages/db/src/schema.test.ts
+++ b/packages/db/src/schema.test.ts
@@ -1,0 +1,33 @@
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+import { describe, expect, it } from "vitest";
+
+const schema = readFileSync(join(process.cwd(), "prisma/schema.prisma"), "utf8");
+
+describe("Prisma schema", () => {
+  it("keeps core entities scoped to workspace_id", () => {
+    for (const model of [
+      "Campaign",
+      "Domain",
+      "Link",
+      "Visit",
+      "Visitor",
+      "VisitorSignal",
+      "Lead",
+      "ApiKey",
+      "WebhookEndpoint",
+      "WebhookDelivery",
+      "NotificationRule",
+      "AIInsight",
+      "AuditLog"
+    ]) {
+      const match = schema.match(new RegExp(`model ${model} \\{([\\s\\S]*?)\\n\\}`));
+      expect(match?.[1]).toContain("workspaceId");
+    }
+  });
+
+  it("does not define a global user model because Supabase Auth owns users", () => {
+    expect(schema).not.toMatch(/model\s+User\s+\{/);
+  });
+});

--- a/packages/db/tsconfig.json
+++ b/packages/db/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@urltrack/shared",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/shared/src/index.test.ts
+++ b/packages/shared/src/index.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+
+import { createLinkSchema, escapeHtml, normalizeDestinationUrl } from "./index";
+
+describe("shared validation", () => {
+  it("normalizes http URLs and rejects dangerous schemes", () => {
+    expect(normalizeDestinationUrl("example.com/path#secret")).toBe("https://example.com/path");
+    expect(() => normalizeDestinationUrl("javascript:alert(1)")).toThrow("Only http/https");
+  });
+
+  it("validates link creation payloads", () => {
+    const parsed = createLinkSchema.parse({
+      workspace_id: "00000000-0000-4000-8000-000000000000",
+      slug: "Launch_01",
+      destination_url: "https://example.com"
+    });
+
+    expect(parsed.status).toBe("active");
+    expect(parsed.destination_url).toBe("https://example.com/");
+  });
+
+  it("escapes HTML for redirect templates", () => {
+    expect(escapeHtml(`<script>"x"</script>`)).toBe("&lt;script&gt;&quot;x&quot;&lt;/script&gt;");
+  });
+});

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,0 +1,278 @@
+import { z } from "zod";
+
+export const WORKSPACE_ROLES = ["owner", "admin", "editor", "analyst", "viewer"] as const;
+export const LINK_STATUSES = ["active", "paused", "archived"] as const;
+export const CAMPAIGN_STATUSES = ["draft", "active", "paused", "completed", "archived"] as const;
+export const SOURCE_TYPES = ["link", "qr"] as const;
+export const WEBHOOK_EVENTS = [
+  "visit.created",
+  "lead.created",
+  "lead.updated",
+  "lead.score_changed",
+  "qr.scanned",
+  "suspicious.detected",
+  "link.blocked",
+  "link.expired",
+  "conversion.created",
+  "visitor.identified"
+] as const;
+
+export type WorkspaceRole = (typeof WORKSPACE_ROLES)[number];
+export type LinkStatus = (typeof LINK_STATUSES)[number];
+export type CampaignStatus = (typeof CAMPAIGN_STATUSES)[number];
+export type SourceType = (typeof SOURCE_TYPES)[number];
+export type WebhookEvent = (typeof WEBHOOK_EVENTS)[number];
+
+export type ApiEnvelope<T> = {
+  data: T;
+  meta?: {
+    page?: number;
+    per_page?: number;
+    total?: number;
+  };
+};
+
+export type ApiErrorEnvelope = {
+  error: {
+    code: string;
+    message: string;
+    details?: unknown;
+  };
+};
+
+export type TrafficQualitySettings = {
+  vpn_penalty: number;
+  bot_penalty: number;
+  datacenter_penalty: number;
+  returning_visitor_bonus: number;
+  email_captured_bonus: number;
+};
+
+export type LeadScoreSettings = {
+  high_confidence_identity: number;
+  email_verified: number;
+  multiple_link_visits: number;
+  high_engagement_dwell: number;
+};
+
+export type WorkspaceScoringSettings = {
+  scoring: {
+    traffic_quality: TrafficQualitySettings;
+    lead_score: LeadScoreSettings;
+  };
+};
+
+export const defaultWorkspaceSettings: WorkspaceScoringSettings = {
+  scoring: {
+    traffic_quality: {
+      vpn_penalty: -30,
+      bot_penalty: -50,
+      datacenter_penalty: -20,
+      returning_visitor_bonus: 10,
+      email_captured_bonus: 20
+    },
+    lead_score: {
+      high_confidence_identity: 40,
+      email_verified: 30,
+      multiple_link_visits: 15,
+      high_engagement_dwell: 10
+    }
+  }
+};
+
+export const slugSchema = z
+  .string()
+  .trim()
+  .min(3)
+  .max(80)
+  .regex(/^[A-Za-z0-9][A-Za-z0-9_-]*$/, "Slug must be alphanumeric with optional '-' or '_'.");
+
+export const idSchema = z.string().uuid();
+export const workspaceIdSchema = idSchema;
+
+export const destinationUrlSchema = z
+  .string()
+  .trim()
+  .min(1)
+  .transform((value, ctx) => {
+    try {
+      return normalizeDestinationUrl(value);
+    } catch (error) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: error instanceof Error ? error.message : "Invalid destination URL."
+      });
+      return z.NEVER;
+    }
+  });
+
+export const paginationSchema = z.object({
+  page: z.coerce.number().int().min(1).default(1),
+  per_page: z.coerce.number().int().min(1).max(100).default(20)
+});
+
+export const accessControlConfigSchema = z
+  .object({
+    expires_at: z.string().datetime().optional(),
+    max_clicks: z.number().int().positive().optional(),
+    geo_allowlist: z.array(z.string().length(2).transform((value) => value.toUpperCase())).optional(),
+    time_window: z
+      .object({
+        timezone: z.string().min(1).default("UTC"),
+        start_hour: z.number().int().min(0).max(23),
+        end_hour: z.number().int().min(0).max(23)
+      })
+      .optional(),
+    device_types: z.array(z.enum(["mobile", "desktop", "tablet"])).optional(),
+    password_gate: z.boolean().optional(),
+    email_gate: z.boolean().optional(),
+    captcha_gate: z.boolean().optional()
+  })
+  .passthrough()
+  .default({});
+
+export const routingConfigSchema = z
+  .object({
+    safe_url: destinationUrlSchema.optional(),
+    ios_url: destinationUrlSchema.optional(),
+    android_url: destinationUrlSchema.optional()
+  })
+  .passthrough()
+  .default({});
+
+export const notificationConfigSchema = z
+  .object({
+    telegram_enabled: z.boolean().optional(),
+    email_enabled: z.boolean().optional(),
+    webhook_events: z.array(z.enum(WEBHOOK_EVENTS)).optional()
+  })
+  .passthrough()
+  .default({});
+
+export const qrConfigSchema = z
+  .object({
+    foreground: z.string().regex(/^#[0-9A-Fa-f]{6}$/).default("#00C853"),
+    background: z.string().regex(/^#[0-9A-Fa-f]{6}$/).default("#0A0A0A"),
+    logo_path: z.string().optional(),
+    format: z.enum(["png", "svg"]).default("png"),
+    size: z.union([z.enum(["small", "medium", "large"]), z.number().int().min(128).max(4096)]).default("medium"),
+    error_correction_level: z.enum(["L", "M", "Q", "H"]).default("M")
+  })
+  .passthrough()
+  .default({});
+
+export const flowConfigSchema = z
+  .object({
+    nodes: z.array(z.record(z.unknown())).default([]),
+    edges: z.array(z.record(z.unknown())).default([])
+  })
+  .passthrough()
+  .default({ nodes: [], edges: [] });
+
+export const createLinkSchema = z.object({
+  workspace_id: workspaceIdSchema,
+  campaign_id: idSchema.nullish(),
+  domain_id: idSchema.nullish(),
+  slug: slugSchema,
+  destination_url: destinationUrlSchema,
+  access_control_config: accessControlConfigSchema.optional(),
+  routing_config: routingConfigSchema.optional(),
+  notification_config: notificationConfigSchema.optional(),
+  qr_config: qrConfigSchema.optional(),
+  flow_config: flowConfigSchema.optional(),
+  status: z.enum(LINK_STATUSES).default("active")
+});
+
+export const updateLinkSchema = createLinkSchema
+  .omit({ workspace_id: true, slug: true })
+  .partial()
+  .extend({
+    slug: slugSchema.optional()
+  });
+
+export const createCampaignSchema = z.object({
+  workspace_id: workspaceIdSchema,
+  name: z.string().trim().min(1).max(160),
+  description: z.string().trim().max(2000).optional(),
+  status: z.enum(CAMPAIGN_STATUSES).default("draft"),
+  goal: z.string().trim().max(500).optional()
+});
+
+export const createWebhookSchema = z.object({
+  workspace_id: workspaceIdSchema,
+  url: destinationUrlSchema,
+  name: z.string().trim().min(1).max(120),
+  events: z.array(z.enum(WEBHOOK_EVENTS)).min(1),
+  enabled: z.boolean().default(true)
+});
+
+export const fingerprintPayloadSchema = z.object({
+  visit_token: z.string().min(20).max(500),
+  thumbmark: z.record(z.unknown())
+});
+
+export const workspaceSettingsSchema = z.object({
+  scoring: z.object({
+    traffic_quality: z.object({
+      vpn_penalty: z.number().min(-100).max(0),
+      bot_penalty: z.number().min(-100).max(0),
+      datacenter_penalty: z.number().min(-100).max(0),
+      returning_visitor_bonus: z.number().min(0).max(100),
+      email_captured_bonus: z.number().min(0).max(100)
+    }),
+    lead_score: z.object({
+      high_confidence_identity: z.number().min(0).max(100),
+      email_verified: z.number().min(0).max(100),
+      multiple_link_visits: z.number().min(0).max(100),
+      high_engagement_dwell: z.number().min(0).max(100)
+    })
+  })
+});
+
+export function normalizeDestinationUrl(rawUrl: string): string {
+  const trimmed = rawUrl.trim();
+  if (!trimmed) {
+    throw new Error("URL is required.");
+  }
+
+  const candidate = /^[a-zA-Z][a-zA-Z\d+\-.]*:/.test(trimmed) ? trimmed : `https://${trimmed}`;
+  const parsed = new URL(candidate);
+
+  if (!["http:", "https:"].includes(parsed.protocol)) {
+    throw new Error("Only http/https URLs are allowed.");
+  }
+  if (!parsed.hostname) {
+    throw new Error("URL must include a valid host.");
+  }
+
+  parsed.hash = "";
+  return parsed.toString();
+}
+
+export function clampScore(score: number): number {
+  return Math.max(0, Math.min(100, Math.round(score)));
+}
+
+export function escapeHtml(value: string): string {
+  return value.replace(/[&<>"']/g, (char) => {
+    switch (char) {
+      case "&":
+        return "&amp;";
+      case "<":
+        return "&lt;";
+      case ">":
+        return "&gt;";
+      case '"':
+        return "&quot;";
+      default:
+        return "&#39;";
+    }
+  });
+}
+
+export function toApiEnvelope<T>(
+  data: T,
+  meta?: ApiEnvelope<T>["meta"]
+): ApiEnvelope<T> {
+  return meta ? { data, meta } : { data };
+}

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/worker/Dockerfile
+++ b/packages/worker/Dockerfile
@@ -1,0 +1,14 @@
+FROM node:22-alpine
+
+WORKDIR /app
+
+RUN corepack enable
+
+COPY package.json pnpm-workspace.yaml turbo.json tsconfig.base.json ./
+COPY packages ./packages
+COPY apps/api/package.json ./apps/api/package.json
+COPY apps/dashboard/package.json ./apps/dashboard/package.json
+
+RUN pnpm install --frozen-lockfile
+
+CMD ["pnpm", "--filter", "@urltrack/worker", "start"]

--- a/packages/worker/package.json
+++ b/packages/worker/package.json
@@ -1,0 +1,31 @@
+{
+  "name": "@urltrack/worker",
+  "version": "2.0.0",
+  "private": true,
+  "type": "module",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "import": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "build": "tsc -p tsconfig.json",
+    "dev": "tsx watch src/index.ts",
+    "lint": "tsc -p tsconfig.json --noEmit",
+    "start": "tsx src/runner.ts",
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json"
+  },
+  "dependencies": {
+    "@urltrack/db": "workspace:*",
+    "@urltrack/shared": "workspace:*",
+    "bullmq": "^5.34.0",
+    "ioredis": "5.10.1",
+    "pino": "^9.5.0",
+    "zod": "^3.24.1"
+  },
+  "devDependencies": {
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/worker/src/identity-matching.test.ts
+++ b/packages/worker/src/identity-matching.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from "vitest";
+
+import { extractSignals, matchIdentity, scoreCandidate } from "./identity-matching";
+
+describe("identity matching", () => {
+  it("confirms a strong multi-signal visitor match", () => {
+    const scored = scoreCandidate(
+      {
+        email: "lead@example.com",
+        canvasHash: "canvas-a",
+        webglHash: "webgl-a",
+        thumbmarkHash: "tm-a"
+      },
+      {
+        visitorId: "visitor-1",
+        email: "lead@example.com",
+        canvasHash: "canvas-a",
+        webglHash: "webgl-a",
+        thumbmarkHash: "tm-a"
+      }
+    );
+
+    expect(scored.confidenceScore).toBeGreaterThanOrEqual(60);
+    expect(scored.matchReasons).toContain("same_email");
+  });
+
+  it("suggests review for medium confidence matches", () => {
+    const result = matchIdentity(
+      {
+        workspaceId: "workspace-1",
+        visitId: "visit-1",
+        canvasHash: "canvas-a",
+        webglHash: "webgl-a"
+      },
+      [{ visitorId: "visitor-1", canvasHash: "canvas-a", webglHash: "webgl-a" }]
+    );
+
+    expect(result.action).toBe("review_suggested");
+    expect(result.reviewSuggested).toBe(true);
+  });
+
+  it("extracts ThumbmarkJS hash fields from raw payloads", () => {
+    const signals = extractSignals({
+      thumbmark: {
+        hash: "abc",
+        components: {
+          canvas: { hash: "canvas" },
+          webgl: { hash: "webgl" },
+          audio: { hash: "audio" },
+          screen: { resolution: "1440x900" }
+        }
+      }
+    });
+
+    expect(signals.thumbmarkHash).toBe("abc");
+    expect(signals.canvasHash).toBe("canvas");
+    expect(signals.webglHash).toBe("webgl");
+    expect(signals.audioFingerprint).toBe("audio");
+  });
+});

--- a/packages/worker/src/identity-matching.ts
+++ b/packages/worker/src/identity-matching.ts
@@ -1,0 +1,241 @@
+import { createHash, createHmac } from "node:crypto";
+
+import { clampScore } from "@urltrack/shared";
+
+export type FingerprintSignals = {
+  email?: string;
+  canvasHash?: string;
+  webglHash?: string;
+  audioFingerprint?: string;
+  thumbmarkHash?: string;
+  webrtcIps?: string[];
+  timezone?: string;
+  language?: string;
+  screen?: string;
+  ip?: string;
+  userAgent?: string;
+  ispOrg?: string;
+  isMobile?: boolean;
+  isVpnOrDatacenter?: boolean;
+};
+
+export type IdentityVisitInput = FingerprintSignals & {
+  workspaceId: string;
+  visitId: string;
+};
+
+export type VisitorCandidate = FingerprintSignals & {
+  visitorId: string;
+};
+
+export type IdentityMatchResult = {
+  visitorId?: string;
+  confidenceScore: number;
+  matchReasons: string[];
+  reviewSuggested: boolean;
+  action: "match_confirmed" | "review_suggested" | "new_visitor";
+};
+
+function normalizeText(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized || undefined;
+}
+
+function normalizeList(value: unknown): string[] | undefined {
+  if (!Array.isArray(value)) {
+    return undefined;
+  }
+  const normalized = value.map(normalizeText).filter((item): item is string => Boolean(item));
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function readRecord(value: unknown): Record<string, unknown> {
+  return value && typeof value === "object" && !Array.isArray(value) ? (value as Record<string, unknown>) : {};
+}
+
+function stringFromPaths(source: Record<string, unknown>, paths: string[][]): string | undefined {
+  for (const path of paths) {
+    let cursor: unknown = source;
+    for (const segment of path) {
+      cursor = readRecord(cursor)[segment];
+    }
+    const normalized = normalizeText(cursor);
+    if (normalized) {
+      return normalized;
+    }
+  }
+  return undefined;
+}
+
+export function hashSignal(value: string, secret?: string): string {
+  const normalized = value.trim().toLowerCase();
+  if (secret) {
+    return createHmac("sha256", secret).update(normalized).digest("hex");
+  }
+  return createHash("sha256").update(normalized).digest("hex");
+}
+
+export function extractSignals(rawFingerprint: unknown, base: Partial<FingerprintSignals> = {}): FingerprintSignals {
+  const root = readRecord(rawFingerprint);
+  const thumbmark = readRecord(root.thumbmark ?? root);
+  const components = readRecord(thumbmark.components);
+  const screen = readRecord(components.screen ?? thumbmark.screen);
+  const webgl = readRecord(components.webgl ?? thumbmark.webgl);
+  const canvas = readRecord(components.canvas ?? thumbmark.canvas);
+  const audio = readRecord(components.audio ?? thumbmark.audio);
+  const network = readRecord(components.network ?? thumbmark.network);
+
+  return {
+    ...base,
+    email: normalizeText(base.email ?? root.email),
+    canvasHash:
+      base.canvasHash ??
+      stringFromPaths(canvas, [["hash"], ["value"], ["canvas_hash"]]) ??
+      stringFromPaths(thumbmark, [["canvasHash"], ["canvas_hash"]]),
+    webglHash:
+      base.webglHash ??
+      stringFromPaths(webgl, [["hash"], ["rendererHash"], ["webgl_hash"]]) ??
+      stringFromPaths(thumbmark, [["webglHash"], ["webgl_hash"]]),
+    audioFingerprint:
+      base.audioFingerprint ??
+      stringFromPaths(audio, [["hash"], ["fingerprint"], ["audio_fp"]]) ??
+      stringFromPaths(thumbmark, [["audioFingerprint"], ["audio_fingerprint"], ["audio_fp"]]),
+    thumbmarkHash:
+      base.thumbmarkHash ??
+      stringFromPaths(thumbmark, [["hash"], ["fingerprint"], ["visitorId"], ["id"]]),
+    webrtcIps: base.webrtcIps ?? normalizeList(network.webrtcIps ?? thumbmark.webrtcIps ?? root.webrtc_ips),
+    timezone:
+      base.timezone ??
+      stringFromPaths(thumbmark, [["timezone"], ["timeZone"]]) ??
+      stringFromPaths(screen, [["timezone"], ["timeZone"]]),
+    language:
+      base.language ??
+      stringFromPaths(thumbmark, [["language"], ["locale"]]) ??
+      stringFromPaths(screen, [["language"], ["locale"]]),
+    screen:
+      base.screen ??
+      stringFromPaths(screen, [["resolution"], ["size"], ["screen"]]) ??
+      stringFromPaths(thumbmark, [["screen"], ["screenResolution"]]),
+    ip: normalizeText(base.ip ?? root.ip),
+    userAgent: normalizeText(base.userAgent ?? root.user_agent),
+    ispOrg: normalizeText(base.ispOrg ?? root.isp_org ?? root.org),
+    isMobile: base.isMobile,
+    isVpnOrDatacenter: base.isVpnOrDatacenter
+  };
+}
+
+function sameValue(first?: string, second?: string): boolean {
+  return Boolean(first && second && first === second);
+}
+
+function overlaps(first?: string[], second?: string[]): boolean {
+  if (!first?.length || !second?.length) {
+    return false;
+  }
+  const secondSet = new Set(second);
+  return first.some((value) => secondSet.has(value));
+}
+
+export function scoreCandidate(visit: FingerprintSignals, candidate: VisitorCandidate): Omit<IdentityMatchResult, "visitorId" | "action" | "reviewSuggested"> {
+  let score = 0;
+  const reasons: string[] = [];
+
+  if (sameValue(visit.email, candidate.email)) {
+    score += 40;
+    reasons.push("same_email");
+  }
+  if (sameValue(visit.canvasHash, candidate.canvasHash) && sameValue(visit.webglHash, candidate.webglHash)) {
+    score += 30;
+    reasons.push("same_canvas_and_webgl");
+  }
+  if (sameValue(visit.audioFingerprint, candidate.audioFingerprint)) {
+    score += 20;
+    reasons.push("same_audio_fingerprint");
+  }
+  if (sameValue(visit.thumbmarkHash, candidate.thumbmarkHash)) {
+    score += 15;
+    reasons.push("same_thumbmark_hash");
+  }
+  if (overlaps(visit.webrtcIps, candidate.webrtcIps)) {
+    score += 10;
+    reasons.push("same_webrtc_ip");
+  }
+  if (
+    sameValue(visit.timezone, candidate.timezone) &&
+    sameValue(visit.language, candidate.language) &&
+    sameValue(visit.screen, candidate.screen)
+  ) {
+    score += 8;
+    reasons.push("same_timezone_language_screen");
+  }
+  if (sameValue(visit.ip, candidate.ip) && !visit.isMobile && !visit.isVpnOrDatacenter) {
+    score += 5;
+    reasons.push("same_stable_ip");
+  }
+  if (sameValue(visit.userAgent, candidate.userAgent)) {
+    score += 3;
+    reasons.push("same_user_agent");
+  }
+  if (sameValue(visit.ispOrg, candidate.ispOrg)) {
+    score += 2;
+    reasons.push("same_isp_org");
+  }
+
+  const hasStrongSignal = reasons.some((reason) =>
+    ["same_email", "same_canvas_and_webgl", "same_audio_fingerprint", "same_thumbmark_hash"].includes(reason)
+  );
+  if (visit.isVpnOrDatacenter && !hasStrongSignal) {
+    score -= 10;
+    reasons.push("vpn_or_datacenter_penalty");
+  }
+
+  return {
+    confidenceScore: clampScore(score),
+    matchReasons: reasons
+  };
+}
+
+export function matchIdentity(visit: IdentityVisitInput, candidates: VisitorCandidate[]): IdentityMatchResult {
+  let bestCandidate: VisitorCandidate | undefined;
+  let bestScore = 0;
+  let bestReasons: string[] = [];
+
+  for (const candidate of candidates) {
+    const scored = scoreCandidate(visit, candidate);
+    if (scored.confidenceScore > bestScore) {
+      bestCandidate = candidate;
+      bestScore = scored.confidenceScore;
+      bestReasons = scored.matchReasons;
+    }
+  }
+
+  if (bestCandidate && bestScore >= 60) {
+    return {
+      visitorId: bestCandidate.visitorId,
+      confidenceScore: bestScore,
+      matchReasons: bestReasons,
+      reviewSuggested: false,
+      action: "match_confirmed"
+    };
+  }
+
+  if (bestCandidate && bestScore >= 30) {
+    return {
+      visitorId: bestCandidate.visitorId,
+      confidenceScore: bestScore,
+      matchReasons: bestReasons,
+      reviewSuggested: true,
+      action: "review_suggested"
+    };
+  }
+
+  return {
+    confidenceScore: bestScore,
+    matchReasons: bestReasons,
+    reviewSuggested: false,
+    action: "new_visitor"
+  };
+}

--- a/packages/worker/src/index.ts
+++ b/packages/worker/src/index.ts
@@ -1,0 +1,3 @@
+export * from "./identity-matching";
+export * from "./queues";
+export * from "./webhook-delivery";

--- a/packages/worker/src/queues.ts
+++ b/packages/worker/src/queues.ts
@@ -1,0 +1,38 @@
+import { Queue, type ConnectionOptions, type JobsOptions } from "bullmq";
+import IORedis from "ioredis";
+
+export const QUEUE_NAMES = {
+  enrichment: "enrichment",
+  webhooks: "webhooks",
+  notifications: "notifications",
+  aiInsights: "ai-insights",
+  cleanup: "cleanup",
+  reports: "reports"
+} as const;
+
+export type QueueName = (typeof QUEUE_NAMES)[keyof typeof QUEUE_NAMES];
+
+export function createRedisConnection(redisUrl = process.env.REDIS_URL ?? "redis://127.0.0.1:6379"): IORedis {
+  return new IORedis(redisUrl, {
+    maxRetriesPerRequest: null
+  });
+}
+
+export function createQueue(name: QueueName, redisUrl?: string): Queue {
+  return new Queue(name, {
+    connection: createRedisConnection(redisUrl) as ConnectionOptions,
+    defaultJobOptions: defaultJobOptions()
+  });
+}
+
+function defaultJobOptions(): JobsOptions {
+  return {
+    attempts: 5,
+    backoff: {
+      type: "exponential",
+      delay: 30_000
+    },
+    removeOnComplete: 1_000,
+    removeOnFail: 5_000
+  };
+}

--- a/packages/worker/src/runner.ts
+++ b/packages/worker/src/runner.ts
@@ -1,0 +1,36 @@
+import { Worker, type ConnectionOptions } from "bullmq";
+import pino from "pino";
+
+import { prisma } from "@urltrack/db";
+
+import { createRedisConnection, QUEUE_NAMES } from "./queues";
+
+const logger = pino({ name: "urltrack-worker" });
+const connection = createRedisConnection();
+
+const enrichmentWorker = new Worker(
+  QUEUE_NAMES.enrichment,
+  async (job) => {
+    logger.info({ jobId: job.id, data: job.data }, "processing enrichment job");
+    const visitId = typeof job.data === "object" && job.data ? (job.data as { visitId?: string }).visitId : undefined;
+    if (!visitId) {
+      return;
+    }
+    await prisma.visit.update({
+      where: { id: visitId },
+      data: { updatedAt: new Date() }
+    });
+  },
+  { connection: connection as ConnectionOptions }
+);
+
+const shutdown = async () => {
+  await enrichmentWorker.close();
+  await connection.quit();
+  await prisma.$disconnect();
+};
+
+process.on("SIGINT", () => void shutdown().then(() => process.exit(0)));
+process.on("SIGTERM", () => void shutdown().then(() => process.exit(0)));
+
+logger.info("UrlTrack worker started");

--- a/packages/worker/src/webhook-delivery.test.ts
+++ b/packages/worker/src/webhook-delivery.test.ts
@@ -1,0 +1,21 @@
+import { createHmac } from "node:crypto";
+
+import { describe, expect, it } from "vitest";
+
+import { retryDelayForAttempt, signWebhookPayload } from "./webhook-delivery";
+
+describe("webhook delivery", () => {
+  it("signs payloads with HMAC-SHA256", () => {
+    const body = JSON.stringify({ event: "visit.created" });
+    const expected = createHmac("sha256", "secret").update(body).digest("hex");
+
+    expect(signWebhookPayload("secret", body)).toBe(`sha256=${expected}`);
+  });
+
+  it("uses the required retry schedule", () => {
+    expect(retryDelayForAttempt(1)).toBe(30_000);
+    expect(retryDelayForAttempt(2)).toBe(5 * 60_000);
+    expect(retryDelayForAttempt(5)).toBe(24 * 60 * 60_000);
+    expect(retryDelayForAttempt(6)).toBeUndefined();
+  });
+});

--- a/packages/worker/src/webhook-delivery.ts
+++ b/packages/worker/src/webhook-delivery.ts
@@ -1,0 +1,91 @@
+import { createHmac, randomUUID } from "node:crypto";
+
+export const WEBHOOK_RETRY_DELAYS_MS = [
+  30_000,
+  5 * 60_000,
+  30 * 60_000,
+  2 * 60 * 60_000,
+  24 * 60 * 60_000
+] as const;
+
+export type WebhookDeliveryInput = {
+  deliveryId?: string;
+  endpointUrl: string;
+  secret: string;
+  eventType: string;
+  payload: unknown;
+  attempt: number;
+};
+
+export type WebhookDeliveryResult =
+  | { status: "delivered"; responseCode: number }
+  | { status: "retrying"; responseCode?: number; nextRetryAt: Date; attempts: number }
+  | { status: "failed"; responseCode?: number; disabledEndpoint: boolean; attempts: number };
+
+export function serializeWebhookPayload(eventType: string, payload: unknown): string {
+  return JSON.stringify({
+    id: randomUUID(),
+    event: eventType,
+    created_at: new Date().toISOString(),
+    data: payload
+  });
+}
+
+export function signWebhookPayload(secret: string, body: string): string {
+  const signature = createHmac("sha256", secret).update(body).digest("hex");
+  return `sha256=${signature}`;
+}
+
+export function retryDelayForAttempt(attempt: number): number | undefined {
+  return WEBHOOK_RETRY_DELAYS_MS[attempt - 1];
+}
+
+export async function deliverWebhook(input: WebhookDeliveryInput): Promise<WebhookDeliveryResult> {
+  const body = serializeWebhookPayload(input.eventType, input.payload);
+  const controller = new AbortController();
+  const timeout = setTimeout(() => controller.abort(), 8_000);
+
+  try {
+    const response = await fetch(input.endpointUrl, {
+      method: "POST",
+      body,
+      headers: {
+        "content-type": "application/json",
+        "user-agent": "UrlTrack-Webhook/2.0",
+        "x-urltrack-event": input.eventType,
+        "x-urltrack-delivery": input.deliveryId ?? randomUUID(),
+        "x-urltrack-signature": signWebhookPayload(input.secret, body)
+      },
+      signal: controller.signal
+    });
+
+    if (response.ok) {
+      return { status: "delivered", responseCode: response.status };
+    }
+
+    return buildRetryResult(input.attempt + 1, response.status);
+  } catch {
+    return buildRetryResult(input.attempt + 1);
+  } finally {
+    clearTimeout(timeout);
+  }
+}
+
+function buildRetryResult(attempts: number, responseCode?: number): WebhookDeliveryResult {
+  const delay = retryDelayForAttempt(attempts);
+  if (delay === undefined) {
+    return {
+      status: "failed",
+      responseCode,
+      disabledEndpoint: true,
+      attempts
+    };
+  }
+
+  return {
+    status: "retrying",
+    responseCode,
+    attempts,
+    nextRetryAt: new Date(Date.now() + delay)
+  };
+}

--- a/packages/worker/tsconfig.json
+++ b/packages/worker/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "rootDir": "src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1,0 +1,4411 @@
+lockfileVersion: '9.0'
+
+settings:
+  autoInstallPeers: true
+  excludeLinksFromLockfile: false
+
+importers:
+
+  .:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.19
+      prisma:
+        specifier: ^6.0.1
+        version: 6.19.3(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.2
+        version: 4.22.4
+      turbo:
+        specifier: ^2.3.3
+        version: 2.9.16
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.19)
+
+  apps/api:
+    dependencies:
+      '@fastify/cors':
+        specifier: ^10.0.2
+        version: 10.1.0
+      '@fastify/helmet':
+        specifier: ^12.0.1
+        version: 12.0.1
+      '@fastify/rate-limit':
+        specifier: ^10.2.1
+        version: 10.3.0
+      '@fastify/swagger':
+        specifier: ^9.4.0
+        version: 9.7.0
+      '@fastify/swagger-ui':
+        specifier: ^5.2.0
+        version: 5.2.6
+      '@prisma/client':
+        specifier: ^6.0.1
+        version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+      '@supabase/supabase-js':
+        specifier: ^2.47.10
+        version: 2.106.2
+      '@urltrack/db':
+        specifier: workspace:*
+        version: link:../../packages/db
+      '@urltrack/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@urltrack/worker':
+        specifier: workspace:*
+        version: link:../../packages/worker
+      bullmq:
+        specifier: ^5.34.0
+        version: 5.77.6
+      fastify:
+        specifier: ^5.2.1
+        version: 5.8.5
+      ioredis:
+        specifier: 5.10.1
+        version: 5.10.1
+      nanoid:
+        specifier: ^5.0.9
+        version: 5.1.11
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
+      ua-parser-js:
+        specifier: ^2.0.0
+        version: 2.0.10
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.19)
+
+  apps/dashboard:
+    dependencies:
+      '@supabase/ssr':
+        specifier: ^0.5.2
+        version: 0.5.2(@supabase/supabase-js@2.106.2)
+      '@supabase/supabase-js':
+        specifier: ^2.47.10
+        version: 2.106.2
+      '@urltrack/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      '@xyflow/react':
+        specifier: ^12.3.6
+        version: 12.10.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      class-variance-authority:
+        specifier: ^0.7.1
+        version: 0.7.1
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
+      lucide-react:
+        specifier: ^0.468.0
+        version: 0.468.0(react@19.2.6)
+      next:
+        specifier: ^16.0.7
+        version: 16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      qrcode:
+        specifier: ^1.5.4
+        version: 1.5.4
+      react:
+        specifier: ^19.0.0
+        version: 19.2.6
+      react-dom:
+        specifier: ^19.0.0
+        version: 19.2.6(react@19.2.6)
+      recharts:
+        specifier: ^2.15.0
+        version: 2.15.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      tailwind-merge:
+        specifier: ^2.5.5
+        version: 2.6.1
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.19
+      '@types/qrcode':
+        specifier: ^1.5.5
+        version: 1.5.6
+      '@types/react':
+        specifier: ^19.0.2
+        version: 19.2.15
+      '@types/react-dom':
+        specifier: ^19.0.2
+        version: 19.2.3(@types/react@19.2.15)
+      autoprefixer:
+        specifier: ^10.4.20
+        version: 10.5.0(postcss@8.5.15)
+      postcss:
+        specifier: ^8.4.49
+        version: 8.5.15
+      tailwindcss:
+        specifier: ^3.4.17
+        version: 3.4.19(tsx@4.22.4)(yaml@2.9.0)
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.19)
+
+  packages/db:
+    dependencies:
+      '@prisma/client':
+        specifier: ^6.0.1
+        version: 6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)
+    devDependencies:
+      prisma:
+        specifier: ^6.0.1
+        version: 6.19.3(typescript@5.9.3)
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.19)
+
+  packages/shared:
+    dependencies:
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.19)
+
+  packages/worker:
+    dependencies:
+      '@urltrack/db':
+        specifier: workspace:*
+        version: link:../db
+      '@urltrack/shared':
+        specifier: workspace:*
+        version: link:../shared
+      bullmq:
+        specifier: ^5.34.0
+        version: 5.77.6
+      ioredis:
+        specifier: 5.10.1
+        version: 5.10.1
+      pino:
+        specifier: ^9.5.0
+        version: 9.14.0
+      zod:
+        specifier: ^3.24.1
+        version: 3.25.76
+    devDependencies:
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.19)
+
+packages:
+
+  '@alloc/quick-lru@5.2.0':
+    resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
+    engines: {node: '>=10'}
+
+  '@babel/runtime@7.29.7':
+    resolution: {integrity: sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==}
+    engines: {node: '>=6.9.0'}
+
+  '@emnapi/runtime@1.10.0':
+    resolution: {integrity: sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==}
+
+  '@esbuild/aix-ppc64@0.21.5':
+    resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/aix-ppc64@0.28.0':
+    resolution: {integrity: sha512-lhRUCeuOyJQURhTxl4WkpFTjIsbDayJHih5kZC1giwE+MhIzAb7mEsQMqMf18rHLsrb5qI1tafG20mLxEWcWlA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
+  '@esbuild/android-arm64@0.21.5':
+    resolution: {integrity: sha512-c0uX9VAUBQ7dTDCjq+wdyGLowMdtR/GoC2U5IYk/7D1H1JYC0qseD7+11iMP2mRLN9RcCMRcjC4YMclCzGwS/A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.28.0':
+    resolution: {integrity: sha512-+WzIXQOSaGs33tLEgYPYe/yQHf0WTU0X42Jca3y8NWMbUVhp7rUnw+vAsRC/QiDrdD31IszMrZy+qwPOPjd+rw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm@0.21.5':
+    resolution: {integrity: sha512-vCPvzSjpPHEi1siZdlvAlsPxXl7WbOVUBBAowWug4rJHb68Ox8KualB+1ocNvT5fjv6wpkX6o/iEpbDrf68zcg==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-arm@0.28.0':
+    resolution: {integrity: sha512-wqh0ByljabXLKHeWXYLqoJ5jKC4XBaw6Hk08OfMrCRd2nP2ZQ5eleDZC41XHyCNgktBGYMbqnrJKq/K/lzPMSQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
+  '@esbuild/android-x64@0.21.5':
+    resolution: {integrity: sha512-D7aPRUUNHRBwHxzxRvp856rjUHRFW1SdQATKXH2hqA0kAZb1hKmi02OpYRacl0TxIGz/ZmXWlbZgjwWYaCakTA==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.28.0':
+    resolution: {integrity: sha512-+VJggoaKhk2VNNqVL7f6S189UzShHC/mR9EE8rDdSkdpN0KflSwWY/gWjDrNxxisg8Fp1ZCD9jLMo4m0OUfeUA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/darwin-arm64@0.21.5':
+    resolution: {integrity: sha512-DwqXqZyuk5AiWWf3UfLiRDJ5EDd49zg6O9wclZ7kUMv2WRFr4HKjXp/5t8JZ11QbQfUS6/cRCKGwYhtNAY88kQ==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-arm64@0.28.0':
+    resolution: {integrity: sha512-0T+A9WZm+bZ84nZBtk1ckYsOvyA3x7e2Acj1KdVfV4/2tdG4fzUp91YHx+GArWLtwqp77pBXVCPn2We7Letr0Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.21.5':
+    resolution: {integrity: sha512-se/JjF8NlmKVG4kNIuyWMV/22ZaerB+qaSi5MdrXtd6R08kvs2qCN4C09miupktDitvh8jRFflwGFBQcxZRjbw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.28.0':
+    resolution: {integrity: sha512-fyzLm/DLDl/84OCfp2f/XQ4flmORsjU7VKt8HLjvIXChJoFFOIL6pLJPH4Yhd1n1gGFF9mPwtlN5Wf82DZs+LQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    resolution: {integrity: sha512-5JcRxxRDUJLX8JXp/wcBCy3pENnCgBR9bN6JsY4OmhfUtIHe3ZW0mawA7+RDAcMLrMIZaf03NlQiX9DGyB8h4g==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    resolution: {integrity: sha512-l9GeW5UZBT9k9brBYI+0WDffcRxgHQD8ShN2Ur4xWq/NFzUKm3k5lsH4PdaRgb2w7mI9u61nr2gI2mLI27Nh3Q==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.21.5':
+    resolution: {integrity: sha512-J95kNBj1zkbMXtHVH29bBriQygMXqoVQOQYA+ISs0/2l3T9/kj42ow2mpqerRBxDJnmkUDCaQT/dfNXWX/ZZCQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.28.0':
+    resolution: {integrity: sha512-BXoQai/A0wPO6Es3yFJ7APCiKGc1tdAEOgeTNy3SsB491S3aHn4S4r3e976eUnPdU+NbdtmBuLncYir2tMU9Nw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/linux-arm64@0.21.5':
+    resolution: {integrity: sha512-ibKvmyYzKsBeX8d8I7MH/TMfWDXBF3db4qM6sy+7re0YXya+K1cem3on9XgdT2EQGMu4hQyZhan7TeQ8XkGp4Q==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm64@0.28.0':
+    resolution: {integrity: sha512-RVyzfb3FWsGA55n6WY0MEIEPURL1FcbhFE6BffZEMEekfCzCIMtB5yyDcFnVbTnwk+CLAgTujmV/Lgvih56W+A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.21.5':
+    resolution: {integrity: sha512-bPb5AHZtbeNGjCKVZ9UGqGwo8EUu4cLq68E95A53KlxAPRmUyYv2D6F0uUI65XisGOL1hBP5mTronbgo+0bFcA==}
+    engines: {node: '>=12'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.28.0':
+    resolution: {integrity: sha512-CjaaREJagqJp7iTaNQjjidaNbCKYcd4IDkzbwwxtSvjI7NZm79qiHc8HqciMddQ6CKvJT6aBd8lO9kN/ZudLlw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.21.5':
+    resolution: {integrity: sha512-YvjXDqLRqPDl2dvRODYmmhz4rPeVKYvppfGYKSNGdyZkA01046pLWyRKKI3ax8fbJoK5QbxblURkwK/MWY18Tg==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-ia32@0.28.0':
+    resolution: {integrity: sha512-KBnSTt1kxl9x70q+ydterVdl+Cn0H18ngRMRCEQfrbqdUuntQQ0LoMZv47uB97NljZFzY6HcfqEZ2SAyIUTQBQ==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.21.5':
+    resolution: {integrity: sha512-uHf1BmMG8qEvzdrzAqg2SIG/02+4/DHB6a9Kbya0XDvwDEKCoC8ZRWI5JJvNdUjtciBGFQ5PuBlpEOXQj+JQSg==}
+    engines: {node: '>=12'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.28.0':
+    resolution: {integrity: sha512-zpSlUce1mnxzgBADvxKXX5sl8aYQHo2ezvMNI8I0lbblJtp8V4odlm3Yzlj7gPyt3T8ReksE6bK+pT3WD+aJRg==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.21.5':
+    resolution: {integrity: sha512-IajOmO+KJK23bj52dFSNCMsz1QP1DqM6cwLUv3W1QwyxkyIWecfafnI555fvSGqEKwjMXVLokcV5ygHW5b3Jbg==}
+    engines: {node: '>=12'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-mips64el@0.28.0':
+    resolution: {integrity: sha512-2jIfP6mmjkdmeTlsX/9vmdmhBmKADrWqN7zcdtHIeNSCH1SqIoNI63cYsjQR8J+wGa4Y5izRcSHSm8K3QWmk3w==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.21.5':
+    resolution: {integrity: sha512-1hHV/Z4OEfMwpLO8rp7CvlhBDnjsC3CttJXIhBi+5Aj5r+MBvy4egg7wCbe//hSsT+RvDAG7s81tAvpL2XAE4w==}
+    engines: {node: '>=12'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.28.0':
+    resolution: {integrity: sha512-bc0FE9wWeC0WBm49IQMPSPILRocGTQt3j5KPCA8os6VprfuJ7KD+5PzESSrJ6GmPIPJK965ZJHTUlSA6GNYEhg==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.21.5':
+    resolution: {integrity: sha512-2HdXDMd9GMgTGrPWnJzP2ALSokE/0O5HhTUvWIbD3YdjME8JwvSCnNGBnTThKGEB91OZhzrJ4qIIxk/SBmyDDA==}
+    engines: {node: '>=12'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-riscv64@0.28.0':
+    resolution: {integrity: sha512-SQPZOwoTTT/HXFXQJG/vBX8sOFagGqvZyXcgLA3NhIqcBv1BJU1d46c0rGcrij2B56Z2rNiSLaZOYW5cUk7yLQ==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.21.5':
+    resolution: {integrity: sha512-zus5sxzqBJD3eXxwvjN1yQkRepANgxE9lgOW2qLnmr8ikMTphkjgXu1HR01K4FJg8h1kEEDAqDcZQtbrRnB41A==}
+    engines: {node: '>=12'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.28.0':
+    resolution: {integrity: sha512-SCfR0HN8CEEjnYnySJTd2cw0k9OHB/YFzt5zgJEwa+wL/T/raGWYMBqwDNAC6dqFKmJYZoQBRfHjgwLHGSrn3Q==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.21.5':
+    resolution: {integrity: sha512-1rYdTpyv03iycF1+BhzrzQJCdOuAOtaqHTWJZCWvijKD2N5Xu0TtVC8/+1faWqcP9iBCWOmjmhoH94dH82BxPQ==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/linux-x64@0.28.0':
+    resolution: {integrity: sha512-us0dSb9iFxIi8srnpl931Nvs65it/Jd2a2K3qs7fz2WfGPHqzfzZTfec7oxZJRNPXPnNYZtanmRc4AL/JwVzHQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-CR/RYotgtCKwtftMwJlUU7xCVNg3lMYZ0RzTmAHSfLCXw3NtZtNpswLEj/Kkf6kEL3Gw+BpOekRX0BYCtklhUw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.21.5':
+    resolution: {integrity: sha512-Woi2MXzXjMULccIwMnLciyZH4nCIMpWQAs049KEeMvOcNADVxo0UBIQPfSmxB3CWKedngg7sWZdLvLczpe0tLg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-x64@0.28.0':
+    resolution: {integrity: sha512-nU1yhmYutL+fQ71Kxnhg8uEOdC0pwEW9entHykTgEbna2pw2dkbFSMeqjjyHZoCmt8SBkOSvV+yNmm94aUrrqw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    resolution: {integrity: sha512-cXb5vApOsRsxsEl4mcZ1XY3D4DzcoMxR/nnc4IyqYs0rTI8ZKmW6kyyg+11Z8yvgMfAEldKzP7AdP64HnSC/6g==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.21.5':
+    resolution: {integrity: sha512-HLNNw99xsvx12lFBUwoT8EVCsSvRNDVxNpjZ7bPn947b8gJPzeHWyNVhFsaerc0n3TsbOINvRP2byTZ5LKezow==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-x64@0.28.0':
+    resolution: {integrity: sha512-8wZM2qqtv9UP3mzy7HiGYNH/zjTA355mpeuA+859TyR+e+Tc08IHYpLJuMsfpDJwoLo1ikIJI8jC3GFjnRClzA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    resolution: {integrity: sha512-FLGfyizszcef5C3YtoyQDACyg95+dndv79i2EekILBofh5wpCa1KuBqOWKrEHZg3zrL3t5ouE5jgr94vA+Wb2w==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/sunos-x64@0.21.5':
+    resolution: {integrity: sha512-6+gjmFpfy0BHU5Tpptkuh8+uw3mnrvgs+dSPQXQOv3ekbordwnzTVEb4qnIvQcYXq6gzkyTnoZ9dZG+D4garKg==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/sunos-x64@0.28.0':
+    resolution: {integrity: sha512-1ZgjUoEdHZZl/YlV76TSCz9Hqj9h9YmMGAgAPYd+q4SicWNX3G5GCyx9uhQWSLcbvPW8Ni7lj4gDa1T40akdlw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
+  '@esbuild/win32-arm64@0.21.5':
+    resolution: {integrity: sha512-Z0gOTd75VvXqyq7nsl93zwahcTROgqvuAcYDUr+vOv8uHhNSKROyU961kgtCD1e95IqPKSQKH7tBTslnS3tA8A==}
+    engines: {node: '>=12'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.28.0':
+    resolution: {integrity: sha512-Q9StnDmQ/enxnpxCCLSg0oo4+34B9TdXpuyPeTedN/6+iXBJ4J+zwfQI28u/Jl40nOYAxGoNi7mFP40RUtkmUA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.21.5':
+    resolution: {integrity: sha512-SWXFF1CL2RVNMaVs+BBClwtfZSvDgtL//G/smwAc5oVK/UPu2Gu9tIaRgFmYFFKrmg3SyAjSrElf0TiJ1v8fYA==}
+    engines: {node: '>=12'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-ia32@0.28.0':
+    resolution: {integrity: sha512-zF3ag/gfiCe6U2iczcRzSYJKH1DCI+ByzSENHlM2FcDbEeo5Zd2C86Aq0tKUYAJJ1obRP84ymxIAksZUcdztHA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.21.5':
+    resolution: {integrity: sha512-tQd/1efJuzPC6rCFwEvLtci/xNFcTZknmXs98FYDfGE4wP9ClFV98nyKrzJKVPMhdDnjzLhdUyMX4PsQAPjwIw==}
+    engines: {node: '>=12'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.28.0':
+    resolution: {integrity: sha512-pEl1bO9mfAmIC+tW5btTmrKaujg3zGtUmWNdCw/xs70FBjwAL3o9OEKNHvNmnyylD6ubxUERiEhdsL0xBQ9efw==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@fastify/accept-negotiator@2.0.1':
+    resolution: {integrity: sha512-/c/TW2bO/v9JeEgoD/g1G5GxGeCF1Hafdf79WPmUlgYiBXummY0oX3VVq4yFkKKVBKDNlaDUYoab7g38RpPqCQ==}
+
+  '@fastify/ajv-compiler@4.0.5':
+    resolution: {integrity: sha512-KoWKW+MhvfTRWL4qrhUwAAZoaChluo0m0vbiJlGMt2GXvL4LVPQEjt8kSpHI3IBq5Rez8fg+XeH3cneztq+C7A==}
+
+  '@fastify/cors@10.1.0':
+    resolution: {integrity: sha512-MZyBCBJtII60CU9Xme/iE4aEy8G7QpzGR8zkdXZkDFt7ElEMachbE61tfhAG/bvSaULlqlf0huMT12T7iqEmdQ==}
+
+  '@fastify/error@4.2.0':
+    resolution: {integrity: sha512-RSo3sVDXfHskiBZKBPRgnQTtIqpi/7zhJOEmAxCiBcM7d0uwdGdxLlsCaLzGs8v8NnxIRlfG0N51p5yFaOentQ==}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    resolution: {integrity: sha512-uik7yYHkLr6fxd8hJSZ8c+xF4WafPK+XzneQDPU+D10r5X19GW8lJcom2YijX2+qtFF1ENJlHXKFM9ouXNJYgQ==}
+
+  '@fastify/forwarded@3.0.1':
+    resolution: {integrity: sha512-JqDochHFqXs3C3Ml3gOY58zM7OqO9ENqPo0UqAjAjH8L01fRZqwX9iLeX34//kiJubF7r2ZQHtBRU36vONbLlw==}
+
+  '@fastify/helmet@12.0.1':
+    resolution: {integrity: sha512-kkjBcedWwdflRThovGuvN9jB2QQLytBqArCFPdMIb7o2Fp0l/H3xxYi/6x/SSRuH/FFt9qpTGIfJz2bfnMrLqA==}
+
+  '@fastify/merge-json-schemas@0.2.1':
+    resolution: {integrity: sha512-OA3KGBCy6KtIvLf8DINC5880o5iBlDX4SxzLQS8HorJAbqluzLRn80UXU0bxZn7UOFhFgpRJDasfwn9nG4FG4A==}
+
+  '@fastify/proxy-addr@5.1.0':
+    resolution: {integrity: sha512-INS+6gh91cLUjB+PVHfu1UqcB76Sqtpyp7bnL+FYojhjygvOPA9ctiD/JDKsyD9Xgu4hUhCSJBPig/w7duNajw==}
+
+  '@fastify/rate-limit@10.3.0':
+    resolution: {integrity: sha512-eIGkG9XKQs0nyynatApA3EVrojHOuq4l6fhB4eeCk4PIOeadvOJz9/4w3vGI44Go17uaXOWEcPkaD8kuKm7g6Q==}
+
+  '@fastify/send@4.1.0':
+    resolution: {integrity: sha512-TMYeQLCBSy2TOFmV95hQWkiTYgC/SEx7vMdV+wnZVX4tt8VBLKzmH8vV9OzJehV0+XBfg+WxPMt5wp+JBUKsVw==}
+
+  '@fastify/static@9.1.3':
+    resolution: {integrity: sha512-aXrYtsiryLhRxRNaxNqsn7FUISeb7rB9q4eHUPIot5aeQBLNahnz1m6thzm7JWC1poSGXS9XrX8DvuMivp2hkQ==}
+
+  '@fastify/swagger-ui@5.2.6':
+    resolution: {integrity: sha512-OMnms0O5s9wb6wis/K5nlrAMLsgUbr1GA8uphM41IasWe3AFdgxz6r/3bA9HTxlDNUYc2FGGKeqMp3ntxmSiNA==}
+
+  '@fastify/swagger@9.7.0':
+    resolution: {integrity: sha512-Vp1SC1GC2Hrkd3faFILv86BzUNyFz5N4/xdExqtCgkGASOzn/x+eMe4qXIGq7cdT6wif/P/oa6r1Ruqx19paZA==}
+
+  '@img/colour@1.1.0':
+    resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
+    engines: {node: '>=18'}
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    resolution: {integrity: sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.34.5':
+    resolution: {integrity: sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    resolution: {integrity: sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    resolution: {integrity: sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    resolution: {integrity: sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    resolution: {integrity: sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    resolution: {integrity: sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    resolution: {integrity: sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    resolution: {integrity: sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    resolution: {integrity: sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    resolution: {integrity: sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    resolution: {integrity: sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linux-arm64@0.34.5':
+    resolution: {integrity: sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-arm@0.34.5':
+    resolution: {integrity: sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    resolution: {integrity: sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    resolution: {integrity: sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-s390x@0.34.5':
+    resolution: {integrity: sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linux-x64@0.34.5':
+    resolution: {integrity: sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    resolution: {integrity: sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    resolution: {integrity: sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@img/sharp-wasm32@0.34.5':
+    resolution: {integrity: sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-arm64@0.34.5':
+    resolution: {integrity: sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@img/sharp-win32-ia32@0.34.5':
+    resolution: {integrity: sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.34.5':
+    resolution: {integrity: sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@ioredis/commands@1.5.1':
+    resolution: {integrity: sha512-JH8ZL/ywcJyR9MmJ5BNqZllXNZQqQbnVZOqpPQqE1vHiFgAw4NHbvE0FOduNU8IX9babitBT46571OnPTT0Zcw==}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
+
+  '@jridgewell/resolve-uri@3.1.2':
+    resolution: {integrity: sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==}
+    engines: {node: '>=6.0.0'}
+
+  '@jridgewell/sourcemap-codec@1.5.5':
+    resolution: {integrity: sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lukeed/ms@2.0.2':
+    resolution: {integrity: sha512-9I2Zn6+NJLfaGoz9jN3lpwDgAYvfGeNYdbAIjJOqzs4Tpc+VU3Jqq4IofSUBKajiDS8k9fZIg18/z13mpk1bsA==}
+    engines: {node: '>=8'}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    resolution: {integrity: sha512-LCkGo6JDfaBhgST7UpPWgNgLINpcpabaHfyz5OBx75nUYxBsaEPxjnyNjWpeb/xBup/682QnBfRBy2/LvPutZQ==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    resolution: {integrity: sha512-zExlW9zUJKZH/tOtVMttwjKa4Xm/3KcNjnE3dPN92uCktwavMxpgCA3MoJK/DOnTWsQgo224OaST27/mPNAf+w==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    resolution: {integrity: sha512-dgX0P/9wGPJeHFBG+ZmhgE6bmtMt7NP5CRBGyyktpopdk/mW4POnrpQsSLtKI1dwpc+pPLuXHDh6vvskyQE/sw==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    resolution: {integrity: sha512-Tg3yX65f5GbtXLkrYEHE5oibZG9epyYWas7FogTTEJeDEF9JlXJzKgXaNhT3UXlTOeA+AfZpYZYZ0uPj7Cfquw==}
+    cpu: [arm]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    resolution: {integrity: sha512-8TNXMEjJc3QEy7R/x1INhgiU+XakDAFUzBhaz7+Rbrs8NH5UQeHQxxmzsSBJGyV6I1jW79undiQm8tOI+D+8FQ==}
+    cpu: [x64]
+    os: [linux]
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    resolution: {integrity: sha512-CmCXPQrkbwExx3j946/PtHWHbYJiCRBRDl4BlkRQcJB/YOwQxJRTpoo7aTsortjgoJ1x7opzTSxn7C+ASSLVjQ==}
+    cpu: [x64]
+    os: [win32]
+
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
+
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
+    engines: {node: '>= 10'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
+    engines: {node: '>= 10'}
+    cpu: [x64]
+    os: [win32]
+
+  '@nodelib/fs.scandir@2.1.5':
+    resolution: {integrity: sha512-vq24Bq3ym5HEQm2NKCr3yXDwjc7vTsEThRDnkp2DK9p1uqLR+DHurm/NOTo0KG7HYHU7eppKZj3MyqYuMBf62g==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.stat@2.0.5':
+    resolution: {integrity: sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A==}
+    engines: {node: '>= 8'}
+
+  '@nodelib/fs.walk@1.2.8':
+    resolution: {integrity: sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg==}
+    engines: {node: '>= 8'}
+
+  '@pinojs/redact@0.4.0':
+    resolution: {integrity: sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg==}
+
+  '@prisma/client@6.19.3':
+    resolution: {integrity: sha512-mKq3jQFhjvko5LTJFHGilsuQs+W+T3Gm451NzuTDGQxwCzwXHYnIu2zGkRoW+Exq3Rob7yp2MfzSrdIiZVhrBg==}
+    engines: {node: '>=18.18'}
+    peerDependencies:
+      prisma: '*'
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      prisma:
+        optional: true
+      typescript:
+        optional: true
+
+  '@prisma/config@6.19.3':
+    resolution: {integrity: sha512-CBPT44BjlQxEt8kiMEauji2WHTDoVBOKl7UlewXmUgBPnr/oPRZC3psci5chJnYmH0ivEIog2OU9PGWoki3DLQ==}
+
+  '@prisma/debug@6.19.3':
+    resolution: {integrity: sha512-ljkJ+SgpXNktLG0Q/n4JGYCkKf0f8oYLyjImS2I8e2q2WCfdRRtWER062ZV/ixaNP2M2VKlWXVJiGzZaUgbKZw==}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7':
+    resolution: {integrity: sha512-03bgb1VD5gvuumNf+7fVGBzfpJPjmqV423l/WxsWk2cNQ42JD0/SsFBPhN6z8iAvdHs07/7ei77SKu7aZfq8bA==}
+
+  '@prisma/engines@6.19.3':
+    resolution: {integrity: sha512-RSYxtlYFl5pJ8ZePgMv0lZ9IzVCOdTPOegrs2qcbAEFrBI1G33h6wyC9kjQvo0DnYEhEVY0X4LsuFHXLKQk88g==}
+
+  '@prisma/fetch-engine@6.19.3':
+    resolution: {integrity: sha512-tKtl/qco9Nt7LU5iKhpultD8O4vMCZcU2CHjNTnRrL1QvSUr5W/GcyFPjNL87GtRrwBc7ubXXD9xy4EvLvt8JA==}
+
+  '@prisma/get-platform@6.19.3':
+    resolution: {integrity: sha512-xFj1VcJ1N3MKooOQAGO0W5tsd0W2QzIvW7DD7c/8H14Zmp4jseeWAITm+w2LLoLrlhoHdPPh0NMZ8mfL6puoHA==}
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    resolution: {integrity: sha512-F5QXMSiFebS9hKZj02XhWLLnRpJ3B3AROP0tWbFBSj+6kCbg5m9j5JoHKd4mmSVy5mS/IMQloYgYxCuJC0fxEQ==}
+    cpu: [arm]
+    os: [android]
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    resolution: {integrity: sha512-GxxTKApUpzRhof7poWvCJHRF51C67u1R7D6DiluBE8wKU1u5GWE8t+v81JvJYtbawoBFX1hLv5Ei4eVjkWokaw==}
+    cpu: [arm64]
+    os: [android]
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    resolution: {integrity: sha512-tua0TaJxMOB1R0V0RS1jFZ/RpURFDJIOR2A6jWwQeawuFyS4gBW+rntLRaQd0EQ4bd6Vp44Z2rXW+YYDBsj6IA==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    resolution: {integrity: sha512-CSKq7MsP+5PFIcydhAiR1K0UhEI1A2jWXVKHPCBZ151yOutENwvnPocgVHkivu2kviURtCEB6zUQw0vs8RrhMg==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    resolution: {integrity: sha512-+O8OkVdyvXMtJEciu2wS/pzm1IxntEEQx3z5TAVy4l32G0etZn+RsA48ARRrFm6Ri8fvqPQfgrvNxSjKAbnd3g==}
+    cpu: [arm64]
+    os: [freebsd]
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    resolution: {integrity: sha512-Iw3oMskH3AfNuhU0MSN7vNbdi4me/NiYo2azqPz/Le16zHSa+3RRmliCMWWQmh4lcndccU40xcJuTYJZxNo/lw==}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    resolution: {integrity: sha512-EIPRXTVQpHyF8WOo219AD2yEltPehLTcTMz2fn6JsatLYSzQf00hj3rulF+yauOlF9/FtM2WpkT/hJh/KJFGhA==}
+    cpu: [arm]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    resolution: {integrity: sha512-J3Yh9PzzF1Ovah2At+lHiGQdsYgArxBbXv/zHfSyaiFQEqvNv7DcW98pCrmdjCZBrqBiKrKKe2V+aaSGWuBe/w==}
+    cpu: [arm]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    resolution: {integrity: sha512-BFDEZMYfUvLn37ONE1yMBojPxnMlTFsdyNoqncT0qFq1mAfllL+ATMMJd8TeuVMiX84s1KbcxcZbXInmcO2mRg==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    resolution: {integrity: sha512-pc9EYOSlOgdQ2uPl1o9PF6/kLSgaUosia7gOuS8mB69IxJvlclko1MECXysjs5ryez1/5zjYqx3+xYU0TU6R1A==}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    resolution: {integrity: sha512-NxnomyxYerDh5n4iLrNa+sH+Z+U4BMEE46V2PgQ/hoB909i8gV1M5wPojWg9fk1jWpO3IQnOs20K4wyZuFLEFQ==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    resolution: {integrity: sha512-nbJnQ8a3z1mtmrwImCYhc6BGpThAyYVRQxw9uKSKG4wR6aAYno9sVjJ0zaZcW9BPJX1GbrDPf+SvdWjgTuDmnw==}
+    cpu: [loong64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    resolution: {integrity: sha512-2EU6acNrQLd8tYvo/LXW535wupT3m6fo7HKo6lr7ktQoItxTyOL1ZCR/GfGCuXl2vR+zmfI6eRXkSemafv+iVg==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    resolution: {integrity: sha512-WeBtoMuaMxiiIrO2IYP3xs6GMWkJP2C0EoT8beTLkUPmzV1i/UcOSVw1d5r9KBODtHKilG5yFxsGRnBbK3wJ4A==}
+    cpu: [ppc64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    resolution: {integrity: sha512-FJHFfqpKUI3A10WrWKiFbBZ7yVbGT4q4B5o1qKFFojqpaYoh9LrQgqWCmmcxQzVSXYtyB5bzkXrYzlHTs21MYA==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    resolution: {integrity: sha512-mcEl6CUT5IAUmQf1m9FYSmVqCJlpQ8r8eyftFUHG8i9OhY7BkBXSUdnLH5DOf0wCOjcP9v/QO93zpmF1SptCCw==}
+    cpu: [riscv64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    resolution: {integrity: sha512-ynt3JxVd2w2buzoKDWIyiV1pJW93xlQic1THVLXilz429oijRpSHivZAgp65KBu+cMcgf1eVVjdnTLvPxgCuoQ==}
+    cpu: [s390x]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-Boiz5+MsaROEWDf+GGEwF8VMHGhlUoQMtIPjOgA5fv4osupqTVnJteQNKJwUcnUog2G55jYXH7KZFFiJe0TEzQ==}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    resolution: {integrity: sha512-+qfSY27qIrFfI/Hom04KYFw3GKZSGU4lXus51wsb5EuySfFlWRwjkKWoE9emgRw/ukoT4Udsj4W/+xxG8VbPKg==}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    resolution: {integrity: sha512-VpTfOPHgVXEBeeR8hZ2O0F3aSso+JDWqTWmTmzcQKted54IAdUVbxE+j/MVxUsKa8L20HJhv3vUezVPoquqWjA==}
+    cpu: [x64]
+    os: [openbsd]
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    resolution: {integrity: sha512-IPOsh5aRYuLv/nkU51X10Bf75Bsf6+gZdx1X+QP5QM6lIJFHHqbHLG0uJn/hWthzo13UAc2umiUorqZy3axoZg==}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    resolution: {integrity: sha512-4QzE9E81OohJ/HKzHhsqU+zcYYojVOXlFMs1DdyMT6qXl/niOH7AVElmmEdUNHHS/oRkc++d5k6Vy85zFs0DEw==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    resolution: {integrity: sha512-zTPgT1YuHHcd+Tmx7h8aml0FWFVelV5N54oHow9SLj+GfoDy/huQ+UV396N/C7KpMDMiPspRktzM1/0r1usYEA==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    resolution: {integrity: sha512-DRS4G7mi9lJxqEDezIkKCaUIKCrLUUDCUaCsTPCi/rtqaC6D/jjwslMQyiDU50Ka0JKpeXeRBFBAXwArY52vBw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    resolution: {integrity: sha512-QVTUovf40zgTqlFVrKA1uXMVvU2QWEFWfAH8Wdc48IxLvrJMQVMBRjuQyUpzZCDkakImib9eVazbWlC6ksWtJw==}
+    cpu: [x64]
+    os: [win32]
+
+  '@standard-schema/spec@1.1.0':
+    resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@supabase/auth-js@2.106.2':
+    resolution: {integrity: sha512-VcAjUErkHkhC5Jaf+g/G1qbkQrFh8edaCdHa7pxJmHUjkWKjT7UnYCtPA89XV0N0GIYRkEqJZw5V62CtOxTmBQ==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/functions-js@2.106.2':
+    resolution: {integrity: sha512-oRnr0QrL8H+zTO1YyQ1QjiHZU/957jvubbxSJTUm2XLAgzoGGV9Tahfyd+uvLsBLRVmXLtpU3oyCjdQIvkGMOA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+
+  '@supabase/postgrest-js@2.106.2':
+    resolution: {integrity: sha512-tDOzyPgp9pIRMR2x6C9+uDSJrnXSzxLtt3d7nC+Lrsy3jnJDHYfdQC/xcRyhJE/TOBJ0heSqRKR3UmejDjZxsw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/realtime-js@2.106.2':
+    resolution: {integrity: sha512-LdRGT7DNhyZkPjubUv5bSdAZ0jSEX8wTHvx7htj7+K59TOZRvz4TuQK7tL2RWxyIZVeFMRluL04SzWS61rKnUA==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/ssr@0.5.2':
+    resolution: {integrity: sha512-n3plRhr2Bs8Xun1o4S3k1CDv17iH5QY9YcoEvXX3bxV1/5XSasA0mNXYycFmADIdtdE6BG9MRjP5CGIs8qxC8A==}
+    peerDependencies:
+      '@supabase/supabase-js': ^2.43.4
+
+  '@supabase/storage-js@2.106.2':
+    resolution: {integrity: sha512-xgKCSYuev1YarV+iVqr+zlfgSyremnJtn8T0NCT8L4XmMv1CLtESc0Q6kNp8+mKWdX/8ND0nzm7OMKx08kwNAw==}
+    engines: {node: '>=20.0.0'}
+
+  '@supabase/supabase-js@2.106.2':
+    resolution: {integrity: sha512-2/RZ/1fmJx/MRSEDG2Xk8+J4JVk5clM9V0uSI6kUTrcS32KA89DtqI5RUOC9r6mzY3WBC9qexLjssIHjbLyVJA==}
+    engines: {node: '>=20.0.0'}
+
+  '@swc/helpers@0.5.15':
+    resolution: {integrity: sha512-JQ5TuMi45Owi4/BIMAJBoSQoOJu12oOk/gADqlcUL9JEdHB8vyjUSsxqeNXnmXHjYKMi2WcYtezGEEhqUI/E2g==}
+
+  '@turbo/darwin-64@2.9.16':
+    resolution: {integrity: sha512-jLjApWTSNd7JZ5JaLYfelW1ytnGQOvB7ivl+2RD1xQvJTbi8I9gBjzcga7tDZVPyaxpl10YTfJt3BrYXR18KDw==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@turbo/darwin-arm64@2.9.16':
+    resolution: {integrity: sha512-YPgrn+5HIGzrx0O2a631SV4MBQUe4W/DafMFUuBVgaU32PW9/OTT0ehviF0QSxTXuRJlHvW2eUTemddF5/spmw==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@turbo/linux-64@2.9.16':
+    resolution: {integrity: sha512-vAEf1H6l26lTpl9FJ/peQo1NUB8RC0sbEJJz5mPcUhHA2bPDup2x3CZPgo/bH8S4cUcBLm4FN3UHd5iUO2RAew==}
+    cpu: [x64]
+    os: [linux]
+
+  '@turbo/linux-arm64@2.9.16':
+    resolution: {integrity: sha512-xDBLR2PZg4BrQOchfG6svgpv5FCNJ2TOtT2psLdEJcdKo1BH+pnPs9Xj6pvUjgfkHbuvBOfeE4R6tvxMoQKDHQ==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@turbo/windows-64@2.9.16':
+    resolution: {integrity: sha512-NBAJnaUiGdgkSzQwUIdOvkCkcpTSu58G/sBGa0mvBtzfvFOOgrQwepKOOQ8cp6sWM6OcKDNFj2p1dsZA1OWjPg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@turbo/windows-arm64@2.9.16':
+    resolution: {integrity: sha512-Y7SJppD0Z8wjO3Ec0ZGd9KQ4Yv0BMnA8CIowj5Vp+OEVsosXDG2weK6/t1RRLfJmc2Ozrnd6y4DOgQys+mn3WQ==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@types/cookie@0.6.0':
+    resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/estree@1.0.8':
+    resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
+
+  '@types/estree@1.0.9':
+    resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/node@22.19.19':
+    resolution: {integrity: sha512-dyh/xO2Fh5bYrfWaaqGrRQQGkNdmYw6AmaAUvYeUMNTWQtvb796ikLdmTchRmOlOiIJ1TDXfWgVx1QkUlQ6Hew==}
+
+  '@types/qrcode@1.5.6':
+    resolution: {integrity: sha512-te7NQcV2BOvdj2b1hCAHzAoMNuj65kNBMz0KBaxM6c3VGBOhU0dURQKOtH8CFNI/dsKkwlv32p26qYQTWoB5bw==}
+
+  '@types/react-dom@19.2.3':
+    resolution: {integrity: sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==}
+    peerDependencies:
+      '@types/react': ^19.2.0
+
+  '@types/react@19.2.15':
+    resolution: {integrity: sha512-eRwcGNHve+E8qtEQSSRl6urh+rFop4v8gm6O8rGv25CodbvFdLjA1vVQ1KkiFE0w0UPOnb8tDiFKL5lp0rtY5Q==}
+
+  '@vitest/expect@2.1.9':
+    resolution: {integrity: sha512-UJCIkTBenHeKT1TTlKMJWy1laZewsRIzYighyYiJKZreqtdxSos/S1t+ktRMQWu2CKqaarrkeszJx1cgC5tGZw==}
+
+  '@vitest/mocker@2.1.9':
+    resolution: {integrity: sha512-tVL6uJgoUdi6icpxmdrn5YNo3g3Dxv+IHJBr0GXHaEdTcw3F+cPKnsXFhli6nO+f/6SDKPHEK1UN+k+TQv0Ehg==}
+    peerDependencies:
+      msw: ^2.4.9
+      vite: ^5.0.0
+    peerDependenciesMeta:
+      msw:
+        optional: true
+      vite:
+        optional: true
+
+  '@vitest/pretty-format@2.1.9':
+    resolution: {integrity: sha512-KhRIdGV2U9HOUzxfiHmY8IFHTdqtOhIzCpd8WRdJiE7D/HUcZVD0EgQCVjm+Q9gkUXWgBvMmTtZgIG48wq7sOQ==}
+
+  '@vitest/runner@2.1.9':
+    resolution: {integrity: sha512-ZXSSqTFIrzduD63btIfEyOmNcBmQvgOVsPNPe0jYtESiXkhd8u2erDLnMxmGrDCwHCCHE7hxwRDCT3pt0esT4g==}
+
+  '@vitest/snapshot@2.1.9':
+    resolution: {integrity: sha512-oBO82rEjsxLNJincVhLhaxxZdEtV0EFHMK5Kmx5sJ6H9L183dHECjiefOAdnqpIgT5eZwT04PoggUnW88vOBNQ==}
+
+  '@vitest/spy@2.1.9':
+    resolution: {integrity: sha512-E1B35FwzXXTs9FHNK6bDszs7mtydNi5MIfUWpceJ8Xbfb1gBMscAnwLbEu+B44ed6W3XjL9/ehLPHR1fkf1KLQ==}
+
+  '@vitest/utils@2.1.9':
+    resolution: {integrity: sha512-v0psaMSkNJ3A2NMrUEHFRzJtDPFn+/VWZ5WxImB21T9fjucJRmS7xCS3ppEnARb9y11OAzaD+P2Ps+b+BGX5iQ==}
+
+  '@xyflow/react@12.10.2':
+    resolution: {integrity: sha512-CgIi6HwlcHXwlkTpr0fxLv/0sRVNZ8IdwKLzzeCscaYBwpvfcH1QFOCeaTCuEn1FQEs/B8CjnTSjhs8udgmBgQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@xyflow/system@0.0.76':
+    resolution: {integrity: sha512-hvwvnRS1B3REwVDlWexsq7YQaPZeG3/mKo1jv38UmnpWmxihp14bW6VtEOuHEwJX2FvzFw8k77LyKSk/wiZVNA==}
+
+  abstract-logging@2.0.1:
+    resolution: {integrity: sha512-2BjRTZxTPvheOvGbBslFSYOUkr+SjPtOnrLP33f+VIWLzezQpZcqVg7ja3L4dBXmzzgwT+a029jRx5PCi3JuiA==}
+
+  ajv-formats@3.0.1:
+    resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
+    peerDependencies:
+      ajv: ^8.0.0
+    peerDependenciesMeta:
+      ajv:
+        optional: true
+
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
+  ansi-styles@4.3.0:
+    resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
+    engines: {node: '>=8'}
+
+  any-promise@1.3.0:
+    resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
+
+  anymatch@3.1.3:
+    resolution: {integrity: sha512-KMReFUr0B4t+D+OBkjR3KYqvocp2XaSzO55UcB6mgQMd3KbcE+mWTyvVV7D/zsdEbNnV6acZUutkiHQXvTr1Rw==}
+    engines: {node: '>= 8'}
+
+  arg@5.0.2:
+    resolution: {integrity: sha512-PYjyFOLKQ9y57JvQ6QLo8dAgNqswh8M1RMJYdQduT6xbWSgK36P/Z/v+p888pM69jMMfS8Xd8F6I1kQ/I9HUGg==}
+
+  assertion-error@2.0.1:
+    resolution: {integrity: sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==}
+    engines: {node: '>=12'}
+
+  atomic-sleep@1.0.0:
+    resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
+    engines: {node: '>=8.0.0'}
+
+  autoprefixer@10.5.0:
+    resolution: {integrity: sha512-FMhOoZV4+qR6aTUALKX2rEqGG+oyATvwBt9IIzVR5rMa2HRWPkxf+P+PAJLD1I/H5/II+HuZcBJYEFBpq39ong==}
+    engines: {node: ^10 || ^12 || >=14}
+    hasBin: true
+    peerDependencies:
+      postcss: ^8.1.0
+
+  avvio@9.2.0:
+    resolution: {integrity: sha512-2t/sy01ArdHHE0vRH5Hsay+RtCZt3dLPji7W7/MMOCEgze5b7SNDC4j5H6FnVgPkI1MTNFGzHdHrVXDDl7QSSQ==}
+
+  balanced-match@4.0.4:
+    resolution: {integrity: sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA==}
+    engines: {node: 18 || 20 || >=22}
+
+  baseline-browser-mapping@2.10.33:
+    resolution: {integrity: sha512-bA6+tcSLpz2tIEdDXZPpPTIuxBcC4+w6SieaYyfigIa4h8GlFxbA17v22Vx3JUtuZQj9SgOsnbK+aTBzyDyEuw==}
+    engines: {node: '>=6.0.0'}
+    hasBin: true
+
+  binary-extensions@2.3.0:
+    resolution: {integrity: sha512-Ceh+7ox5qe7LJuLHoY0feh3pHuUDHAcRUeyL2VYghZwfpkNIy/+8Ocg0a3UuSoYzavmylwuLWQOf3hl0jjMMIw==}
+    engines: {node: '>=8'}
+
+  brace-expansion@5.0.6:
+    resolution: {integrity: sha512-kLpxurY4Z4r9sgMsyG0Z9uzsBlgiU/EFKhj/h91/8yHu0edo7XuixOIH3VcJ8kkxs6/jPzoI6U9Vj3WqbMQ94g==}
+    engines: {node: 18 || 20 || >=22}
+
+  braces@3.0.3:
+    resolution: {integrity: sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA==}
+    engines: {node: '>=8'}
+
+  browserslist@4.28.2:
+    resolution: {integrity: sha512-48xSriZYYg+8qXna9kwqjIVzuQxi+KYWp2+5nCYnYKPTr0LvD89Jqk2Or5ogxz0NUMfIjhh2lIUX/LyX9B4oIg==}
+    engines: {node: ^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7}
+    hasBin: true
+
+  bullmq@5.77.6:
+    resolution: {integrity: sha512-WCpSoCD4vWyRD+btOsFrO7iBGInrTgG155gTZCV8qY0Yex2KtsbVtFERx6V1WZ2xWl/5ZxnLar8Z8ufnS4f5jg==}
+    engines: {node: '>=12.22.0'}
+    peerDependencies:
+      redis: '>=5.0.0'
+    peerDependenciesMeta:
+      redis:
+        optional: true
+
+  c12@3.1.0:
+    resolution: {integrity: sha512-uWoS8OU1MEIsOv8p/5a82c3H31LsWVR5qiyXVfBNOzfffjUWtPnhAb4BYI2uG2HfGmZmFjCtui5XNWaps+iFuw==}
+    peerDependencies:
+      magicast: ^0.3.5
+    peerDependenciesMeta:
+      magicast:
+        optional: true
+
+  cac@6.7.14:
+    resolution: {integrity: sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==}
+    engines: {node: '>=8'}
+
+  camelcase-css@2.0.1:
+    resolution: {integrity: sha512-QOSvevhslijgYwRx6Rv7zKdMF8lbRmx+uQGx2+vDc+KI/eBnsy9kit5aj23AgGu3pa4t9AgwbnXWqS+iOY+2aA==}
+    engines: {node: '>= 6'}
+
+  camelcase@5.3.1:
+    resolution: {integrity: sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==}
+    engines: {node: '>=6'}
+
+  caniuse-lite@1.0.30001793:
+    resolution: {integrity: sha512-iwSsYWaCOoh26cV8NwNRViHlrfUvYsHDfRVcbtmw0Kg6PJIZZXwMkj1442FYLBGkeUf1juAsU3DTfxW579mrPA==}
+
+  chai@5.3.3:
+    resolution: {integrity: sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==}
+    engines: {node: '>=18'}
+
+  check-error@2.1.3:
+    resolution: {integrity: sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==}
+    engines: {node: '>= 16'}
+
+  chokidar@3.6.0:
+    resolution: {integrity: sha512-7VT13fmjotKpGipCW9JEQAusEPE+Ei8nl6/g4FBAmIm0GOOLMua9NDDo/DWp0ZAxCr3cPq5ZpBqmPAQgDda2Pw==}
+    engines: {node: '>= 8.10.0'}
+
+  chokidar@4.0.3:
+    resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
+    engines: {node: '>= 14.16.0'}
+
+  citty@0.1.6:
+    resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  citty@0.2.2:
+    resolution: {integrity: sha512-+6vJA3L98yv+IdfKGZHBNiGW5KHn22e/JwID0Strsz8h4S/csAu/OuICwxrg44k5MRiZHWIo8XXuJgQTriRP4w==}
+
+  class-variance-authority@0.7.1:
+    resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
+
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
+  client-only@0.0.1:
+    resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
+
+  cliui@6.0.0:
+    resolution: {integrity: sha512-t6wbgtoCXvAzst7QgXxJYqPt0usEfbgQdftEPbLL/cvv6HPE5VgvqCuAIDR0NgU52ds6rFwqrgakNLrHEjCbrQ==}
+
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
+  cluster-key-slot@1.1.2:
+    resolution: {integrity: sha512-RMr0FhtfXemyinomL4hrWcYJxmX6deFdCxpJzhDttxgO1+bcCnkk+9drydLVDmAMG7NE6aN/fl4F7ucU/90gAA==}
+    engines: {node: '>=0.10.0'}
+
+  color-convert@2.0.1:
+    resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
+    engines: {node: '>=7.0.0'}
+
+  color-name@1.1.4:
+    resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  commander@4.1.1:
+    resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
+    engines: {node: '>= 6'}
+
+  confbox@0.2.4:
+    resolution: {integrity: sha512-ysOGlgTFbN2/Y6Cg3Iye8YKulHw+R2fNXHrgSmXISQdMnomY6eNDprVdW9R5xBguEqI954+S6709UyiO7B+6OQ==}
+
+  consola@3.4.2:
+    resolution: {integrity: sha512-5IKcdX0nnYavi6G7TtOhwkYzyjfJlatbjMjuLSfE2kYT5pMDOilZ4OvMhi637CcDICTmz3wARPoyhqyX1Y+XvA==}
+    engines: {node: ^14.18.0 || >=16.10.0}
+
+  content-disposition@1.1.0:
+    resolution: {integrity: sha512-5jRCH9Z/+DRP7rkvY83B+yGIGX96OYdJmzngqnw2SBSxqCFPd0w2km3s5iawpGX8krnwSGmF0FW5Nhr0Hfai3g==}
+    engines: {node: '>=18'}
+
+  cookie@0.7.2:
+    resolution: {integrity: sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==}
+    engines: {node: '>= 0.6'}
+
+  cookie@1.1.1:
+    resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
+    engines: {node: '>=18'}
+
+  cron-parser@4.9.0:
+    resolution: {integrity: sha512-p0SaNjrHOnQeR8/VnfGbmg9te2kfyYSQ7Sc/j/6DtPL3JQvKxmjO9TSjNFpujqV3vEYYBvNNvXSxzyksBWAx1Q==}
+    engines: {node: '>=12.0.0'}
+
+  cssesc@3.0.0:
+    resolution: {integrity: sha512-/Tb/JcjK111nNScGob5MNtsntNM1aCNUDipB/TkwZFhyDrrE47SOx/18wF2bbjgc3ZzCSKW1T5nt5EbFoAz/Vg==}
+    engines: {node: '>=4'}
+    hasBin: true
+
+  csstype@3.2.3:
+    resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  debug@4.4.3:
+    resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
+    engines: {node: '>=6.0'}
+    peerDependencies:
+      supports-color: '*'
+    peerDependenciesMeta:
+      supports-color:
+        optional: true
+
+  decamelize@1.2.0:
+    resolution: {integrity: sha512-z2S+W9X73hAUUki+N+9Za2lBlun89zigOyGrsax+KUQ6wKW4ZoWpEYBkGhQjwAjjDCkWxhY0VKEhk8wzY7F5cA==}
+    engines: {node: '>=0.10.0'}
+
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  deep-eql@5.0.2:
+    resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
+    engines: {node: '>=6'}
+
+  deepmerge-ts@7.1.5:
+    resolution: {integrity: sha512-HOJkrhaYsweh+W+e74Yn7YStZOilkoPb6fycpwNLKzSPtruFs48nYis0zy5yJz1+ktUhHxoRDJ27RQAWLIJVJw==}
+    engines: {node: '>=16.0.0'}
+
+  defu@6.1.7:
+    resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  denque@2.1.0:
+    resolution: {integrity: sha512-HVQE3AAb/pxF8fQAoiqpvg9i3evqug3hoiwakOyZAwJm+6vZehbkYXZ0l4JxS+I3QxM97v5aaRNhj8v5oBhekw==}
+    engines: {node: '>=0.10'}
+
+  depd@2.0.0:
+    resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
+    engines: {node: '>= 0.8'}
+
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  destr@2.0.5:
+    resolution: {integrity: sha512-ugFTXCtDZunbzasqBxrK93Ik/DRYsO6S/fedkWEMKqt04xZ4csmnmwGDBAb07QWNaGMAmnTIemsYZCksjATwsA==}
+
+  detect-europe-js@0.1.2:
+    resolution: {integrity: sha512-lgdERlL3u0aUdHocoouzT10d9I89VVhk0qNRmll7mXdGfJT1/wqZ2ZLA4oJAjeACPY5fT1wsbq2AT+GkuInsow==}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
+  didyoumean@1.2.2:
+    resolution: {integrity: sha512-gxtyfqMg7GKyhQmb056K7M3xszy/myH8w+B4RT+QXBQsvAOdc3XymqDDPHx1BgPgsdAA5SIifona89YtRATDzw==}
+
+  dijkstrajs@1.0.3:
+    resolution: {integrity: sha512-qiSlmBq9+BCdCA/L46dw8Uy93mloxsPSbwnm5yrKn2vMPiy8KyAskTF6zuV/j5BMsmOGZDPs7KjU+mjb670kfA==}
+
+  dlv@1.1.3:
+    resolution: {integrity: sha512-+HlytyjlPKnIG8XuRG8WvmBP8xs8P71y+SKKS6ZXWoEgLuePxtDoUEiH7WkdePWrQ5JBpE6aoVqfZfJUQkjXwA==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
+  dotenv@16.6.1:
+    resolution: {integrity: sha512-uBq4egWHTcTt33a72vpSG0z3HnPuIl6NqYcTrKEg2azoEyl2hpW0zqlxysq2pK9HlDIHyHyakeYaYnSAwd8bow==}
+    engines: {node: '>=12'}
+
+  effect@3.21.0:
+    resolution: {integrity: sha512-PPN80qRokCd1f015IANNhrwOnLO7GrrMQfk4/lnZRE/8j7UPWrNNjPV0uBrZutI/nHzernbW+J0hdqQysHiSnQ==}
+
+  electron-to-chromium@1.5.364:
+    resolution: {integrity: sha512-G/dYE3+AYhyHwzTwg8UbnXf7zqMERYh7l2jJ3QujhFsH8agSYwtnGAR2aZ7f0AakIKJXd5En/Hre4igIUrdlYw==}
+
+  emoji-regex@8.0.0:
+    resolution: {integrity: sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==}
+
+  empathic@2.0.0:
+    resolution: {integrity: sha512-i6UzDscO/XfAcNYD75CfICkmfLedpyPDdozrLMmQc5ORaQcdMoc21OnlEylMIqI7U8eniKrPMxxtj8k0vhmJhA==}
+    engines: {node: '>=14'}
+
+  es-errors@1.3.0:
+    resolution: {integrity: sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==}
+    engines: {node: '>= 0.4'}
+
+  es-module-lexer@1.7.0:
+    resolution: {integrity: sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==}
+
+  esbuild@0.21.5:
+    resolution: {integrity: sha512-mg3OPMV4hXywwpoDxu3Qda5xCKQi+vCTZq8S9J/EpkhB2HzKXq4SNFZE3+NK93JYxc8VMSep+lOUSC/RVKaBqw==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  esbuild@0.28.0:
+    resolution: {integrity: sha512-sNR9MHpXSUV/XB4zmsFKN+QgVG82Cc7+/aaxJ8Adi8hyOac+EXptIp45QBPaVyX3N70664wRbTcLTOemCAnyqw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  escalade@3.2.0:
+    resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
+    engines: {node: '>=6'}
+
+  escape-html@1.0.3:
+    resolution: {integrity: sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==}
+
+  estree-walker@3.0.3:
+    resolution: {integrity: sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==}
+
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
+  expect-type@1.3.0:
+    resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
+    engines: {node: '>=12.0.0'}
+
+  exsolve@1.0.8:
+    resolution: {integrity: sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==}
+
+  fast-check@3.23.2:
+    resolution: {integrity: sha512-h5+1OzzfCC3Ef7VbtKdcv7zsstUQwUDlYpUTvjeUsJAssPgLn7QzbboPtL5ro04Mq0rPOsMzl7q5hIbRs2wD1A==}
+    engines: {node: '>=8.0.0'}
+
+  fast-decode-uri-component@1.0.1:
+    resolution: {integrity: sha512-WKgKWg5eUxvRZGwW8FvfbaH7AXSh2cL+3j5fMGzUMCxWBJ3dV3a7Wz8y2f/uQ0e3B6WmodD3oS54jTQ9HVTIIg==}
+
+  fast-deep-equal@3.1.3:
+    resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
+
+  fast-glob@3.3.3:
+    resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
+    engines: {node: '>=8.6.0'}
+
+  fast-json-stringify@6.4.0:
+    resolution: {integrity: sha512-ibRCQ0GZKJIQ+P3Et1h0LhPgp3PMTYk0MH8O+kW3lNYsvmaQww5Nn3f1jf73Q0jR1Yz3a1CDP4/NZD3vOajWJQ==}
+
+  fast-querystring@1.1.2:
+    resolution: {integrity: sha512-g6KuKWmFXc0fID8WWH0jit4g0AGBoJhCkJMb1RmbsSEUNvQ+ZC8D6CUZ+GtF8nMzSPXnhiePyyqqipzNNEnHjg==}
+
+  fast-uri@3.1.2:
+    resolution: {integrity: sha512-rVjf7ArG3LTk+FS6Yw81V1DLuZl1bRbNrev6Tmd/9RaroeeRRJhAt7jg/6YFxbvAQXUCavSoZhPPj6oOx+5KjQ==}
+
+  fastify-plugin@5.1.0:
+    resolution: {integrity: sha512-FAIDA8eovSt5qcDgcBvDuX/v0Cjz0ohGhENZ/wpc3y+oZCY2afZ9Baqql3g/lC+OHRnciQol4ww7tuthOb9idw==}
+
+  fastify@5.8.5:
+    resolution: {integrity: sha512-Yqptv59pQzPgQUSIm87hMqHJmdkb1+GPxdE6vW6FRyVE9G86mt7rOghitiU4JHRaTyDUk9pfeKmDeu70lAwM4Q==}
+
+  fastq@1.20.1:
+    resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
+
+  fdir@6.5.0:
+    resolution: {integrity: sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg==}
+    engines: {node: '>=12.0.0'}
+    peerDependencies:
+      picomatch: ^3 || ^4
+    peerDependenciesMeta:
+      picomatch:
+        optional: true
+
+  fill-range@7.1.1:
+    resolution: {integrity: sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg==}
+    engines: {node: '>=8'}
+
+  find-my-way@9.6.0:
+    resolution: {integrity: sha512-Zf4Xve4RymLl7NgaavNebZ01joJ8MfVerOG43wy7SHLO+r+K0C6d/SE0BiR7AV5V1VOCFlOP7ecdo+I4qmiHrQ==}
+    engines: {node: '>=20'}
+
+  find-up@4.1.0:
+    resolution: {integrity: sha512-PpOwAdQ/YlXQ2vj8a3h8IipDuYRi3wceVQQGYWxNINccq40Anw7BlsEXCMbt1Zt+OLA6Fq9suIpIWD0OsnISlw==}
+    engines: {node: '>=8'}
+
+  fraction.js@5.3.4:
+    resolution: {integrity: sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==}
+
+  fsevents@2.3.3:
+    resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
+  function-bind@1.1.2:
+    resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
+
+  get-caller-file@2.0.5:
+    resolution: {integrity: sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg==}
+    engines: {node: 6.* || 8.* || >= 10.*}
+
+  giget@2.0.0:
+    resolution: {integrity: sha512-L5bGsVkxJbJgdnwyuheIunkGatUF/zssUoxxjACCseZYAVbaqdh9Tsmmlkl8vYan09H7sbvKt4pS8GqKLBrEzA==}
+    hasBin: true
+
+  glob-parent@5.1.2:
+    resolution: {integrity: sha512-AOIgSQCepiJYwP3ARnGx+5VnTu2HBYdzbGP45eLw1vr3zB3vZLeyed1sC9hnbcOc9/SrMyM5RPQrkGz4aS9Zow==}
+    engines: {node: '>= 6'}
+
+  glob-parent@6.0.2:
+    resolution: {integrity: sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A==}
+    engines: {node: '>=10.13.0'}
+
+  glob@13.0.6:
+    resolution: {integrity: sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw==}
+    engines: {node: 18 || 20 || >=22}
+
+  hasown@2.0.4:
+    resolution: {integrity: sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==}
+    engines: {node: '>= 0.4'}
+
+  helmet@7.2.0:
+    resolution: {integrity: sha512-ZRiwvN089JfMXokizgqEPXsl2Guk094yExfoDXR0cBYWxtBbaSww/w+vT4WEJsBW2iTUi1GgZ6swmoug3Oy4Xw==}
+    engines: {node: '>=16.0.0'}
+
+  http-errors@2.0.1:
+    resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
+    engines: {node: '>= 0.8'}
+
+  iceberg-js@0.8.1:
+    resolution: {integrity: sha512-1dhVQZXhcHje7798IVM+xoo/1ZdVfzOMIc8/rgVSijRK38EDqOJoGula9N/8ZI5RD8QTxNQtK/Gozpr+qUqRRA==}
+    engines: {node: '>=20.0.0'}
+
+  inherits@2.0.4:
+    resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
+
+  ioredis@5.10.1:
+    resolution: {integrity: sha512-HuEDBTI70aYdx1v6U97SbNx9F1+svQKBDo30o0b9fw055LMepzpOOd0Ccg9Q6tbqmBSJaMuY0fB7yw9/vjBYCA==}
+    engines: {node: '>=12.22.0'}
+
+  ipaddr.js@2.4.0:
+    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
+    engines: {node: '>= 10'}
+
+  is-binary-path@2.1.0:
+    resolution: {integrity: sha512-ZMERYes6pDydyuGidse7OsHxtbI7WVeUEozgR/g7rd0xUimYNlvZRE/K2MgZTjWy725IfelLeVcEM97mmtRGXw==}
+    engines: {node: '>=8'}
+
+  is-core-module@2.16.2:
+    resolution: {integrity: sha512-evOr8xfXKxE6qSR0hSXL2r3sd7ALj8+7jQEUvPYcm5sgZFdJ+AYzT6yNmJenvIYQBgIGwfwz08sL8zoL7yq2BA==}
+    engines: {node: '>= 0.4'}
+
+  is-extglob@2.1.1:
+    resolution: {integrity: sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ==}
+    engines: {node: '>=0.10.0'}
+
+  is-fullwidth-code-point@3.0.0:
+    resolution: {integrity: sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==}
+    engines: {node: '>=8'}
+
+  is-glob@4.0.3:
+    resolution: {integrity: sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg==}
+    engines: {node: '>=0.10.0'}
+
+  is-number@7.0.0:
+    resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
+    engines: {node: '>=0.12.0'}
+
+  is-standalone-pwa@0.1.1:
+    resolution: {integrity: sha512-9Cbovsa52vNQCjdXOzeQq5CnCbAcRk05aU62K20WO372NrTv0NxibLFCK6lQ4/iZEFdEA3p3t2VNOn8AJ53F5g==}
+
+  jiti@1.21.7:
+    resolution: {integrity: sha512-/imKNG4EbWNrVjoNC/1H5/9GFy+tqjGBHCaSsN+P2RnPqjsLmv6UD3Ej+Kj8nBWaRAwyk7kK5ZUc+OEatnTR3A==}
+    hasBin: true
+
+  jiti@2.7.0:
+    resolution: {integrity: sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==}
+    hasBin: true
+
+  js-tokens@4.0.0:
+    resolution: {integrity: sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==}
+
+  json-schema-ref-resolver@3.0.0:
+    resolution: {integrity: sha512-hOrZIVL5jyYFjzk7+y7n5JDzGlU8rfWDuYyHwGa2WA8/pcmMHezp2xsVwxrebD/Q9t8Nc5DboieySDpCp4WG4A==}
+
+  json-schema-resolver@3.0.0:
+    resolution: {integrity: sha512-HqMnbz0tz2DaEJ3ntsqtx3ezzZyDE7G56A/pPY/NGmrPu76UzsWquOpHFRAf5beTNXoH2LU5cQePVvRli1nchA==}
+    engines: {node: '>=20'}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
+
+  light-my-request@6.6.0:
+    resolution: {integrity: sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A==}
+
+  lilconfig@3.1.3:
+    resolution: {integrity: sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw==}
+    engines: {node: '>=14'}
+
+  lines-and-columns@1.2.4:
+    resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  locate-path@5.0.0:
+    resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
+    engines: {node: '>=8'}
+
+  lodash.defaults@4.2.0:
+    resolution: {integrity: sha512-qjxPLHd3r5DnsdGacqOMU6pb/avJzdh9tFX2ymgoZE27BmjXrNy/y4LoaiTeAb+O3gL8AfpJGtqfX/ae2leYYQ==}
+
+  lodash.isarguments@3.1.0:
+    resolution: {integrity: sha512-chi4NHZlZqZD18a0imDHnZPrDeBbTtVN7GXMwuGdRH9qotxAjYs3aVLKc7zNOG9eddR5Ksd8rvFEBc9SsggPpg==}
+
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
+  loose-envify@1.4.0:
+    resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
+    hasBin: true
+
+  loupe@3.2.1:
+    resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@11.5.1:
+    resolution: {integrity: sha512-RPimw/7aMdv2oqRrxKwvZXcPfwBrn/JZ2xYcY9Hus/6LaS3VOAKVWKWgNLCFSiOm1ESXinjsDlidVU7JlnCN2A==}
+    engines: {node: 20 || >=22}
+
+  lucide-react@0.468.0:
+    resolution: {integrity: sha512-6koYRhnM2N0GGZIdXzSeiNwguv1gt/FAjZOiPl76roBi3xKEXa4WmfpxgQwTTL4KipXjefrnf3oV4IsYhi4JFA==}
+    peerDependencies:
+      react: ^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0-rc
+
+  luxon@3.7.2:
+    resolution: {integrity: sha512-vtEhXh/gNjI9Yg1u4jX/0YVPMvxzHuGgCm6tC5kZyb08yjGWGnqAjGJvcXbqQR2P3MyMEFnRbpcdFS6PBcLqew==}
+    engines: {node: '>=12'}
+
+  magic-string@0.30.21:
+    resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
+
+  merge2@1.4.1:
+    resolution: {integrity: sha512-8q7VEgMJW4J8tcfVPy8g09NcQwZdbwFEqhe/WZkoIzjn/3TGDwtOCYtXGxA3O8tPzpczCCDgv+P2P5y00ZJOOg==}
+    engines: {node: '>= 8'}
+
+  micromatch@4.0.8:
+    resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
+    engines: {node: '>=8.6'}
+
+  mime@3.0.0:
+    resolution: {integrity: sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==}
+    engines: {node: '>=10.0.0'}
+    hasBin: true
+
+  minimatch@10.2.5:
+    resolution: {integrity: sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg==}
+    engines: {node: 18 || 20 || >=22}
+
+  minipass@7.1.3:
+    resolution: {integrity: sha512-tEBHqDnIoM/1rXME1zgka9g6Q2lcoCkxHLuc7ODJ5BxbP5d4c2Z5cGgtXAku59200Cx7diuHTOYfSBD8n6mm8A==}
+    engines: {node: '>=16 || 14 >=14.17'}
+
+  mnemonist@0.40.0:
+    resolution: {integrity: sha512-kdd8AFNig2AD5Rkih7EPCXhu/iMvwevQFX/uEiGhZyPZi7fHqOoF4V4kHLpCfysxXMgQ4B52kdPMCwARshKvEg==}
+
+  ms@2.1.3:
+    resolution: {integrity: sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==}
+
+  msgpackr-extract@3.0.4:
+    resolution: {integrity: sha512-4kmO/MdyUIkLIvTPr8VHLil4AtoKIoniWPIEk5+CDy0xnWC84azhSFmuJ7PxZdsYtiP5kEeQsORAVIeMgxT+Hw==}
+    hasBin: true
+
+  msgpackr@2.0.1:
+    resolution: {integrity: sha512-9J+tqTEsbHqY8YohazYgty7LgerFIWxvMLpUjqETSmjHojtJm2WnX2kK/2a1fLI7CO7ERP1YSEUXMucz4j+yBA==}
+
+  mz@2.7.0:
+    resolution: {integrity: sha512-z81GNO7nnYMEhrGh9LeymoE4+Yr0Wn5McHIZMK5cfQCl+NDX08sCZgUc9/6MHni9IWuFLm1Z3HTCXu2z9fN62Q==}
+
+  nanoid@3.3.12:
+    resolution: {integrity: sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==}
+    engines: {node: ^10 || ^12 || ^13.7 || ^14 || >=15.0.1}
+    hasBin: true
+
+  nanoid@5.1.11:
+    resolution: {integrity: sha512-v+KEsUv2ps74PaSKv0gHTxTCgMXOIfBEbaqa6w6ISIGC7ZsvHN4N9oJ8d4cmf0n5oTzQz2SLmThbQWhjd/8eKg==}
+    engines: {node: ^18 || >=20}
+    hasBin: true
+
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
+    engines: {node: '>=20.9.0'}
+    hasBin: true
+    peerDependencies:
+      '@opentelemetry/api': ^1.1.0
+      '@playwright/test': ^1.51.1
+      babel-plugin-react-compiler: '*'
+      react: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      react-dom: ^18.2.0 || 19.0.0-rc-de68d2f4-20241204 || ^19.0.0
+      sass: ^1.3.0
+    peerDependenciesMeta:
+      '@opentelemetry/api':
+        optional: true
+      '@playwright/test':
+        optional: true
+      babel-plugin-react-compiler:
+        optional: true
+      sass:
+        optional: true
+
+  node-abort-controller@3.1.1:
+    resolution: {integrity: sha512-AGK2yQKIjRuqnc6VkX2Xj5d+QW8xZ87pa1UK6yA6ouUyuxfHuMP6umE5QK7UmTeOAymo+Zx1Fxiuw9rVx8taHQ==}
+
+  node-fetch-native@1.6.7:
+    resolution: {integrity: sha512-g9yhqoedzIUm0nTnTqAQvueMPVOuIY16bqgAJJC8XOOubYFNwz6IER9qs0Gq2Xd0+CecCKFjtdDTMA4u4xG06Q==}
+
+  node-gyp-build-optional-packages@5.2.2:
+    resolution: {integrity: sha512-s+w+rBWnpTMwSFbaE0UXsRlg7hU4FjekKU4eyAih5T8nJuNZT1nNsskXpxmeqSK9UzkBl6UgRlnKc8hz8IEqOw==}
+    hasBin: true
+
+  node-releases@2.0.46:
+    resolution: {integrity: sha512-GYVXHE2KnrzAfsAjl4uP++evGFCrAU1jta4ubEjIG7YWt/64Gqv66a30yKwWczVjA6j3bM4nBwH7Pk1JmDHaxQ==}
+    engines: {node: '>=18'}
+
+  normalize-path@3.0.0:
+    resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
+    engines: {node: '>=0.10.0'}
+
+  nypm@0.6.6:
+    resolution: {integrity: sha512-vRyr0r4cbBapw07Xw8xrj9Teq3o7MUD35rSaTcanDbW+aK2XHDgJFiU6ZTj2GBw7Q12ysdsyFss+Vdz4hQ0Y6Q==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  object-assign@4.1.1:
+    resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
+    engines: {node: '>=0.10.0'}
+
+  object-hash@3.0.0:
+    resolution: {integrity: sha512-RSn9F68PjH9HqtltsSnqYC1XXoWe9Bju5+213R98cNGttag9q9yAOTzdbsqvIa7aNm5WffBZFpWYr2aWrklWAw==}
+    engines: {node: '>= 6'}
+
+  obliterator@2.0.5:
+    resolution: {integrity: sha512-42CPE9AhahZRsMNslczq0ctAEtqk8Eka26QofnqC346BZdHDySk3LWka23LI7ULIw11NmltpiLagIq8gBozxTw==}
+
+  ohash@2.0.11:
+    resolution: {integrity: sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==}
+
+  on-exit-leak-free@2.1.2:
+    resolution: {integrity: sha512-0eJJY6hXLGf1udHwfNftBqH+g73EU4B504nZeKpz1sYRKafAghwxEJunB2O7rDZkL4PGfsMVnTXZ2EjibbqcsA==}
+    engines: {node: '>=14.0.0'}
+
+  openapi-types@12.1.3:
+    resolution: {integrity: sha512-N4YtSYJqghVu4iek2ZUvcN/0aqH1kRDuNqzcycDxhOUpg7GdvLa2F3DgS6yBNhInhv2r/6I0Flkn7CqL8+nIcw==}
+
+  p-limit@2.3.0:
+    resolution: {integrity: sha512-//88mFWSJx8lxCzwdAABTJL2MyWB12+eIY7MDL2SqLmAkeKU9qxRvWuSyTjm3FUmpBEMuFfckAIqEaVGUDxb6w==}
+    engines: {node: '>=6'}
+
+  p-locate@4.1.0:
+    resolution: {integrity: sha512-R79ZZ/0wAxKGu3oYMlz8jy/kbhsNrS7SKZ7PxEHBgJ5+F2mtFW2fK2cOtBh1cHYkQsbzFV7I+EoRKe6Yt0oK7A==}
+    engines: {node: '>=8'}
+
+  p-try@2.2.0:
+    resolution: {integrity: sha512-R4nPAVTAU0B9D35/Gk3uJf/7XYbQcyohSKdvAxIRSNghFl4e71hVoGnBNQz9cWaXxO2I10KTC+3jMdvvoKw6dQ==}
+    engines: {node: '>=6'}
+
+  path-exists@4.0.0:
+    resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
+    engines: {node: '>=8'}
+
+  path-parse@1.0.7:
+    resolution: {integrity: sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==}
+
+  path-scurry@2.0.2:
+    resolution: {integrity: sha512-3O/iVVsJAPsOnpwWIeD+d6z/7PmqApyQePUtCndjatj/9I5LylHvt5qluFaBT3I5h3r1ejfR056c+FCv+NnNXg==}
+    engines: {node: 18 || 20 || >=22}
+
+  pathe@1.1.2:
+    resolution: {integrity: sha512-whLdWMYL2TwI08hn8/ZqAbrVemu0LNaNNJZX73O6qaIdCTfXutsLhMkjdENX0qhsQ9uIimo4/aQOmXkoon2nDQ==}
+
+  pathe@2.0.3:
+    resolution: {integrity: sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==}
+
+  pathval@2.0.1:
+    resolution: {integrity: sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==}
+    engines: {node: '>= 14.16'}
+
+  perfect-debounce@1.0.0:
+    resolution: {integrity: sha512-xCy9V055GLEqoFaHoC1SoLIaLmWctgCUaBaWxDZ7/Zx4CTyX7cJQLJOok/orfjZAh9kEYpjJa4d0KcJmCbctZA==}
+
+  picocolors@1.1.1:
+    resolution: {integrity: sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==}
+
+  picomatch@2.3.2:
+    resolution: {integrity: sha512-V7+vQEJ06Z+c5tSye8S+nHUfI51xoXIXjHQ99cQtKUkQqqO1kO/KCJUfZXuB47h/YBlDhah2H3hdUGXn8ie0oA==}
+    engines: {node: '>=8.6'}
+
+  picomatch@4.0.4:
+    resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
+    engines: {node: '>=12'}
+
+  pify@2.3.0:
+    resolution: {integrity: sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==}
+    engines: {node: '>=0.10.0'}
+
+  pino-abstract-transport@2.0.0:
+    resolution: {integrity: sha512-F63x5tizV6WCh4R6RHyi2Ml+M70DNRXt/+HANowMflpgGFMAym/VKm6G7ZOQRjqN7XbGxK1Lg9t6ZrtzOaivMw==}
+
+  pino-std-serializers@7.1.0:
+    resolution: {integrity: sha512-BndPH67/JxGExRgiX1dX0w1FvZck5Wa4aal9198SrRhZjH3GxKQUKIBnYJTdj2HDN3UQAS06HlfcSbQj2OHmaw==}
+
+  pino@9.14.0:
+    resolution: {integrity: sha512-8OEwKp5juEvb/MjpIc4hjqfgCNysrS94RIOMXYvpYCdm/jglrKEiAYmiumbmGhCvs+IcInsphYDFwqrjr7398w==}
+    hasBin: true
+
+  pirates@4.0.7:
+    resolution: {integrity: sha512-TfySrs/5nm8fQJDcBDuUng3VOUKsd7S+zqvbOTiGXHfxX4wK31ard+hoNuvkicM/2YFzlpDgABOevKSsB4G/FA==}
+    engines: {node: '>= 6'}
+
+  pkg-types@2.3.1:
+    resolution: {integrity: sha512-y+ichcgc2LrADuhLNAx8DFjVfgz91pRxfZdI3UDhxHvcVEZsenLO+7XaU5vOp0u/7V/wZ+plyuQxtrDlZJ+yeg==}
+
+  pngjs@5.0.0:
+    resolution: {integrity: sha512-40QW5YalBNfQo5yRYmiw7Yz6TKKVr3h6970B2YE+3fQpsWcrbj1PzJgxeJ19DRQjhMbKPIuMY8rFaXc8moolVw==}
+    engines: {node: '>=10.13.0'}
+
+  postcss-import@15.1.0:
+    resolution: {integrity: sha512-hpr+J05B2FVYUAXHeK1YyI267J/dDDhMU6B6civm8hSY1jYJnBXxzKDKDswzJmtLHryrjhnDjqqp/49t8FALew==}
+    engines: {node: '>=14.0.0'}
+    peerDependencies:
+      postcss: ^8.0.0
+
+  postcss-js@4.1.0:
+    resolution: {integrity: sha512-oIAOTqgIo7q2EOwbhb8UalYePMvYoIeRY2YKntdpFQXNosSu3vLrniGgmH9OKs/qAkfoj5oB3le/7mINW1LCfw==}
+    engines: {node: ^12 || ^14 || >= 16}
+    peerDependencies:
+      postcss: ^8.4.21
+
+  postcss-load-config@6.0.1:
+    resolution: {integrity: sha512-oPtTM4oerL+UXmx+93ytZVN82RrlY/wPUV8IeDxFrzIjXOLF1pN+EmKPLbubvKHT2HC20xXsCAH2Z+CKV6Oz/g==}
+    engines: {node: '>= 18'}
+    peerDependencies:
+      jiti: '>=1.21.0'
+      postcss: '>=8.0.9'
+      tsx: ^4.8.1
+      yaml: ^2.4.2
+    peerDependenciesMeta:
+      jiti:
+        optional: true
+      postcss:
+        optional: true
+      tsx:
+        optional: true
+      yaml:
+        optional: true
+
+  postcss-nested@6.2.0:
+    resolution: {integrity: sha512-HQbt28KulC5AJzG+cZtj9kvKB93CFCdLvog1WFLf1D+xmMvPGlBstkpTEZfK5+AN9hfJocyBFCNiqyS48bpgzQ==}
+    engines: {node: '>=12.0'}
+    peerDependencies:
+      postcss: ^8.2.14
+
+  postcss-selector-parser@6.1.2:
+    resolution: {integrity: sha512-Q8qQfPiZ+THO/3ZrOrO0cJJKfpYCagtMUkXbnEfmgUjwXg6z/WBeOyS9APBBPCTSiDV+s4SwQGu8yFsiMRIudg==}
+    engines: {node: '>=4'}
+
+  postcss-value-parser@4.2.0:
+    resolution: {integrity: sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==}
+
+  postcss@8.4.31:
+    resolution: {integrity: sha512-PS08Iboia9mts/2ygV3eLpY5ghnUcfLV/EXTOW1E2qYxJKGGBUtNjN76FYHnMs36RmARn41bC0AZmn+rR0OVpQ==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  postcss@8.5.15:
+    resolution: {integrity: sha512-FfR8sjd4em2T6fb3I2MwAJU7HWVMr9zba+enmQeeWFfCbm+UOC/0X4DS8XtpUTMwWMGbjKYP7xjfNekzyGmB3A==}
+    engines: {node: ^10 || ^12 || >=14}
+
+  prisma@6.19.3:
+    resolution: {integrity: sha512-++ZJ0ijLrDJF6hNB4t4uxg2br3fC4H9Yc9tcbjr2fcNFP3rh/SBNrAgjhsqBU4Ght8JPrVofG/ZkXfnSfnYsFg==}
+    engines: {node: '>=18.18'}
+    hasBin: true
+    peerDependencies:
+      typescript: '>=5.1.0'
+    peerDependenciesMeta:
+      typescript:
+        optional: true
+
+  process-warning@4.0.1:
+    resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
+
+  process-warning@5.0.0:
+    resolution: {integrity: sha512-a39t9ApHNx2L4+HBnQKqxxHNs1r7KF+Intd8Q/g1bUh6q0WIp9voPXJ/x0j+ZL45KF1pJd9+q2jLIRMfvEshkA==}
+
+  prop-types@15.8.1:
+    resolution: {integrity: sha512-oj87CgZICdulUohogVAR7AjlC0327U4el4L6eAvOqCeudMDVU0NThNaV+b9Df4dXgSP1gXMTnPdhfe/2qDH5cg==}
+
+  pure-rand@6.1.0:
+    resolution: {integrity: sha512-bVWawvoZoBYpp6yIoQtQXHZjmz35RSVHnUOTefl8Vcjr8snTPY1wnpSPMWekcFwbxI6gtmT7rSYPFvz71ldiOA==}
+
+  qrcode@1.5.4:
+    resolution: {integrity: sha512-1ca71Zgiu6ORjHqFBDpnSMTR2ReToX4l1Au1VFLyVeBTFavzQnv5JxMFr3ukHVKpSrSA2MCk0lNJSykjUfz7Zg==}
+    engines: {node: '>=10.13.0'}
+    hasBin: true
+
+  queue-microtask@1.2.3:
+    resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
+
+  quick-format-unescaped@4.0.4:
+    resolution: {integrity: sha512-tYC1Q1hgyRuHgloV/YXs2w15unPVh8qfu/qCTfhTYamaw7fyhumKa2yGpdSo87vY32rIclj+4fWYQXUMs9EHvg==}
+
+  rc9@2.1.2:
+    resolution: {integrity: sha512-btXCnMmRIBINM2LDZoEmOogIZU7Qe7zn4BpomSKZ/ykbLObuBdvG+mFq11DL6fjH1DRwHhrlgtYWG96bJiC7Cg==}
+
+  react-dom@19.2.6:
+    resolution: {integrity: sha512-0prMI+hvBbPjsWnxDLxlCGyM8PN6UuWjEUCYmZhO67xIV9Xasa/r/vDnq+Xyq4Lo27g8QSbO5YzARu0D1Sps3g==}
+    peerDependencies:
+      react: ^19.2.6
+
+  react-is@16.13.1:
+    resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
+  react@19.2.6:
+    resolution: {integrity: sha512-sfWGGfavi0xr8Pg0sVsyHMAOziVYKgPLNrS7ig+ivMNb3wbCBw3KxtflsGBAwD3gYQlE/AEZsTLgToRrSCjb0Q==}
+    engines: {node: '>=0.10.0'}
+
+  read-cache@1.0.0:
+    resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
+
+  readdirp@3.6.0:
+    resolution: {integrity: sha512-hOS089on8RduqdbhvQ5Z37A0ESjsqz6qnRcffsMU3495FuTdqSm+7bhJ29JvIOsBDEEnan5DPu9t3To9VRlMzA==}
+    engines: {node: '>=8.10.0'}
+
+  readdirp@4.1.2:
+    resolution: {integrity: sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==}
+    engines: {node: '>= 14.18.0'}
+
+  real-require@0.2.0:
+    resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
+    engines: {node: '>= 12.13.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    deprecated: 1.x and 2.x branches are no longer active. Bump to Recharts v3 to receive latest features and bugfixes. See https://github.com/recharts/recharts/wiki/3.0-migration-guide
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  redis-errors@1.2.0:
+    resolution: {integrity: sha512-1qny3OExCf0UvUV/5wpYKf2YwPcOqXzkwKKSmKHiE6ZMQs5heeE/c8eXK+PNllPvmjgAbfnsbpkGZWy8cBpn9w==}
+    engines: {node: '>=4'}
+
+  redis-parser@3.0.0:
+    resolution: {integrity: sha512-DJnGAeenTdpMEH6uAJRK/uiyEIH9WVsUmoLwzudwGJUwZPp80PDBWPHXSAGNPwNvIXAbe7MSUB1zQFugFml66A==}
+    engines: {node: '>=4'}
+
+  require-directory@2.1.1:
+    resolution: {integrity: sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q==}
+    engines: {node: '>=0.10.0'}
+
+  require-from-string@2.0.2:
+    resolution: {integrity: sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw==}
+    engines: {node: '>=0.10.0'}
+
+  require-main-filename@2.0.0:
+    resolution: {integrity: sha512-NKN5kMDylKuldxYLSUfrbo5Tuzh4hd+2E8NPPX02mZtn1VuREQToYe/ZdlJy+J3uCpfaiGF05e7B8W0iXbQHmg==}
+
+  resolve@1.22.12:
+    resolution: {integrity: sha512-TyeJ1zif53BPfHootBGwPRYT1RUt6oGWsaQr8UyZW/eAm9bKoijtvruSDEmZHm92CwS9nj7/fWttqPCgzep8CA==}
+    engines: {node: '>= 0.4'}
+    hasBin: true
+
+  ret@0.5.0:
+    resolution: {integrity: sha512-I1XxrZSQ+oErkRR4jYbAyEEu2I0avBvvMM5JN+6EBprOGRCs63ENqZ3vjavq8fBw2+62G5LF5XelKwuJpcvcxw==}
+    engines: {node: '>=10'}
+
+  reusify@1.1.0:
+    resolution: {integrity: sha512-g6QUff04oZpHs0eG5p83rFLhHeV00ug/Yf9nZM6fLeUrPguBTkTQOdpAWWspMh55TZfVQDPaN3NQJfbVRAxdIw==}
+    engines: {iojs: '>=1.0.0', node: '>=0.10.0'}
+
+  rfdc@1.4.1:
+    resolution: {integrity: sha512-q1b3N5QkRUWUl7iyylaaj3kOpIT0N2i9MqIEQXP73GVsN9cw3fdx8X63cEmWhJGi2PPCF23Ijp7ktmd39rawIA==}
+
+  rollup@4.60.4:
+    resolution: {integrity: sha512-WHeFSbZYsPu3+bLoNRUuAO+wavNlocOPf3wSHTP7hcFKVnJeWsYlCDbr3mTS14FCizf9ccIxXA8sGL8zKeQN3g==}
+    engines: {node: '>=18.0.0', npm: '>=8.0.0'}
+    hasBin: true
+
+  run-parallel@1.2.0:
+    resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
+
+  safe-regex2@5.1.1:
+    resolution: {integrity: sha512-mOSBvHGDZMuIEZMdOz/aCEYDCv0E7nfcNsIhUF+/P+xC7Hyf3FkvymqgPbg9D1EdSGu+uKbJgy09K/RKKc7kJA==}
+    hasBin: true
+
+  safe-stable-stringify@2.5.0:
+    resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
+    engines: {node: '>=10'}
+
+  scheduler@0.27.0:
+    resolution: {integrity: sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q==}
+
+  secure-json-parse@4.1.0:
+    resolution: {integrity: sha512-l4KnYfEyqYJxDwlNVyRfO2E4NTHfMKAWdUuA8J0yve2Dz/E/PdBepY03RvyJpssIpRFwJoCD55wA+mEDs6ByWA==}
+
+  semver@7.8.0:
+    resolution: {integrity: sha512-AcM7dV/5ul4EekoQ29Agm5vri8JNqRyj39o0qpX6vDF2GZrtutZl5RwgD1XnZjiTAfncsJhMI48QQH3sN87YNA==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  semver@7.8.1:
+    resolution: {integrity: sha512-rkVq3IXh+4FDGch+KwzX3aV9W3kO54GyEgpvBzSyctDA6Xtd7RJQV1xmXbeQp5v7+VzLOfVqiutSE6GICgPFvg==}
+    engines: {node: '>=10'}
+    hasBin: true
+
+  set-blocking@2.0.0:
+    resolution: {integrity: sha512-KiKBS8AnWGEyLzofFfmvKwpdPzqiy16LvQfK3yv/fVH7Bj13/wl3JSR1J+rfgRE9q7xUJK4qvgS8raSOeLUehw==}
+
+  set-cookie-parser@2.7.2:
+    resolution: {integrity: sha512-oeM1lpU/UvhTxw+g3cIfxXHyJRc/uidd3yK1P242gzHds0udQBYzs3y8j4gCCW+ZJ7ad0yctld8RYO+bdurlvw==}
+
+  setprototypeof@1.2.0:
+    resolution: {integrity: sha512-E5LDX7Wrp85Kil5bhZv46j8jOeboKq5JMmYM3gVGdGH8xFpPWXUMsNrlODCrkoxMEeNi/XZIwuRvY4XNwYMJpw==}
+
+  sharp@0.34.5:
+    resolution: {integrity: sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
+  siginfo@2.0.0:
+    resolution: {integrity: sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==}
+
+  sonic-boom@4.2.1:
+    resolution: {integrity: sha512-w6AxtubXa2wTXAUsZMMWERrsIRAdrK0Sc+FUytWvYAhBJLyuI4llrMIC1DtlNSdI99EI86KZum2MMq3EAZlF9Q==}
+
+  source-map-js@1.2.1:
+    resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
+    engines: {node: '>=0.10.0'}
+
+  split2@4.2.0:
+    resolution: {integrity: sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==}
+    engines: {node: '>= 10.x'}
+
+  stackback@0.0.2:
+    resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
+
+  standard-as-callback@2.1.0:
+    resolution: {integrity: sha512-qoRRSyROncaz1z0mvYqIE4lCd9p2R90i6GxW3uZv5ucSu8tU7B5HXUP1gG8pVZsYNVaXjk8ClXHPttLyxAL48A==}
+
+  statuses@2.0.2:
+    resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
+    engines: {node: '>= 0.8'}
+
+  std-env@3.10.0:
+    resolution: {integrity: sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==}
+
+  string-width@4.2.3:
+    resolution: {integrity: sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==}
+    engines: {node: '>=8'}
+
+  strip-ansi@6.0.1:
+    resolution: {integrity: sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==}
+    engines: {node: '>=8'}
+
+  styled-jsx@5.1.6:
+    resolution: {integrity: sha512-qSVyDTeMotdvQYoHWLNGwRFJHC+i+ZvdBRYosOFgC+Wg1vx4frN2/RG/NA7SYqqvKNLf39P2LSRA2pu6n0XYZA==}
+    engines: {node: '>= 12.0.0'}
+    peerDependencies:
+      '@babel/core': '*'
+      babel-plugin-macros: '*'
+      react: '>= 16.8.0 || 17.x.x || ^18.0.0-0 || ^19.0.0-0'
+    peerDependenciesMeta:
+      '@babel/core':
+        optional: true
+      babel-plugin-macros:
+        optional: true
+
+  sucrase@3.35.1:
+    resolution: {integrity: sha512-DhuTmvZWux4H1UOnWMB3sk0sbaCVOoQZjv8u1rDoTV0HTdGem9hkAZtl4JZy8P2z4Bg0nT+YMeOFyVr4zcG5Tw==}
+    engines: {node: '>=16 || 14 >=14.17'}
+    hasBin: true
+
+  supports-preserve-symlinks-flag@1.0.0:
+    resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
+    engines: {node: '>= 0.4'}
+
+  tailwind-merge@2.6.1:
+    resolution: {integrity: sha512-Oo6tHdpZsGpkKG88HJ8RR1rg/RdnEkQEfMoEk2x1XRI3F1AxeU+ijRXpiVUF4UbLfcxxRGw6TbUINKYdWVsQTQ==}
+
+  tailwindcss@3.4.19:
+    resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
+    engines: {node: '>=14.0.0'}
+    hasBin: true
+
+  thenify-all@1.6.0:
+    resolution: {integrity: sha512-RNxQH/qI8/t3thXJDwcstUO4zeqo64+Uy/+sNVRBx4Xn2OX+OZ9oP+iJnNFqplFra2ZUVeKCSa2oVWi3T4uVmA==}
+    engines: {node: '>=0.8'}
+
+  thenify@3.3.1:
+    resolution: {integrity: sha512-RVZSIV5IG10Hk3enotrhvz0T9em6cyHBLkH/YAZuKqd8hRkKhSfCGIcP2KUY0EPxndzANBmNllzWPwak+bheSw==}
+
+  thread-stream@3.1.0:
+    resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
+
+  tinybench@2.9.0:
+    resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
+
+  tinyexec@0.3.2:
+    resolution: {integrity: sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==}
+
+  tinyexec@1.2.4:
+    resolution: {integrity: sha512-SHf/r48b7vOrjve9PxJo3MN5v5yuyjHvdUcrQffT3WXMUfnGmHDVbC4k3sHJaJTgZCwpUplIaAo5ANtMyp3YHg==}
+    engines: {node: '>=18'}
+
+  tinyglobby@0.2.17:
+    resolution: {integrity: sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g==}
+    engines: {node: '>=12.0.0'}
+
+  tinypool@1.1.1:
+    resolution: {integrity: sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+
+  tinyrainbow@1.2.0:
+    resolution: {integrity: sha512-weEDEq7Z5eTHPDh4xjX789+fHfF+P8boiFB+0vbWzpbnbsEr/GRaohi/uMKxg8RZMXnl1ItAi/IUHWMsjDV7kQ==}
+    engines: {node: '>=14.0.0'}
+
+  tinyspy@3.0.2:
+    resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
+    engines: {node: '>=14.0.0'}
+
+  to-regex-range@5.0.1:
+    resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
+    engines: {node: '>=8.0'}
+
+  toad-cache@3.7.1:
+    resolution: {integrity: sha512-5DXWzE4Vz7xNHsv+xQ+MGfJYyC78Aok3tEr0MNwHoRf7vZnga1mQXZ4/Nsodld4VR6Wd+VhfmqnNrsRJyYPfrQ==}
+    engines: {node: '>=20'}
+
+  toidentifier@1.0.1:
+    resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
+    engines: {node: '>=0.6'}
+
+  ts-interface-checker@0.1.13:
+    resolution: {integrity: sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.22.4:
+    resolution: {integrity: sha512-X8EX+XV4QR5xCsrgxaED954zTDfY8KqlDtskKEL0cHhyS/P8b4IFOvGDQpsC9Q1XnLq915wEfwwY/zzskCtmhg==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
+
+  turbo@2.9.16:
+    resolution: {integrity: sha512-NqgRQy6j6dPYcdSdv0q1g9QsZg7SWg87RERM8otw/1AtKU2yTFVClOM7cbwKzOonZr/Ek1blTBucw64L9H0Bwg==}
+    hasBin: true
+
+  typescript@5.9.3:
+    resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
+    engines: {node: '>=14.17'}
+    hasBin: true
+
+  ua-is-frozen@0.1.2:
+    resolution: {integrity: sha512-RwKDW2p3iyWn4UbaxpP2+VxwqXh0jpvdxsYpZ5j/MLLiQOfbsV5shpgQiw93+KMYQPcteeMQ289MaAFzs3G9pw==}
+
+  ua-parser-js@2.0.10:
+    resolution: {integrity: sha512-t+3Ktbq0Ies2vaSezfOaWiolH4OigQIO1dk+1xDpOydB1COVPocVYOrEV5rqZ0kFY9XYG1v9LutCyMgYBpABcw==}
+    hasBin: true
+
+  undici-types@6.21.0:
+    resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  update-browserslist-db@1.2.3:
+    resolution: {integrity: sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==}
+    hasBin: true
+    peerDependencies:
+      browserslist: '>= 4.21.0'
+
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  util-deprecate@1.0.2:
+    resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
+
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
+  vite-node@2.1.9:
+    resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+
+  vite@5.4.21:
+    resolution: {integrity: sha512-o5a9xKjbtuhY6Bi5S3+HvbRERmouabWbyUcpXXUA1u+GNUKoROi9byOJ8M0nHbHYHkYICiMlqxkg1KkYmm25Sw==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@types/node': ^18.0.0 || >=20.0.0
+      less: '*'
+      lightningcss: ^1.21.0
+      sass: '*'
+      sass-embedded: '*'
+      stylus: '*'
+      sugarss: '*'
+      terser: ^5.4.0
+    peerDependenciesMeta:
+      '@types/node':
+        optional: true
+      less:
+        optional: true
+      lightningcss:
+        optional: true
+      sass:
+        optional: true
+      sass-embedded:
+        optional: true
+      stylus:
+        optional: true
+      sugarss:
+        optional: true
+      terser:
+        optional: true
+
+  vitest@2.1.9:
+    resolution: {integrity: sha512-MSmPM9REYqDGBI8439mA4mWhV5sKmDlBKWIYbA3lRb2PTHACE0mgKwA8yQ2xq9vxDTuk4iPrECBAEW2aoFXY0Q==}
+    engines: {node: ^18.0.0 || >=20.0.0}
+    hasBin: true
+    peerDependencies:
+      '@edge-runtime/vm': '*'
+      '@types/node': ^18.0.0 || >=20.0.0
+      '@vitest/browser': 2.1.9
+      '@vitest/ui': 2.1.9
+      happy-dom: '*'
+      jsdom: '*'
+    peerDependenciesMeta:
+      '@edge-runtime/vm':
+        optional: true
+      '@types/node':
+        optional: true
+      '@vitest/browser':
+        optional: true
+      '@vitest/ui':
+        optional: true
+      happy-dom:
+        optional: true
+      jsdom:
+        optional: true
+
+  which-module@2.0.1:
+    resolution: {integrity: sha512-iBdZ57RDvnOR9AGBhML2vFZf7h8vmBjhoaZqODJBFWHVtKkDmKuHai3cx5PgVMrX5YDNp27AofYbAwctSS+vhQ==}
+
+  why-is-node-running@2.3.0:
+    resolution: {integrity: sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==}
+    engines: {node: '>=8'}
+    hasBin: true
+
+  wrap-ansi@6.2.0:
+    resolution: {integrity: sha512-r6lPcBGxZXlIcymEu7InxDMhdW0KDxpLgoFLcguasxCaJ/SOIZwINatK9KY/tf+ZrlywOKU0UDj3ATXUBfxJXA==}
+    engines: {node: '>=8'}
+
+  y18n@4.0.3:
+    resolution: {integrity: sha512-JKhqTOwSrqNA1NY5lSztJ1GrBiUodLMmIZuLiDaMRJ+itFd+ABVE8XBjOvIWL+rSqNDC74LCSFmlb/U4UZ4hJQ==}
+
+  yaml@2.9.0:
+    resolution: {integrity: sha512-2AvhNX3mb8zd6Zy7INTtSpl1F15HW6Wnqj0srWlkKLcpYl/gMIMJiyuGq2KeI2YFxUPjdlB+3Lc10seMLtL4cA==}
+    engines: {node: '>= 14.6'}
+    hasBin: true
+
+  yargs-parser@18.1.3:
+    resolution: {integrity: sha512-o50j0JeToy/4K6OZcaQmW6lyXXKhq7csREXcDwk2omFPJEwUNOVtJKvmDr9EI1fAJZUyZcRF7kxGBWmRXudrCQ==}
+    engines: {node: '>=6'}
+
+  yargs@15.4.1:
+    resolution: {integrity: sha512-aePbxDmcYW++PaqBsJ+HYUFwCdv4LVvdnhBy78E57PIor8/OVvhMrADFFEDh8DHDFRv/O9i3lPhsENjO7QX0+A==}
+    engines: {node: '>=8'}
+
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
+
+snapshots:
+
+  '@alloc/quick-lru@5.2.0': {}
+
+  '@babel/runtime@7.29.7': {}
+
+  '@emnapi/runtime@1.10.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@esbuild/aix-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/aix-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/android-arm@0.21.5':
+    optional: true
+
+  '@esbuild/android-arm@0.28.0':
+    optional: true
+
+  '@esbuild/android-x64@0.21.5':
+    optional: true
+
+  '@esbuild/android-x64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/darwin-x64@0.21.5':
+    optional: true
+
+  '@esbuild/darwin-x64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-arm@0.21.5':
+    optional: true
+
+  '@esbuild/linux-arm@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/linux-loong64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-loong64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.21.5':
+    optional: true
+
+  '@esbuild/linux-mips64el@0.28.0':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-riscv64@0.28.0':
+    optional: true
+
+  '@esbuild/linux-s390x@0.21.5':
+    optional: true
+
+  '@esbuild/linux-s390x@0.28.0':
+    optional: true
+
+  '@esbuild/linux-x64@0.21.5':
+    optional: true
+
+  '@esbuild/linux-x64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/netbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.21.5':
+    optional: true
+
+  '@esbuild/openbsd-x64@0.28.0':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/sunos-x64@0.21.5':
+    optional: true
+
+  '@esbuild/sunos-x64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-arm64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-arm64@0.28.0':
+    optional: true
+
+  '@esbuild/win32-ia32@0.21.5':
+    optional: true
+
+  '@esbuild/win32-ia32@0.28.0':
+    optional: true
+
+  '@esbuild/win32-x64@0.21.5':
+    optional: true
+
+  '@esbuild/win32-x64@0.28.0':
+    optional: true
+
+  '@fastify/accept-negotiator@2.0.1': {}
+
+  '@fastify/ajv-compiler@4.0.5':
+    dependencies:
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 3.1.2
+
+  '@fastify/cors@10.1.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      mnemonist: 0.40.0
+
+  '@fastify/error@4.2.0': {}
+
+  '@fastify/fast-json-stringify-compiler@5.0.3':
+    dependencies:
+      fast-json-stringify: 6.4.0
+
+  '@fastify/forwarded@3.0.1': {}
+
+  '@fastify/helmet@12.0.1':
+    dependencies:
+      fastify-plugin: 5.1.0
+      helmet: 7.2.0
+
+  '@fastify/merge-json-schemas@0.2.1':
+    dependencies:
+      dequal: 2.0.3
+
+  '@fastify/proxy-addr@5.1.0':
+    dependencies:
+      '@fastify/forwarded': 3.0.1
+      ipaddr.js: 2.4.0
+
+  '@fastify/rate-limit@10.3.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      fastify-plugin: 5.1.0
+      toad-cache: 3.7.1
+
+  '@fastify/send@4.1.0':
+    dependencies:
+      '@lukeed/ms': 2.0.2
+      escape-html: 1.0.3
+      fast-decode-uri-component: 1.0.1
+      http-errors: 2.0.1
+      mime: 3.0.0
+
+  '@fastify/static@9.1.3':
+    dependencies:
+      '@fastify/accept-negotiator': 2.0.1
+      '@fastify/send': 4.1.0
+      content-disposition: 1.1.0
+      fastify-plugin: 5.1.0
+      fastq: 1.20.1
+      glob: 13.0.6
+
+  '@fastify/swagger-ui@5.2.6':
+    dependencies:
+      '@fastify/static': 9.1.3
+      fastify-plugin: 5.1.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.9.0
+
+  '@fastify/swagger@9.7.0':
+    dependencies:
+      fastify-plugin: 5.1.0
+      json-schema-resolver: 3.0.0
+      openapi-types: 12.1.3
+      rfdc: 1.4.1
+      yaml: 2.9.0
+    transitivePeerDependencies:
+      - supports-color
+
+  '@img/colour@1.1.0':
+    optional: true
+
+  '@img/sharp-darwin-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-ppc64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-riscv64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.2.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.2.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-ppc64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-riscv64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-s390x@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.34.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+    optional: true
+
+  '@img/sharp-wasm32@0.34.5':
+    dependencies:
+      '@emnapi/runtime': 1.10.0
+    optional: true
+
+  '@img/sharp-win32-arm64@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-ia32@0.34.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.34.5':
+    optional: true
+
+  '@ioredis/commands@1.5.1': {}
+
+  '@jridgewell/gen-mapping@0.3.13':
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+      '@jridgewell/trace-mapping': 0.3.31
+
+  '@jridgewell/resolve-uri@3.1.2': {}
+
+  '@jridgewell/sourcemap-codec@1.5.5': {}
+
+  '@jridgewell/trace-mapping@0.3.31':
+    dependencies:
+      '@jridgewell/resolve-uri': 3.1.2
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lukeed/ms@2.0.2': {}
+
+  '@msgpackr-extract/msgpackr-extract-darwin-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-darwin-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-arm@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-linux-x64@3.0.4':
+    optional: true
+
+  '@msgpackr-extract/msgpackr-extract-win32-x64@3.0.4':
+    optional: true
+
+  '@next/env@16.2.6': {}
+
+  '@next/swc-darwin-arm64@16.2.6':
+    optional: true
+
+  '@next/swc-darwin-x64@16.2.6':
+    optional: true
+
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-arm64-musl@16.2.6':
+    optional: true
+
+  '@next/swc-linux-x64-gnu@16.2.6':
+    optional: true
+
+  '@next/swc-linux-x64-musl@16.2.6':
+    optional: true
+
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    optional: true
+
+  '@next/swc-win32-x64-msvc@16.2.6':
+    optional: true
+
+  '@nodelib/fs.scandir@2.1.5':
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      run-parallel: 1.2.0
+
+  '@nodelib/fs.stat@2.0.5': {}
+
+  '@nodelib/fs.walk@1.2.8':
+    dependencies:
+      '@nodelib/fs.scandir': 2.1.5
+      fastq: 1.20.1
+
+  '@pinojs/redact@0.4.0': {}
+
+  '@prisma/client@6.19.3(prisma@6.19.3(typescript@5.9.3))(typescript@5.9.3)':
+    optionalDependencies:
+      prisma: 6.19.3(typescript@5.9.3)
+      typescript: 5.9.3
+
+  '@prisma/config@6.19.3':
+    dependencies:
+      c12: 3.1.0
+      deepmerge-ts: 7.1.5
+      effect: 3.21.0
+      empathic: 2.0.0
+    transitivePeerDependencies:
+      - magicast
+
+  '@prisma/debug@6.19.3': {}
+
+  '@prisma/engines-version@7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7': {}
+
+  '@prisma/engines@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/fetch-engine': 6.19.3
+      '@prisma/get-platform': 6.19.3
+
+  '@prisma/fetch-engine@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+      '@prisma/engines-version': 7.1.1-3.c2990dca591cba766e3b7ef5d9e8a84796e47ab7
+      '@prisma/get-platform': 6.19.3
+
+  '@prisma/get-platform@6.19.3':
+    dependencies:
+      '@prisma/debug': 6.19.3
+
+  '@rollup/rollup-android-arm-eabi@4.60.4':
+    optional: true
+
+  '@rollup/rollup-android-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-darwin-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-freebsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-gnueabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm-musleabihf@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-arm64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-loong64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-ppc64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-riscv64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-s390x-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-linux-x64-musl@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openbsd-x64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-openharmony-arm64@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-arm64-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-ia32-msvc@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-gnu@4.60.4':
+    optional: true
+
+  '@rollup/rollup-win32-x64-msvc@4.60.4':
+    optional: true
+
+  '@standard-schema/spec@1.1.0': {}
+
+  '@supabase/auth-js@2.106.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/functions-js@2.106.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/phoenix@0.4.2': {}
+
+  '@supabase/postgrest-js@2.106.2':
+    dependencies:
+      tslib: 2.8.1
+
+  '@supabase/realtime-js@2.106.2':
+    dependencies:
+      '@supabase/phoenix': 0.4.2
+      tslib: 2.8.1
+
+  '@supabase/ssr@0.5.2(@supabase/supabase-js@2.106.2)':
+    dependencies:
+      '@supabase/supabase-js': 2.106.2
+      '@types/cookie': 0.6.0
+      cookie: 0.7.2
+
+  '@supabase/storage-js@2.106.2':
+    dependencies:
+      iceberg-js: 0.8.1
+      tslib: 2.8.1
+
+  '@supabase/supabase-js@2.106.2':
+    dependencies:
+      '@supabase/auth-js': 2.106.2
+      '@supabase/functions-js': 2.106.2
+      '@supabase/postgrest-js': 2.106.2
+      '@supabase/realtime-js': 2.106.2
+      '@supabase/storage-js': 2.106.2
+
+  '@swc/helpers@0.5.15':
+    dependencies:
+      tslib: 2.8.1
+
+  '@turbo/darwin-64@2.9.16':
+    optional: true
+
+  '@turbo/darwin-arm64@2.9.16':
+    optional: true
+
+  '@turbo/linux-64@2.9.16':
+    optional: true
+
+  '@turbo/linux-arm64@2.9.16':
+    optional: true
+
+  '@turbo/windows-64@2.9.16':
+    optional: true
+
+  '@turbo/windows-arm64@2.9.16':
+    optional: true
+
+  '@types/cookie@0.6.0': {}
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/estree@1.0.8': {}
+
+  '@types/estree@1.0.9': {}
+
+  '@types/node@22.19.19':
+    dependencies:
+      undici-types: 6.21.0
+
+  '@types/qrcode@1.5.6':
+    dependencies:
+      '@types/node': 22.19.19
+
+  '@types/react-dom@19.2.3(@types/react@19.2.15)':
+    dependencies:
+      '@types/react': 19.2.15
+
+  '@types/react@19.2.15':
+    dependencies:
+      csstype: 3.2.3
+
+  '@vitest/expect@2.1.9':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      tinyrainbow: 1.2.0
+
+  '@vitest/mocker@2.1.9(vite@5.4.21(@types/node@22.19.19))':
+    dependencies:
+      '@vitest/spy': 2.1.9
+      estree-walker: 3.0.3
+      magic-string: 0.30.21
+    optionalDependencies:
+      vite: 5.4.21(@types/node@22.19.19)
+
+  '@vitest/pretty-format@2.1.9':
+    dependencies:
+      tinyrainbow: 1.2.0
+
+  '@vitest/runner@2.1.9':
+    dependencies:
+      '@vitest/utils': 2.1.9
+      pathe: 1.1.2
+
+  '@vitest/snapshot@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      magic-string: 0.30.21
+      pathe: 1.1.2
+
+  '@vitest/spy@2.1.9':
+    dependencies:
+      tinyspy: 3.0.2
+
+  '@vitest/utils@2.1.9':
+    dependencies:
+      '@vitest/pretty-format': 2.1.9
+      loupe: 3.2.1
+      tinyrainbow: 1.2.0
+
+  '@xyflow/react@12.10.2(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+    dependencies:
+      '@xyflow/system': 0.0.76
+      classcat: 5.0.5
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      zustand: 4.5.7(@types/react@19.2.15)(react@19.2.6)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@xyflow/system@0.0.76':
+    dependencies:
+      '@types/d3-drag': 3.0.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+
+  abstract-logging@2.0.1: {}
+
+  ajv-formats@3.0.1(ajv@8.20.0):
+    optionalDependencies:
+      ajv: 8.20.0
+
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.2
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
+  ansi-regex@5.0.1: {}
+
+  ansi-styles@4.3.0:
+    dependencies:
+      color-convert: 2.0.1
+
+  any-promise@1.3.0: {}
+
+  anymatch@3.1.3:
+    dependencies:
+      normalize-path: 3.0.0
+      picomatch: 2.3.2
+
+  arg@5.0.2: {}
+
+  assertion-error@2.0.1: {}
+
+  atomic-sleep@1.0.0: {}
+
+  autoprefixer@10.5.0(postcss@8.5.15):
+    dependencies:
+      browserslist: 4.28.2
+      caniuse-lite: 1.0.30001793
+      fraction.js: 5.3.4
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+
+  avvio@9.2.0:
+    dependencies:
+      '@fastify/error': 4.2.0
+      fastq: 1.20.1
+
+  balanced-match@4.0.4: {}
+
+  baseline-browser-mapping@2.10.33: {}
+
+  binary-extensions@2.3.0: {}
+
+  brace-expansion@5.0.6:
+    dependencies:
+      balanced-match: 4.0.4
+
+  braces@3.0.3:
+    dependencies:
+      fill-range: 7.1.1
+
+  browserslist@4.28.2:
+    dependencies:
+      baseline-browser-mapping: 2.10.33
+      caniuse-lite: 1.0.30001793
+      electron-to-chromium: 1.5.364
+      node-releases: 2.0.46
+      update-browserslist-db: 1.2.3(browserslist@4.28.2)
+
+  bullmq@5.77.6:
+    dependencies:
+      cron-parser: 4.9.0
+      ioredis: 5.10.1
+      msgpackr: 2.0.1
+      node-abort-controller: 3.1.1
+      semver: 7.8.0
+      tslib: 2.8.1
+    transitivePeerDependencies:
+      - supports-color
+
+  c12@3.1.0:
+    dependencies:
+      chokidar: 4.0.3
+      confbox: 0.2.4
+      defu: 6.1.7
+      dotenv: 16.6.1
+      exsolve: 1.0.8
+      giget: 2.0.0
+      jiti: 2.7.0
+      ohash: 2.0.11
+      pathe: 2.0.3
+      perfect-debounce: 1.0.0
+      pkg-types: 2.3.1
+      rc9: 2.1.2
+
+  cac@6.7.14: {}
+
+  camelcase-css@2.0.1: {}
+
+  camelcase@5.3.1: {}
+
+  caniuse-lite@1.0.30001793: {}
+
+  chai@5.3.3:
+    dependencies:
+      assertion-error: 2.0.1
+      check-error: 2.1.3
+      deep-eql: 5.0.2
+      loupe: 3.2.1
+      pathval: 2.0.1
+
+  check-error@2.1.3: {}
+
+  chokidar@3.6.0:
+    dependencies:
+      anymatch: 3.1.3
+      braces: 3.0.3
+      glob-parent: 5.1.2
+      is-binary-path: 2.1.0
+      is-glob: 4.0.3
+      normalize-path: 3.0.0
+      readdirp: 3.6.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  chokidar@4.0.3:
+    dependencies:
+      readdirp: 4.1.2
+
+  citty@0.1.6:
+    dependencies:
+      consola: 3.4.2
+
+  citty@0.2.2: {}
+
+  class-variance-authority@0.7.1:
+    dependencies:
+      clsx: 2.1.1
+
+  classcat@5.0.5: {}
+
+  client-only@0.0.1: {}
+
+  cliui@6.0.0:
+    dependencies:
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+      wrap-ansi: 6.2.0
+
+  clsx@2.1.1: {}
+
+  cluster-key-slot@1.1.2: {}
+
+  color-convert@2.0.1:
+    dependencies:
+      color-name: 1.1.4
+
+  color-name@1.1.4: {}
+
+  commander@4.1.1: {}
+
+  confbox@0.2.4: {}
+
+  consola@3.4.2: {}
+
+  content-disposition@1.1.0: {}
+
+  cookie@0.7.2: {}
+
+  cookie@1.1.1: {}
+
+  cron-parser@4.9.0:
+    dependencies:
+      luxon: 3.7.2
+
+  cssesc@3.0.0: {}
+
+  csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  debug@4.4.3:
+    dependencies:
+      ms: 2.1.3
+
+  decamelize@1.2.0: {}
+
+  decimal.js-light@2.5.1: {}
+
+  deep-eql@5.0.2: {}
+
+  deepmerge-ts@7.1.5: {}
+
+  defu@6.1.7: {}
+
+  denque@2.1.0: {}
+
+  depd@2.0.0: {}
+
+  dequal@2.0.3: {}
+
+  destr@2.0.5: {}
+
+  detect-europe-js@0.1.2: {}
+
+  detect-libc@2.1.2:
+    optional: true
+
+  didyoumean@1.2.2: {}
+
+  dijkstrajs@1.0.3: {}
+
+  dlv@1.1.3: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.7
+      csstype: 3.2.3
+
+  dotenv@16.6.1: {}
+
+  effect@3.21.0:
+    dependencies:
+      '@standard-schema/spec': 1.1.0
+      fast-check: 3.23.2
+
+  electron-to-chromium@1.5.364: {}
+
+  emoji-regex@8.0.0: {}
+
+  empathic@2.0.0: {}
+
+  es-errors@1.3.0: {}
+
+  es-module-lexer@1.7.0: {}
+
+  esbuild@0.21.5:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.21.5
+      '@esbuild/android-arm': 0.21.5
+      '@esbuild/android-arm64': 0.21.5
+      '@esbuild/android-x64': 0.21.5
+      '@esbuild/darwin-arm64': 0.21.5
+      '@esbuild/darwin-x64': 0.21.5
+      '@esbuild/freebsd-arm64': 0.21.5
+      '@esbuild/freebsd-x64': 0.21.5
+      '@esbuild/linux-arm': 0.21.5
+      '@esbuild/linux-arm64': 0.21.5
+      '@esbuild/linux-ia32': 0.21.5
+      '@esbuild/linux-loong64': 0.21.5
+      '@esbuild/linux-mips64el': 0.21.5
+      '@esbuild/linux-ppc64': 0.21.5
+      '@esbuild/linux-riscv64': 0.21.5
+      '@esbuild/linux-s390x': 0.21.5
+      '@esbuild/linux-x64': 0.21.5
+      '@esbuild/netbsd-x64': 0.21.5
+      '@esbuild/openbsd-x64': 0.21.5
+      '@esbuild/sunos-x64': 0.21.5
+      '@esbuild/win32-arm64': 0.21.5
+      '@esbuild/win32-ia32': 0.21.5
+      '@esbuild/win32-x64': 0.21.5
+
+  esbuild@0.28.0:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.28.0
+      '@esbuild/android-arm': 0.28.0
+      '@esbuild/android-arm64': 0.28.0
+      '@esbuild/android-x64': 0.28.0
+      '@esbuild/darwin-arm64': 0.28.0
+      '@esbuild/darwin-x64': 0.28.0
+      '@esbuild/freebsd-arm64': 0.28.0
+      '@esbuild/freebsd-x64': 0.28.0
+      '@esbuild/linux-arm': 0.28.0
+      '@esbuild/linux-arm64': 0.28.0
+      '@esbuild/linux-ia32': 0.28.0
+      '@esbuild/linux-loong64': 0.28.0
+      '@esbuild/linux-mips64el': 0.28.0
+      '@esbuild/linux-ppc64': 0.28.0
+      '@esbuild/linux-riscv64': 0.28.0
+      '@esbuild/linux-s390x': 0.28.0
+      '@esbuild/linux-x64': 0.28.0
+      '@esbuild/netbsd-arm64': 0.28.0
+      '@esbuild/netbsd-x64': 0.28.0
+      '@esbuild/openbsd-arm64': 0.28.0
+      '@esbuild/openbsd-x64': 0.28.0
+      '@esbuild/openharmony-arm64': 0.28.0
+      '@esbuild/sunos-x64': 0.28.0
+      '@esbuild/win32-arm64': 0.28.0
+      '@esbuild/win32-ia32': 0.28.0
+      '@esbuild/win32-x64': 0.28.0
+
+  escalade@3.2.0: {}
+
+  escape-html@1.0.3: {}
+
+  estree-walker@3.0.3:
+    dependencies:
+      '@types/estree': 1.0.9
+
+  eventemitter3@4.0.7: {}
+
+  expect-type@1.3.0: {}
+
+  exsolve@1.0.8: {}
+
+  fast-check@3.23.2:
+    dependencies:
+      pure-rand: 6.1.0
+
+  fast-decode-uri-component@1.0.1: {}
+
+  fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
+
+  fast-glob@3.3.3:
+    dependencies:
+      '@nodelib/fs.stat': 2.0.5
+      '@nodelib/fs.walk': 1.2.8
+      glob-parent: 5.1.2
+      merge2: 1.4.1
+      micromatch: 4.0.8
+
+  fast-json-stringify@6.4.0:
+    dependencies:
+      '@fastify/merge-json-schemas': 0.2.1
+      ajv: 8.20.0
+      ajv-formats: 3.0.1(ajv@8.20.0)
+      fast-uri: 3.1.2
+      json-schema-ref-resolver: 3.0.0
+      rfdc: 1.4.1
+
+  fast-querystring@1.1.2:
+    dependencies:
+      fast-decode-uri-component: 1.0.1
+
+  fast-uri@3.1.2: {}
+
+  fastify-plugin@5.1.0: {}
+
+  fastify@5.8.5:
+    dependencies:
+      '@fastify/ajv-compiler': 4.0.5
+      '@fastify/error': 4.2.0
+      '@fastify/fast-json-stringify-compiler': 5.0.3
+      '@fastify/proxy-addr': 5.1.0
+      abstract-logging: 2.0.1
+      avvio: 9.2.0
+      fast-json-stringify: 6.4.0
+      find-my-way: 9.6.0
+      light-my-request: 6.6.0
+      pino: 9.14.0
+      process-warning: 5.0.0
+      rfdc: 1.4.1
+      secure-json-parse: 4.1.0
+      semver: 7.8.1
+      toad-cache: 3.7.1
+
+  fastq@1.20.1:
+    dependencies:
+      reusify: 1.1.0
+
+  fdir@6.5.0(picomatch@4.0.4):
+    optionalDependencies:
+      picomatch: 4.0.4
+
+  fill-range@7.1.1:
+    dependencies:
+      to-regex-range: 5.0.1
+
+  find-my-way@9.6.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-querystring: 1.1.2
+      safe-regex2: 5.1.1
+
+  find-up@4.1.0:
+    dependencies:
+      locate-path: 5.0.0
+      path-exists: 4.0.0
+
+  fraction.js@5.3.4: {}
+
+  fsevents@2.3.3:
+    optional: true
+
+  function-bind@1.1.2: {}
+
+  get-caller-file@2.0.5: {}
+
+  giget@2.0.0:
+    dependencies:
+      citty: 0.1.6
+      consola: 3.4.2
+      defu: 6.1.7
+      node-fetch-native: 1.6.7
+      nypm: 0.6.6
+      pathe: 2.0.3
+
+  glob-parent@5.1.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob-parent@6.0.2:
+    dependencies:
+      is-glob: 4.0.3
+
+  glob@13.0.6:
+    dependencies:
+      minimatch: 10.2.5
+      minipass: 7.1.3
+      path-scurry: 2.0.2
+
+  hasown@2.0.4:
+    dependencies:
+      function-bind: 1.1.2
+
+  helmet@7.2.0: {}
+
+  http-errors@2.0.1:
+    dependencies:
+      depd: 2.0.0
+      inherits: 2.0.4
+      setprototypeof: 1.2.0
+      statuses: 2.0.2
+      toidentifier: 1.0.1
+
+  iceberg-js@0.8.1: {}
+
+  inherits@2.0.4: {}
+
+  internmap@2.0.3: {}
+
+  ioredis@5.10.1:
+    dependencies:
+      '@ioredis/commands': 1.5.1
+      cluster-key-slot: 1.1.2
+      debug: 4.4.3
+      denque: 2.1.0
+      lodash.defaults: 4.2.0
+      lodash.isarguments: 3.1.0
+      redis-errors: 1.2.0
+      redis-parser: 3.0.0
+      standard-as-callback: 2.1.0
+    transitivePeerDependencies:
+      - supports-color
+
+  ipaddr.js@2.4.0: {}
+
+  is-binary-path@2.1.0:
+    dependencies:
+      binary-extensions: 2.3.0
+
+  is-core-module@2.16.2:
+    dependencies:
+      hasown: 2.0.4
+
+  is-extglob@2.1.1: {}
+
+  is-fullwidth-code-point@3.0.0: {}
+
+  is-glob@4.0.3:
+    dependencies:
+      is-extglob: 2.1.1
+
+  is-number@7.0.0: {}
+
+  is-standalone-pwa@0.1.1: {}
+
+  jiti@1.21.7: {}
+
+  jiti@2.7.0: {}
+
+  js-tokens@4.0.0: {}
+
+  json-schema-ref-resolver@3.0.0:
+    dependencies:
+      dequal: 2.0.3
+
+  json-schema-resolver@3.0.0:
+    dependencies:
+      debug: 4.4.3
+      fast-uri: 3.1.2
+      rfdc: 1.4.1
+    transitivePeerDependencies:
+      - supports-color
+
+  json-schema-traverse@1.0.0: {}
+
+  light-my-request@6.6.0:
+    dependencies:
+      cookie: 1.1.1
+      process-warning: 4.0.1
+      set-cookie-parser: 2.7.2
+
+  lilconfig@3.1.3: {}
+
+  lines-and-columns@1.2.4: {}
+
+  locate-path@5.0.0:
+    dependencies:
+      p-locate: 4.1.0
+
+  lodash.defaults@4.2.0: {}
+
+  lodash.isarguments@3.1.0: {}
+
+  lodash@4.18.1: {}
+
+  loose-envify@1.4.0:
+    dependencies:
+      js-tokens: 4.0.0
+
+  loupe@3.2.1: {}
+
+  lru-cache@11.5.1: {}
+
+  lucide-react@0.468.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  luxon@3.7.2: {}
+
+  magic-string@0.30.21:
+    dependencies:
+      '@jridgewell/sourcemap-codec': 1.5.5
+
+  merge2@1.4.1: {}
+
+  micromatch@4.0.8:
+    dependencies:
+      braces: 3.0.3
+      picomatch: 2.3.2
+
+  mime@3.0.0: {}
+
+  minimatch@10.2.5:
+    dependencies:
+      brace-expansion: 5.0.6
+
+  minipass@7.1.3: {}
+
+  mnemonist@0.40.0:
+    dependencies:
+      obliterator: 2.0.5
+
+  ms@2.1.3: {}
+
+  msgpackr-extract@3.0.4:
+    dependencies:
+      node-gyp-build-optional-packages: 5.2.2
+    optionalDependencies:
+      '@msgpackr-extract/msgpackr-extract-darwin-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-darwin-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-arm64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-linux-x64': 3.0.4
+      '@msgpackr-extract/msgpackr-extract-win32-x64': 3.0.4
+    optional: true
+
+  msgpackr@2.0.1:
+    optionalDependencies:
+      msgpackr-extract: 3.0.4
+
+  mz@2.7.0:
+    dependencies:
+      any-promise: 1.3.0
+      object-assign: 4.1.1
+      thenify-all: 1.6.0
+
+  nanoid@3.3.12: {}
+
+  nanoid@5.1.11: {}
+
+  next@16.2.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@next/env': 16.2.6
+      '@swc/helpers': 0.5.15
+      baseline-browser-mapping: 2.10.33
+      caniuse-lite: 1.0.30001793
+      postcss: 8.4.31
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      styled-jsx: 5.1.6(react@19.2.6)
+    optionalDependencies:
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
+      sharp: 0.34.5
+    transitivePeerDependencies:
+      - '@babel/core'
+      - babel-plugin-macros
+
+  node-abort-controller@3.1.1: {}
+
+  node-fetch-native@1.6.7: {}
+
+  node-gyp-build-optional-packages@5.2.2:
+    dependencies:
+      detect-libc: 2.1.2
+    optional: true
+
+  node-releases@2.0.46: {}
+
+  normalize-path@3.0.0: {}
+
+  nypm@0.6.6:
+    dependencies:
+      citty: 0.2.2
+      pathe: 2.0.3
+      tinyexec: 1.2.4
+
+  object-assign@4.1.1: {}
+
+  object-hash@3.0.0: {}
+
+  obliterator@2.0.5: {}
+
+  ohash@2.0.11: {}
+
+  on-exit-leak-free@2.1.2: {}
+
+  openapi-types@12.1.3: {}
+
+  p-limit@2.3.0:
+    dependencies:
+      p-try: 2.2.0
+
+  p-locate@4.1.0:
+    dependencies:
+      p-limit: 2.3.0
+
+  p-try@2.2.0: {}
+
+  path-exists@4.0.0: {}
+
+  path-parse@1.0.7: {}
+
+  path-scurry@2.0.2:
+    dependencies:
+      lru-cache: 11.5.1
+      minipass: 7.1.3
+
+  pathe@1.1.2: {}
+
+  pathe@2.0.3: {}
+
+  pathval@2.0.1: {}
+
+  perfect-debounce@1.0.0: {}
+
+  picocolors@1.1.1: {}
+
+  picomatch@2.3.2: {}
+
+  picomatch@4.0.4: {}
+
+  pify@2.3.0: {}
+
+  pino-abstract-transport@2.0.0:
+    dependencies:
+      split2: 4.2.0
+
+  pino-std-serializers@7.1.0: {}
+
+  pino@9.14.0:
+    dependencies:
+      '@pinojs/redact': 0.4.0
+      atomic-sleep: 1.0.0
+      on-exit-leak-free: 2.1.2
+      pino-abstract-transport: 2.0.0
+      pino-std-serializers: 7.1.0
+      process-warning: 5.0.0
+      quick-format-unescaped: 4.0.4
+      real-require: 0.2.0
+      safe-stable-stringify: 2.5.0
+      sonic-boom: 4.2.1
+      thread-stream: 3.1.0
+
+  pirates@4.0.7: {}
+
+  pkg-types@2.3.1:
+    dependencies:
+      confbox: 0.2.4
+      exsolve: 1.0.8
+      pathe: 2.0.3
+
+  pngjs@5.0.0: {}
+
+  postcss-import@15.1.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-value-parser: 4.2.0
+      read-cache: 1.0.0
+      resolve: 1.22.12
+
+  postcss-js@4.1.0(postcss@8.5.15):
+    dependencies:
+      camelcase-css: 2.0.1
+      postcss: 8.5.15
+
+  postcss-load-config@6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      lilconfig: 3.1.3
+    optionalDependencies:
+      jiti: 1.21.7
+      postcss: 8.5.15
+      tsx: 4.22.4
+      yaml: 2.9.0
+
+  postcss-nested@6.2.0(postcss@8.5.15):
+    dependencies:
+      postcss: 8.5.15
+      postcss-selector-parser: 6.1.2
+
+  postcss-selector-parser@6.1.2:
+    dependencies:
+      cssesc: 3.0.0
+      util-deprecate: 1.0.2
+
+  postcss-value-parser@4.2.0: {}
+
+  postcss@8.4.31:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  postcss@8.5.15:
+    dependencies:
+      nanoid: 3.3.12
+      picocolors: 1.1.1
+      source-map-js: 1.2.1
+
+  prisma@6.19.3(typescript@5.9.3):
+    dependencies:
+      '@prisma/config': 6.19.3
+      '@prisma/engines': 6.19.3
+    optionalDependencies:
+      typescript: 5.9.3
+    transitivePeerDependencies:
+      - magicast
+
+  process-warning@4.0.1: {}
+
+  process-warning@5.0.0: {}
+
+  prop-types@15.8.1:
+    dependencies:
+      loose-envify: 1.4.0
+      object-assign: 4.1.1
+      react-is: 16.13.1
+
+  pure-rand@6.1.0: {}
+
+  qrcode@1.5.4:
+    dependencies:
+      dijkstrajs: 1.0.3
+      pngjs: 5.0.0
+      yargs: 15.4.1
+
+  queue-microtask@1.2.3: {}
+
+  quick-format-unescaped@4.0.4: {}
+
+  rc9@2.1.2:
+    dependencies:
+      defu: 6.1.7
+      destr: 2.0.5
+
+  react-dom@19.2.6(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+      scheduler: 0.27.0
+
+  react-is@16.13.1: {}
+
+  react-is@18.3.1: {}
+
+  react-smooth@4.0.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-transition-group: 4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+
+  react-transition-group@4.4.5(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      '@babel/runtime': 7.29.7
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+
+  react@19.2.6: {}
+
+  read-cache@1.0.0:
+    dependencies:
+      pify: 2.3.0
+
+  readdirp@3.6.0:
+    dependencies:
+      picomatch: 2.3.2
+
+  readdirp@4.1.2: {}
+
+  real-require@0.2.0: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 19.2.6
+      react-dom: 19.2.6(react@19.2.6)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
+
+  redis-errors@1.2.0: {}
+
+  redis-parser@3.0.0:
+    dependencies:
+      redis-errors: 1.2.0
+
+  require-directory@2.1.1: {}
+
+  require-from-string@2.0.2: {}
+
+  require-main-filename@2.0.0: {}
+
+  resolve@1.22.12:
+    dependencies:
+      es-errors: 1.3.0
+      is-core-module: 2.16.2
+      path-parse: 1.0.7
+      supports-preserve-symlinks-flag: 1.0.0
+
+  ret@0.5.0: {}
+
+  reusify@1.1.0: {}
+
+  rfdc@1.4.1: {}
+
+  rollup@4.60.4:
+    dependencies:
+      '@types/estree': 1.0.8
+    optionalDependencies:
+      '@rollup/rollup-android-arm-eabi': 4.60.4
+      '@rollup/rollup-android-arm64': 4.60.4
+      '@rollup/rollup-darwin-arm64': 4.60.4
+      '@rollup/rollup-darwin-x64': 4.60.4
+      '@rollup/rollup-freebsd-arm64': 4.60.4
+      '@rollup/rollup-freebsd-x64': 4.60.4
+      '@rollup/rollup-linux-arm-gnueabihf': 4.60.4
+      '@rollup/rollup-linux-arm-musleabihf': 4.60.4
+      '@rollup/rollup-linux-arm64-gnu': 4.60.4
+      '@rollup/rollup-linux-arm64-musl': 4.60.4
+      '@rollup/rollup-linux-loong64-gnu': 4.60.4
+      '@rollup/rollup-linux-loong64-musl': 4.60.4
+      '@rollup/rollup-linux-ppc64-gnu': 4.60.4
+      '@rollup/rollup-linux-ppc64-musl': 4.60.4
+      '@rollup/rollup-linux-riscv64-gnu': 4.60.4
+      '@rollup/rollup-linux-riscv64-musl': 4.60.4
+      '@rollup/rollup-linux-s390x-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-gnu': 4.60.4
+      '@rollup/rollup-linux-x64-musl': 4.60.4
+      '@rollup/rollup-openbsd-x64': 4.60.4
+      '@rollup/rollup-openharmony-arm64': 4.60.4
+      '@rollup/rollup-win32-arm64-msvc': 4.60.4
+      '@rollup/rollup-win32-ia32-msvc': 4.60.4
+      '@rollup/rollup-win32-x64-gnu': 4.60.4
+      '@rollup/rollup-win32-x64-msvc': 4.60.4
+      fsevents: 2.3.3
+
+  run-parallel@1.2.0:
+    dependencies:
+      queue-microtask: 1.2.3
+
+  safe-regex2@5.1.1:
+    dependencies:
+      ret: 0.5.0
+
+  safe-stable-stringify@2.5.0: {}
+
+  scheduler@0.27.0: {}
+
+  secure-json-parse@4.1.0: {}
+
+  semver@7.8.0: {}
+
+  semver@7.8.1: {}
+
+  set-blocking@2.0.0: {}
+
+  set-cookie-parser@2.7.2: {}
+
+  setprototypeof@1.2.0: {}
+
+  sharp@0.34.5:
+    dependencies:
+      '@img/colour': 1.1.0
+      detect-libc: 2.1.2
+      semver: 7.8.1
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.34.5
+      '@img/sharp-darwin-x64': 0.34.5
+      '@img/sharp-libvips-darwin-arm64': 1.2.4
+      '@img/sharp-libvips-darwin-x64': 1.2.4
+      '@img/sharp-libvips-linux-arm': 1.2.4
+      '@img/sharp-libvips-linux-arm64': 1.2.4
+      '@img/sharp-libvips-linux-ppc64': 1.2.4
+      '@img/sharp-libvips-linux-riscv64': 1.2.4
+      '@img/sharp-libvips-linux-s390x': 1.2.4
+      '@img/sharp-libvips-linux-x64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.2.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.2.4
+      '@img/sharp-linux-arm': 0.34.5
+      '@img/sharp-linux-arm64': 0.34.5
+      '@img/sharp-linux-ppc64': 0.34.5
+      '@img/sharp-linux-riscv64': 0.34.5
+      '@img/sharp-linux-s390x': 0.34.5
+      '@img/sharp-linux-x64': 0.34.5
+      '@img/sharp-linuxmusl-arm64': 0.34.5
+      '@img/sharp-linuxmusl-x64': 0.34.5
+      '@img/sharp-wasm32': 0.34.5
+      '@img/sharp-win32-arm64': 0.34.5
+      '@img/sharp-win32-ia32': 0.34.5
+      '@img/sharp-win32-x64': 0.34.5
+    optional: true
+
+  siginfo@2.0.0: {}
+
+  sonic-boom@4.2.1:
+    dependencies:
+      atomic-sleep: 1.0.0
+
+  source-map-js@1.2.1: {}
+
+  split2@4.2.0: {}
+
+  stackback@0.0.2: {}
+
+  standard-as-callback@2.1.0: {}
+
+  statuses@2.0.2: {}
+
+  std-env@3.10.0: {}
+
+  string-width@4.2.3:
+    dependencies:
+      emoji-regex: 8.0.0
+      is-fullwidth-code-point: 3.0.0
+      strip-ansi: 6.0.1
+
+  strip-ansi@6.0.1:
+    dependencies:
+      ansi-regex: 5.0.1
+
+  styled-jsx@5.1.6(react@19.2.6):
+    dependencies:
+      client-only: 0.0.1
+      react: 19.2.6
+
+  sucrase@3.35.1:
+    dependencies:
+      '@jridgewell/gen-mapping': 0.3.13
+      commander: 4.1.1
+      lines-and-columns: 1.2.4
+      mz: 2.7.0
+      pirates: 4.0.7
+      tinyglobby: 0.2.17
+      ts-interface-checker: 0.1.13
+
+  supports-preserve-symlinks-flag@1.0.0: {}
+
+  tailwind-merge@2.6.1: {}
+
+  tailwindcss@3.4.19(tsx@4.22.4)(yaml@2.9.0):
+    dependencies:
+      '@alloc/quick-lru': 5.2.0
+      arg: 5.0.2
+      chokidar: 3.6.0
+      didyoumean: 1.2.2
+      dlv: 1.1.3
+      fast-glob: 3.3.3
+      glob-parent: 6.0.2
+      is-glob: 4.0.3
+      jiti: 1.21.7
+      lilconfig: 3.1.3
+      micromatch: 4.0.8
+      normalize-path: 3.0.0
+      object-hash: 3.0.0
+      picocolors: 1.1.1
+      postcss: 8.5.15
+      postcss-import: 15.1.0(postcss@8.5.15)
+      postcss-js: 4.1.0(postcss@8.5.15)
+      postcss-load-config: 6.0.1(jiti@1.21.7)(postcss@8.5.15)(tsx@4.22.4)(yaml@2.9.0)
+      postcss-nested: 6.2.0(postcss@8.5.15)
+      postcss-selector-parser: 6.1.2
+      resolve: 1.22.12
+      sucrase: 3.35.1
+    transitivePeerDependencies:
+      - tsx
+      - yaml
+
+  thenify-all@1.6.0:
+    dependencies:
+      thenify: 3.3.1
+
+  thenify@3.3.1:
+    dependencies:
+      any-promise: 1.3.0
+
+  thread-stream@3.1.0:
+    dependencies:
+      real-require: 0.2.0
+
+  tiny-invariant@1.3.3: {}
+
+  tinybench@2.9.0: {}
+
+  tinyexec@0.3.2: {}
+
+  tinyexec@1.2.4: {}
+
+  tinyglobby@0.2.17:
+    dependencies:
+      fdir: 6.5.0(picomatch@4.0.4)
+      picomatch: 4.0.4
+
+  tinypool@1.1.1: {}
+
+  tinyrainbow@1.2.0: {}
+
+  tinyspy@3.0.2: {}
+
+  to-regex-range@5.0.1:
+    dependencies:
+      is-number: 7.0.0
+
+  toad-cache@3.7.1: {}
+
+  toidentifier@1.0.1: {}
+
+  ts-interface-checker@0.1.13: {}
+
+  tslib@2.8.1: {}
+
+  tsx@4.22.4:
+    dependencies:
+      esbuild: 0.28.0
+    optionalDependencies:
+      fsevents: 2.3.3
+
+  turbo@2.9.16:
+    optionalDependencies:
+      '@turbo/darwin-64': 2.9.16
+      '@turbo/darwin-arm64': 2.9.16
+      '@turbo/linux-64': 2.9.16
+      '@turbo/linux-arm64': 2.9.16
+      '@turbo/windows-64': 2.9.16
+      '@turbo/windows-arm64': 2.9.16
+
+  typescript@5.9.3: {}
+
+  ua-is-frozen@0.1.2: {}
+
+  ua-parser-js@2.0.10:
+    dependencies:
+      detect-europe-js: 0.1.2
+      is-standalone-pwa: 0.1.1
+      ua-is-frozen: 0.1.2
+
+  undici-types@6.21.0: {}
+
+  update-browserslist-db@1.2.3(browserslist@4.28.2):
+    dependencies:
+      browserslist: 4.28.2
+      escalade: 3.2.0
+      picocolors: 1.1.1
+
+  use-sync-external-store@1.6.0(react@19.2.6):
+    dependencies:
+      react: 19.2.6
+
+  util-deprecate@1.0.2: {}
+
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
+  vite-node@2.1.9(@types/node@22.19.19):
+    dependencies:
+      cac: 6.7.14
+      debug: 4.4.3
+      es-module-lexer: 1.7.0
+      pathe: 1.1.2
+      vite: 5.4.21(@types/node@22.19.19)
+    transitivePeerDependencies:
+      - '@types/node'
+      - less
+      - lightningcss
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  vite@5.4.21(@types/node@22.19.19):
+    dependencies:
+      esbuild: 0.21.5
+      postcss: 8.5.15
+      rollup: 4.60.4
+    optionalDependencies:
+      '@types/node': 22.19.19
+      fsevents: 2.3.3
+
+  vitest@2.1.9(@types/node@22.19.19):
+    dependencies:
+      '@vitest/expect': 2.1.9
+      '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.19))
+      '@vitest/pretty-format': 2.1.9
+      '@vitest/runner': 2.1.9
+      '@vitest/snapshot': 2.1.9
+      '@vitest/spy': 2.1.9
+      '@vitest/utils': 2.1.9
+      chai: 5.3.3
+      debug: 4.4.3
+      expect-type: 1.3.0
+      magic-string: 0.30.21
+      pathe: 1.1.2
+      std-env: 3.10.0
+      tinybench: 2.9.0
+      tinyexec: 0.3.2
+      tinypool: 1.1.1
+      tinyrainbow: 1.2.0
+      vite: 5.4.21(@types/node@22.19.19)
+      vite-node: 2.1.9(@types/node@22.19.19)
+      why-is-node-running: 2.3.0
+    optionalDependencies:
+      '@types/node': 22.19.19
+    transitivePeerDependencies:
+      - less
+      - lightningcss
+      - msw
+      - sass
+      - sass-embedded
+      - stylus
+      - sugarss
+      - supports-color
+      - terser
+
+  which-module@2.0.1: {}
+
+  why-is-node-running@2.3.0:
+    dependencies:
+      siginfo: 2.0.0
+      stackback: 0.0.2
+
+  wrap-ansi@6.2.0:
+    dependencies:
+      ansi-styles: 4.3.0
+      string-width: 4.2.3
+      strip-ansi: 6.0.1
+
+  y18n@4.0.3: {}
+
+  yaml@2.9.0: {}
+
+  yargs-parser@18.1.3:
+    dependencies:
+      camelcase: 5.3.1
+      decamelize: 1.2.0
+
+  yargs@15.4.1:
+    dependencies:
+      cliui: 6.0.0
+      decamelize: 1.2.0
+      find-up: 4.1.0
+      get-caller-file: 2.0.5
+      require-directory: 2.1.1
+      require-main-filename: 2.0.0
+      set-blocking: 2.0.0
+      string-width: 4.2.3
+      which-module: 2.0.1
+      y18n: 4.0.3
+      yargs-parser: 18.1.3
+
+  zod@3.25.76: {}
+
+  zustand@4.5.7(@types/react@19.2.15)(react@19.2.6):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@19.2.6)
+    optionalDependencies:
+      '@types/react': 19.2.15
+      react: 19.2.6

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -1,0 +1,10 @@
+packages:
+  - "apps/*"
+  - "packages/*"
+allowBuilds:
+  '@prisma/client': true
+  '@prisma/engines': true
+  esbuild: true
+  msgpackr-extract: true
+  prisma: true
+  sharp: true

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "forceConsistentCasingInFileNames": true,
+    "isolatedModules": true,
+    "lib": ["ES2023", "DOM", "DOM.Iterable"],
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noEmit": true,
+    "noFallthroughCasesInSwitch": true,
+    "noImplicitOverride": true,
+    "noImplicitReturns": true,
+    "noUncheckedIndexedAccess": true,
+    "resolveJsonModule": true,
+    "skipLibCheck": true,
+    "strict": true,
+    "target": "ES2023"
+  }
+}

--- a/turbo.json
+++ b/turbo.json
@@ -1,0 +1,24 @@
+{
+  "$schema": "https://turbo.build/schema.json",
+  "tasks": {
+    "build": {
+      "dependsOn": ["^build"],
+      "outputs": [".next/**", "!.next/cache/**", "dist/**"]
+    },
+    "dev": {
+      "cache": false,
+      "persistent": true
+    },
+    "lint": {
+      "outputs": []
+    },
+    "test": {
+      "dependsOn": ["^build"],
+      "outputs": ["coverage/**"]
+    },
+    "typecheck": {
+      "dependsOn": ["^build"],
+      "outputs": []
+    }
+  }
+}


### PR DESCRIPTION
## Summary
- Adds the UrlTrack V2 pnpm monorepo with Fastify API, Next.js dashboard, Prisma/Supabase schema, BullMQ worker primitives, and shared validation.
- Implements public link CRUD, redirect bounce page with ThumbmarkJS beacon, API key/Supabase auth boundaries, OpenAPI docs, webhook signing/retry utilities, and identity matching scoring.
- Updates Docker Compose, env example, and README for the self-hosted Supabase + Redis stack.

## Validation
- corepack pnpm typecheck
- corepack pnpm test
- corepack pnpm lint
- corepack pnpm build
- DATABASE_URL=postgresql://postgres:postgres@localhost:5432/urltrack corepack pnpm --filter @urltrack/db exec prisma validate --schema prisma/schema.prisma
- Browser smoke check: http://localhost:3000 and /links/demo loaded with no console errors

## Notes
- Existing dirty Flask template/static changes in server/ were intentionally left unstaged and are not part of this PR.
- Supabase Postgres is required; docker-compose intentionally includes Redis but not Postgres.