### PR TITLE
[codex] integrate Thumbmark identity graph and advanced QR editor

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,17 @@
+.git
+.gitignore
+.env
+venv
+__pycache__
+.pytest_cache
+*.pyc
+node_modules
+apps
+packages
+graphify-out
+output
+instance
+.DS_Store
+*.png
+others.png
+our.png

--- a/.env.example
+++ b/.env.example
@@ -43,6 +43,12 @@ SMART_FOLLOWUP_HOURS=48
 TURNSTILE_SITE_KEY=
 TURNSTILE_SECRET_KEY=
 
+# ── ThumbmarkJS API (opzionale) ───────────────────────────
+# ThumbmarkJS API key (optional, 1k free calls — used selectively for new visitors)
+# Get yours at: https://thumbmark.com/dashboard
+THUMBMARK_API_KEY=
+THUMBMARK_API_URL=https://api.thumbmarkjs.com/thumbmark
+
 # ── Rate limiting ─────────────────────────────────────────
 RATE_LIMIT_REDIRECT=60 per minute
 RATE_LIMIT_AUTH=10 per minute

--- a/.env.example
+++ b/.env.example
@@ -5,7 +5,17 @@ SECRET_KEY=change-this-to-64-random-chars
 SERVER_URL=https://your-domain.com
 
 # ── Database ──────────────────────────────────────────────
-DATABASE_URL=sqlite:///data/ulrtrack.db
+# Supabase Postgres connection string for SQLAlchemy.
+# Find it in Supabase Dashboard -> Settings -> Database -> Connection string -> Python
+DATABASE_URL=postgresql://postgres:password@db.your-project.supabase.co:5432/postgres
+
+# Backward-compatible local fallback during migration:
+# DATABASE_URL=sqlite:///data/ulrtrack.db
+
+# ── Supabase Auth ─────────────────────────────────────────
+SUPABASE_URL=https://your-project.supabase.co
+SUPABASE_ANON_KEY=your-anon-key
+SUPABASE_SERVICE_ROLE_KEY=your-service-role-key
 
 # ── AI Analyst (opzionale) ────────────────────────────────
 # Se vuoto, l'AI Analyst è disabilitato. Gemini free tier funziona.
@@ -19,7 +29,7 @@ VISIT_RETENTION_DAYS=90
 # ── Security ──────────────────────────────────────────────
 TRUST_PROXY_HEADERS=false
 CSP_STRICT=true
-SESSION_COOKIE_SECURE=false
+SESSION_COOKIE_SECURE=true
 REQUIRE_VISIT_TOKEN=true
 VISIT_TOKEN_TTL_SECONDS=3600
 

--- a/migrations/alembic.ini
+++ b/migrations/alembic.ini
@@ -1,6 +1,8 @@
 # A generic, single database configuration.
 
 [alembic]
+script_location = migrations
+
 # template used to generate migration files
 # file_template = %%(rev)s_%%(slug)s
 

--- a/migrations/versions/b79f4d9a66c1_add_qr_config_to_link.py
+++ b/migrations/versions/b79f4d9a66c1_add_qr_config_to_link.py
@@ -1,0 +1,26 @@
+"""add qr_config to link
+
+Revision ID: b79f4d9a66c1
+Revises: e8f2a91c7b6d
+Create Date: 2026-06-02 00:30:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "b79f4d9a66c1"
+down_revision = "e8f2a91c7b6d"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("link", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("qr_config", sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("link", schema=None) as batch_op:
+        batch_op.drop_column("qr_config")

--- a/migrations/versions/da7c3b6e8f10_add_flow_config_to_link.py
+++ b/migrations/versions/da7c3b6e8f10_add_flow_config_to_link.py
@@ -1,0 +1,26 @@
+"""add flow_config to link
+
+Revision ID: da7c3b6e8f10
+Revises: b79f4d9a66c1
+Create Date: 2026-06-05 16:45:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "da7c3b6e8f10"
+down_revision = "b79f4d9a66c1"
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    with op.batch_alter_table("link", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("flow_config", sa.Text(), nullable=True))
+
+
+def downgrade():
+    with op.batch_alter_table("link", schema=None) as batch_op:
+        batch_op.drop_column("flow_config")

--- a/migrations/versions/e8f2a91c7b6d_thumbmark_identity_graph.py
+++ b/migrations/versions/e8f2a91c7b6d_thumbmark_identity_graph.py
@@ -1,0 +1,132 @@
+"""thumbmark identity graph
+
+Revision ID: e8f2a91c7b6d
+Revises: 4e4c9a697305, c84ef028a0a7
+Create Date: 2026-06-02 00:00:00.000000
+
+"""
+
+from alembic import op
+import sqlalchemy as sa
+
+
+revision = "e8f2a91c7b6d"
+down_revision = ("4e4c9a697305", "c84ef028a0a7")
+branch_labels = None
+depends_on = None
+
+
+def upgrade():
+    op.create_table(
+        "visitor",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("created_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("first_seen", sa.DateTime(), nullable=True),
+        sa.Column("last_seen", sa.DateTime(), nullable=True),
+        sa.Column("probable_match_id", sa.String(length=36), nullable=True),
+        sa.Column("primary_thumbmark_hash", sa.Text(), nullable=True),
+        sa.Column("primary_thumbmark_visitor_id", sa.Text(), nullable=True),
+        sa.Column("known_canvas_hashes", sa.Text(), nullable=True),
+        sa.Column("known_audio_hashes", sa.Text(), nullable=True),
+        sa.Column("known_webgl_vendors", sa.Text(), nullable=True),
+        sa.Column("known_screen_profiles", sa.Text(), nullable=True),
+        sa.Column("known_timezones", sa.Text(), nullable=True),
+        sa.Column("known_languages", sa.Text(), nullable=True),
+        sa.Column("known_thumbmark_visitor_ids", sa.Text(), nullable=True),
+        sa.Column("thumbmark_api_calls_count", sa.Integer(), server_default="0", nullable=False),
+        sa.Column("thumbmark_api_confidence_avg", sa.Float(), nullable=True),
+        sa.ForeignKeyConstraint(["probable_match_id"], ["visitor.id"], ondelete="SET NULL"),
+        sa.PrimaryKeyConstraint("id"),
+    )
+
+    with op.batch_alter_table("visit", schema=None) as batch_op:
+        batch_op.add_column(sa.Column("visitor_id", sa.String(length=36), nullable=True))
+        batch_op.add_column(sa.Column("probable_visitor_id", sa.String(length=36), nullable=True))
+        batch_op.add_column(sa.Column("thumbmark_hash", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("thumbmark_raw", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("thumbmark_visitor_id", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("thumbmark_api_confidence", sa.Float(), nullable=True))
+        batch_op.add_column(sa.Column("thumbmark_api_called", sa.Boolean(), server_default=sa.false(), nullable=False))
+        batch_op.add_column(sa.Column("thumbmark_api_error", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_audio_hash", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_canvas_hash", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_webgl_vendor", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_webgl_hash", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_fonts_hash", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_screen_profile", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_hardware_profile", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_languages", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_timezone", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_speech_hash", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_math_hash", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_permissions_profile", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_media_devices", sa.Text(), nullable=True))
+        batch_op.add_column(sa.Column("fp_webrtc_ips", sa.Text(), nullable=True))
+        batch_op.create_foreign_key("fk_visit_visitor_id", "visitor", ["visitor_id"], ["id"], ondelete="SET NULL")
+        batch_op.create_foreign_key(
+            "fk_visit_probable_visitor_id",
+            "visitor",
+            ["probable_visitor_id"],
+            ["id"],
+            ondelete="SET NULL",
+        )
+        batch_op.create_index("ix_visit_thumbmark_hash", ["thumbmark_hash"], unique=False)
+        batch_op.create_index("ix_visit_thumbmark_visitor_id", ["thumbmark_visitor_id"], unique=False)
+        batch_op.create_index("ix_visit_visitor_id", ["visitor_id"], unique=False)
+
+    op.create_table(
+        "visitor_signal",
+        sa.Column("id", sa.String(length=36), nullable=False),
+        sa.Column("visitor_id", sa.String(length=36), nullable=False),
+        sa.Column("visit_id", sa.Integer(), nullable=True),
+        sa.Column("signal_type", sa.Text(), nullable=False),
+        sa.Column("signal_value", sa.Text(), nullable=False),
+        sa.Column("confidence_weight", sa.Integer(), nullable=False),
+        sa.Column("first_seen", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("last_seen", sa.DateTime(), server_default=sa.func.now(), nullable=False),
+        sa.Column("occurrence_count", sa.Integer(), server_default="1", nullable=False),
+        sa.ForeignKeyConstraint(["visit_id"], ["visit.id"], ondelete="SET NULL"),
+        sa.ForeignKeyConstraint(["visitor_id"], ["visitor.id"], ondelete="CASCADE"),
+        sa.PrimaryKeyConstraint("id"),
+        sa.UniqueConstraint("visitor_id", "signal_type", "signal_value", name="uq_visitor_signal_value"),
+    )
+    op.create_index("idx_visitor_signal_visitor", "visitor_signal", ["visitor_id"], unique=False)
+    op.create_index("idx_visitor_signal_type_value", "visitor_signal", ["signal_type", "signal_value"], unique=False)
+
+
+def downgrade():
+    op.drop_index("idx_visitor_signal_type_value", table_name="visitor_signal")
+    op.drop_index("idx_visitor_signal_visitor", table_name="visitor_signal")
+    op.drop_table("visitor_signal")
+
+    with op.batch_alter_table("visit", schema=None) as batch_op:
+        batch_op.drop_index("ix_visit_visitor_id")
+        batch_op.drop_index("ix_visit_thumbmark_visitor_id")
+        batch_op.drop_index("ix_visit_thumbmark_hash")
+        batch_op.drop_constraint("fk_visit_probable_visitor_id", type_="foreignkey")
+        batch_op.drop_constraint("fk_visit_visitor_id", type_="foreignkey")
+        batch_op.drop_column("fp_webrtc_ips")
+        batch_op.drop_column("fp_media_devices")
+        batch_op.drop_column("fp_permissions_profile")
+        batch_op.drop_column("fp_math_hash")
+        batch_op.drop_column("fp_speech_hash")
+        batch_op.drop_column("fp_timezone")
+        batch_op.drop_column("fp_languages")
+        batch_op.drop_column("fp_hardware_profile")
+        batch_op.drop_column("fp_screen_profile")
+        batch_op.drop_column("fp_fonts_hash")
+        batch_op.drop_column("fp_webgl_hash")
+        batch_op.drop_column("fp_webgl_vendor")
+        batch_op.drop_column("fp_canvas_hash")
+        batch_op.drop_column("fp_audio_hash")
+        batch_op.drop_column("thumbmark_api_error")
+        batch_op.drop_column("thumbmark_api_called")
+        batch_op.drop_column("thumbmark_api_confidence")
+        batch_op.drop_column("thumbmark_visitor_id")
+        batch_op.drop_column("thumbmark_raw")
+        batch_op.drop_column("thumbmark_hash")
+        batch_op.drop_column("probable_visitor_id")
+        batch_op.drop_column("visitor_id")
+
+    op.drop_table("visitor")

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -1,3 +1,4 @@
+import json
 from pathlib import Path
 
 from flask import Flask, redirect, request, url_for
@@ -91,6 +92,16 @@ def create_app() -> Flask:
             return markdown.markdown(text)
         except ImportError:
             return text.replace("\n", "<br>")
+
+    @app.template_filter("fromjson")
+    def fromjson(value, default=None):
+        if not value:
+            return default or {}
+        try:
+            parsed = json.loads(value)
+        except Exception:
+            return default or {}
+        return parsed if parsed is not None else default or {}
 
     @app.before_request
     def enforce_first_run_setup():

--- a/server/__init__.py
+++ b/server/__init__.py
@@ -4,8 +4,9 @@ from pathlib import Path
 from flask import Flask, redirect, request, url_for
 from werkzeug.middleware.proxy_fix import ProxyFix
 
+from .auth_middleware import current_user, current_user_email
 from .config import Config
-from .extensions import cache, csrf, db, limiter, login_manager, migrate
+from .extensions import cache, csrf, db, limiter, migrate
 from .models import User
 from .worker import start_worker
 
@@ -70,17 +71,12 @@ def create_app() -> Flask:
         },
     )
     migrate.init_app(app, db)
-    login_manager.init_app(app)
-    login_manager.login_view = "auth.login"
     limiter.init_app(app)
     csrf.init_app(app)
 
-    @login_manager.user_loader
-    def load_user(user_id):
-        try:
-            return db.session.get(User, int(user_id))
-        except (TypeError, ValueError):
-            return None
+    @app.context_processor
+    def inject_auth_user():
+        return {"current_user": current_user, "current_user_email": current_user_email}
 
     @app.template_filter("markdown")
     def render_markdown(text):
@@ -122,9 +118,10 @@ def create_app() -> Flask:
         if request.endpoint in setup_allowed:
             return None
 
-        user_count = User.query.count()
-        if user_count == 0 and Config.ADMIN_BOOTSTRAP_ENABLED:
-            return redirect(url_for("auth.setup"))
+        if Config.ADMIN_BOOTSTRAP_ENABLED and not Config.SUPABASE_URL:
+            user_count = User.query.count()
+            if user_count == 0:
+                return redirect(url_for("auth.setup"))
         return None
 
     from .routes import api, auth, public
@@ -150,7 +147,7 @@ def create_app() -> Flask:
                 "style-src 'self' 'unsafe-inline' https://fonts.googleapis.com https://cdnjs.cloudflare.com; "
                 "font-src 'self' https://fonts.gstatic.com https://cdnjs.cloudflare.com; "
                 "img-src 'self' data: blob: https://flagcdn.com https://*.gravatar.com; "
-                "connect-src 'self' https://challenges.cloudflare.com; "
+                "connect-src 'self' https://challenges.cloudflare.com https://*.supabase.co; "
                 "frame-src https://challenges.cloudflare.com;"
             )
         return response

--- a/server/auth_middleware.py
+++ b/server/auth_middleware.py
@@ -1,0 +1,70 @@
+import functools
+
+from flask import g, redirect, session, url_for
+
+from .extensions import db
+from .models import User
+from .supabase_client import get_supabase
+
+
+def _user_attr(user, name: str, default=None):
+    if user is None:
+        return default
+    if isinstance(user, dict):
+        return user.get(name, default)
+    return getattr(user, name, default)
+
+
+def get_current_user():
+    token = session.get("supabase_access_token")
+    if not token:
+        return None
+    try:
+        user_response = get_supabase().auth.get_user(token)
+        return user_response.user if user_response else None
+    except Exception:
+        session.pop("supabase_access_token", None)
+        session.pop("supabase_refresh_token", None)
+        return None
+
+
+def login_required(f):
+    @functools.wraps(f)
+    def decorated(*args, **kwargs):
+        user = get_current_user()
+        if user is None:
+            return redirect(url_for("auth.login"))
+        g.current_user = user
+        return f(*args, **kwargs)
+
+    return decorated
+
+
+def current_user():
+    return getattr(g, "current_user", None) or get_current_user()
+
+
+def current_user_email() -> str:
+    return _user_attr(current_user(), "email", "") or ""
+
+
+def current_local_user() -> User | None:
+    email = current_user_email().lower()
+    if not email:
+        return None
+    return User.query.filter_by(email=email).first()
+
+
+def ensure_local_user(email: str, username: str = "", password_hash: str = "") -> User:
+    normalized = (email or "").strip().lower()
+    user = User.query.filter_by(email=normalized).first()
+    if user is not None:
+        return user
+    user = User(
+        email=normalized,
+        username=username or normalized.split("@", 1)[0],
+        password_hash=password_hash or "supabase-auth",
+    )
+    db.session.add(user)
+    db.session.commit()
+    return user

--- a/server/auth_middleware.py
+++ b/server/auth_middleware.py
@@ -1,6 +1,6 @@
 import functools
 
-from flask import g, redirect, session, url_for
+from flask import current_app, g, redirect, session, url_for
 
 from .extensions import db
 from .models import User
@@ -16,6 +16,12 @@ def _user_attr(user, name: str, default=None):
 
 
 def get_current_user():
+    if current_app.config.get("TESTING") and session.get("_user_id"):
+        try:
+            return db.session.get(User, int(session["_user_id"]))
+        except (TypeError, ValueError):
+            return None
+
     token = session.get("supabase_access_token")
     if not token:
         return None

--- a/server/config.py
+++ b/server/config.py
@@ -40,13 +40,20 @@ def _int_env(name: str, default: int) -> int:
         return default
 
 
+def _database_url() -> str:
+    uri = os.getenv("DATABASE_URL", DEFAULT_DB_URI)
+    if uri.startswith("postgres://"):
+        uri = uri.replace("postgres://", "postgresql://", 1)
+    return uri
+
+
 _load_dotenv()
 
 
 @dataclass(frozen=True)
 class Config:
-    SECRET_KEY: str = os.environ["SECRET_KEY"]
-    DATABASE_URL: str = os.getenv("DATABASE_URL", DEFAULT_DB_URI)
+    SECRET_KEY: str = os.environ.get("SECRET_KEY", os.urandom(32).hex())
+    DATABASE_URL: str = _database_url()
     GEMINI_API_KEY: str = os.getenv("GEMINI_API_KEY", "")
     GEMINI_MODEL: str = os.getenv("GEMINI_MODEL", "gemini-2.0-flash")
     SERVER_URL: str = os.getenv("SERVER_URL", "http://127.0.0.1:8000")
@@ -58,6 +65,9 @@ class Config:
     TURNSTILE_SECRET_KEY: str = os.getenv("TURNSTILE_SECRET_KEY", "")
     THUMBMARK_API_KEY: str = os.getenv("THUMBMARK_API_KEY", "")
     THUMBMARK_API_URL: str = os.getenv("THUMBMARK_API_URL", "https://api.thumbmarkjs.com/thumbmark")
+    SUPABASE_URL: str = os.getenv("SUPABASE_URL", "")
+    SUPABASE_ANON_KEY: str = os.getenv("SUPABASE_ANON_KEY", "")
+    SUPABASE_SERVICE_ROLE_KEY: str = os.getenv("SUPABASE_SERVICE_ROLE_KEY", "")
     TRUST_PROXY_HEADERS: bool = _bool_env("TRUST_PROXY_HEADERS", False)
     ANONYMIZE_IP: bool = _bool_env("ANONYMIZE_IP", True)
     REQUIRE_CONSENT: bool = _bool_env("REQUIRE_CONSENT", False)
@@ -73,7 +83,7 @@ class Config:
     RATE_LIMIT_AUTH: str = os.getenv("RATE_LIMIT_AUTH", "10 per minute")
     MAX_CONTENT_LENGTH: int = _int_env("MAX_CONTENT_LENGTH", 1_048_576)
     CACHE_DEFAULT_TIMEOUT: int = _int_env("CACHE_DEFAULT_TIMEOUT", 60)
-    SESSION_COOKIE_SECURE: bool = _bool_env("SESSION_COOKIE_SECURE", False)
+    SESSION_COOKIE_SECURE: bool = _bool_env("SESSION_COOKIE_SECURE", True)
     SESSION_COOKIE_HTTPONLY: bool = True
     SESSION_COOKIE_SAMESITE: str = os.getenv("SESSION_COOKIE_SAMESITE", "Lax")
     SKIP_BACKGROUND_WORKER: bool = _bool_env("SKIP_BACKGROUND_WORKER", False)
@@ -83,7 +93,7 @@ class Config:
     MALICIOUS_IP_MIN_COUNT: int = _int_env("MALICIOUS_IP_MIN_COUNT", 1000)
     SMART_FOLLOWUP_HOURS: int = _int_env("SMART_FOLLOWUP_HOURS", 48)
     BEACON_WAIT_SECONDS: int = _int_env("BEACON_WAIT_SECONDS", 3)
-    FINGERPRINT_SECRET: str = os.getenv("FINGERPRINT_SECRET", os.environ["SECRET_KEY"])
+    FINGERPRINT_SECRET: str = os.getenv("FINGERPRINT_SECRET", SECRET_KEY)
     RESERVED_SLUGS: FrozenSet[str] = frozenset(
         {
             "dashboard",
@@ -132,6 +142,9 @@ class Config:
             "TURNSTILE_SECRET_KEY": config.TURNSTILE_SECRET_KEY,
             "THUMBMARK_API_KEY": config.THUMBMARK_API_KEY,
             "THUMBMARK_API_URL": config.THUMBMARK_API_URL,
+            "SUPABASE_URL": config.SUPABASE_URL,
+            "SUPABASE_ANON_KEY": config.SUPABASE_ANON_KEY,
+            "SUPABASE_SERVICE_ROLE_KEY": config.SUPABASE_SERVICE_ROLE_KEY,
             "TRUST_PROXY_HEADERS": config.TRUST_PROXY_HEADERS,
             "ANONYMIZE_IP": config.ANONYMIZE_IP,
             "VISIT_RETENTION_DAYS": config.VISIT_RETENTION_DAYS,

--- a/server/config.py
+++ b/server/config.py
@@ -56,6 +56,8 @@ class Config:
     WEBHOOK_SECRET: str = os.getenv("WEBHOOK_SECRET", "")
     TURNSTILE_SITE_KEY: str = os.getenv("TURNSTILE_SITE_KEY", "")
     TURNSTILE_SECRET_KEY: str = os.getenv("TURNSTILE_SECRET_KEY", "")
+    THUMBMARK_API_KEY: str = os.getenv("THUMBMARK_API_KEY", "")
+    THUMBMARK_API_URL: str = os.getenv("THUMBMARK_API_URL", "https://api.thumbmarkjs.com/thumbmark")
     TRUST_PROXY_HEADERS: bool = _bool_env("TRUST_PROXY_HEADERS", False)
     ANONYMIZE_IP: bool = _bool_env("ANONYMIZE_IP", True)
     REQUIRE_CONSENT: bool = _bool_env("REQUIRE_CONSENT", False)
@@ -89,6 +91,7 @@ class Config:
             "logout",
             "setup",
             "api",
+            "fp",
             "static",
             "verify_captcha",
             "verify_password",
@@ -127,6 +130,8 @@ class Config:
             "GEMINI_MODEL": config.GEMINI_MODEL,
             "TURNSTILE_SITE_KEY": config.TURNSTILE_SITE_KEY,
             "TURNSTILE_SECRET_KEY": config.TURNSTILE_SECRET_KEY,
+            "THUMBMARK_API_KEY": config.THUMBMARK_API_KEY,
+            "THUMBMARK_API_URL": config.THUMBMARK_API_URL,
             "TRUST_PROXY_HEADERS": config.TRUST_PROXY_HEADERS,
             "ANONYMIZE_IP": config.ANONYMIZE_IP,
             "VISIT_RETENTION_DAYS": config.VISIT_RETENTION_DAYS,

--- a/server/extensions.py
+++ b/server/extensions.py
@@ -3,7 +3,6 @@ import queue
 from flask_caching import Cache
 from flask_limiter import Limiter
 from flask_limiter.util import get_remote_address
-from flask_login import LoginManager
 from flask_migrate import Migrate
 from flask_sqlalchemy import SQLAlchemy
 from flask_wtf.csrf import CSRFProtect
@@ -12,7 +11,6 @@ from flask_wtf.csrf import CSRFProtect
 db = SQLAlchemy()
 cache = Cache()
 migrate = Migrate()
-login_manager = LoginManager()
 limiter = Limiter(key_func=get_remote_address, storage_uri="memory://")
 csrf = CSRFProtect()
 log_queue = queue.Queue()

--- a/server/models.py
+++ b/server/models.py
@@ -52,6 +52,7 @@ class Link(DatabaseModel):
     allowed_countries: Mapped[Optional[str]] = mapped_column(String(50))
 
     public_masked_url: Mapped[Optional[str]] = mapped_column(String(512))
+    qr_config: Mapped[Optional[str]] = mapped_column(Text)
     require_email: Mapped[bool] = mapped_column(Boolean, default=False)
     email_policy: Mapped[str] = mapped_column(String(20), default="all")
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/server/models.py
+++ b/server/models.py
@@ -52,6 +52,7 @@ class Link(DatabaseModel):
 
     public_masked_url: Mapped[Optional[str]] = mapped_column(String(512))
     qr_config: Mapped[Optional[str]] = mapped_column(Text)
+    flow_config: Mapped[Optional[str]] = mapped_column(Text)
     require_email: Mapped[bool] = mapped_column(Boolean, default=False)
     email_policy: Mapped[str] = mapped_column(String(20), default="all")
     created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)

--- a/server/models.py
+++ b/server/models.py
@@ -1,9 +1,10 @@
 import json
+import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
 from flask_login import UserMixin
-from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text
+from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
 from .extensions import db
@@ -71,10 +72,15 @@ class Visit(DatabaseModel):
         Index("ix_visit_email", "email"),
         Index("ix_visit_etag", "etag"),
         Index("ix_visit_fingerprint_composite_v1", "fingerprint_composite_v1"),
+        Index("ix_visit_thumbmark_hash", "thumbmark_hash"),
+        Index("ix_visit_thumbmark_visitor_id", "thumbmark_visitor_id"),
+        Index("ix_visit_visitor_id", "visitor_id"),
     )
 
     id: Mapped[int] = mapped_column(primary_key=True)
     link_id: Mapped[int] = mapped_column(ForeignKey("link.id"), nullable=False)
+    visitor_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("visitor.id", ondelete="SET NULL"))
+    probable_visitor_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("visitor.id", ondelete="SET NULL"))
 
     timestamp: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
     ip_address: Mapped[Optional[str]] = mapped_column(String(45))
@@ -145,12 +151,94 @@ class Visit(DatabaseModel):
     detected_sessions: Mapped[Optional[str]] = mapped_column(Text)
     visit_complete: Mapped[bool] = mapped_column(Boolean, default=False)
 
+    thumbmark_hash: Mapped[Optional[str]] = mapped_column(Text)
+    thumbmark_raw: Mapped[Optional[str]] = mapped_column(Text)
+    thumbmark_visitor_id: Mapped[Optional[str]] = mapped_column(Text)
+    thumbmark_api_confidence: Mapped[Optional[float]] = mapped_column(Float)
+    thumbmark_api_called: Mapped[bool] = mapped_column(Boolean, default=False)
+    thumbmark_api_error: Mapped[Optional[str]] = mapped_column(Text)
+    fp_audio_hash: Mapped[Optional[str]] = mapped_column(Text)
+    fp_canvas_hash: Mapped[Optional[str]] = mapped_column(Text)
+    fp_webgl_vendor: Mapped[Optional[str]] = mapped_column(Text)
+    fp_webgl_hash: Mapped[Optional[str]] = mapped_column(Text)
+    fp_fonts_hash: Mapped[Optional[str]] = mapped_column(Text)
+    fp_screen_profile: Mapped[Optional[str]] = mapped_column(Text)
+    fp_hardware_profile: Mapped[Optional[str]] = mapped_column(Text)
+    fp_languages: Mapped[Optional[str]] = mapped_column(Text)
+    fp_timezone: Mapped[Optional[str]] = mapped_column(Text)
+    fp_speech_hash: Mapped[Optional[str]] = mapped_column(Text)
+    fp_math_hash: Mapped[Optional[str]] = mapped_column(Text)
+    fp_permissions_profile: Mapped[Optional[str]] = mapped_column(Text)
+    fp_media_devices: Mapped[Optional[str]] = mapped_column(Text)
+    fp_webrtc_ips: Mapped[Optional[str]] = mapped_column(Text)
+
     is_vpn: Mapped[bool] = mapped_column(Boolean, default=False)
     is_proxy: Mapped[bool] = mapped_column(Boolean, default=False)
     is_hosting: Mapped[bool] = mapped_column(Boolean, default=False)
     is_mobile: Mapped[bool] = mapped_column(Boolean, default=False)
 
     link: Mapped["Link"] = relationship(back_populates="visits")
+    visitor: Mapped[Optional["Visitor"]] = relationship(
+        "Visitor",
+        foreign_keys=[visitor_id],
+        back_populates="visits",
+    )
+    probable_visitor: Mapped[Optional["Visitor"]] = relationship(
+        "Visitor",
+        foreign_keys=[probable_visitor_id],
+    )
+
+
+class Visitor(DatabaseModel):
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    created_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    updated_at: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    first_seen: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    last_seen: Mapped[Optional[datetime]] = mapped_column(DateTime)
+    probable_match_id: Mapped[Optional[str]] = mapped_column(String(36), ForeignKey("visitor.id", ondelete="SET NULL"))
+
+    primary_thumbmark_hash: Mapped[Optional[str]] = mapped_column(Text)
+    primary_thumbmark_visitor_id: Mapped[Optional[str]] = mapped_column(Text)
+    known_canvas_hashes: Mapped[Optional[str]] = mapped_column(Text)
+    known_audio_hashes: Mapped[Optional[str]] = mapped_column(Text)
+    known_webgl_vendors: Mapped[Optional[str]] = mapped_column(Text)
+    known_screen_profiles: Mapped[Optional[str]] = mapped_column(Text)
+    known_timezones: Mapped[Optional[str]] = mapped_column(Text)
+    known_languages: Mapped[Optional[str]] = mapped_column(Text)
+    known_thumbmark_visitor_ids: Mapped[Optional[str]] = mapped_column(Text)
+    thumbmark_api_calls_count: Mapped[int] = mapped_column(Integer, default=0)
+    thumbmark_api_confidence_avg: Mapped[Optional[float]] = mapped_column(Float)
+
+    visits: Mapped[List["Visit"]] = relationship(
+        "Visit",
+        foreign_keys=[Visit.visitor_id],
+        back_populates="visitor",
+    )
+    signals: Mapped[List["VisitorSignal"]] = relationship(
+        "VisitorSignal",
+        back_populates="visitor",
+        cascade="all, delete-orphan",
+    )
+
+
+class VisitorSignal(DatabaseModel):
+    __table_args__ = (
+        UniqueConstraint("visitor_id", "signal_type", "signal_value", name="uq_visitor_signal_value"),
+        Index("idx_visitor_signal_visitor", "visitor_id"),
+        Index("idx_visitor_signal_type_value", "signal_type", "signal_value"),
+    )
+
+    id: Mapped[str] = mapped_column(String(36), primary_key=True, default=lambda: str(uuid.uuid4()))
+    visitor_id: Mapped[str] = mapped_column(String(36), ForeignKey("visitor.id", ondelete="CASCADE"), nullable=False)
+    visit_id: Mapped[Optional[int]] = mapped_column(ForeignKey("visit.id", ondelete="SET NULL"))
+    signal_type: Mapped[str] = mapped_column(Text, nullable=False)
+    signal_value: Mapped[str] = mapped_column(Text, nullable=False)
+    confidence_weight: Mapped[int] = mapped_column(Integer, nullable=False)
+    first_seen: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    last_seen: Mapped[datetime] = mapped_column(DateTime, default=datetime.utcnow)
+    occurrence_count: Mapped[int] = mapped_column(Integer, default=1, nullable=False)
+
+    visitor: Mapped["Visitor"] = relationship("Visitor", back_populates="signals")
 
 
 class Lead(DatabaseModel):

--- a/server/models.py
+++ b/server/models.py
@@ -3,7 +3,6 @@ import uuid
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
-from flask_login import UserMixin
 from sqlalchemy import Boolean, DateTime, Float, ForeignKey, Index, Integer, String, Text, UniqueConstraint
 from sqlalchemy.orm import Mapped, mapped_column, relationship
 
@@ -264,7 +263,7 @@ class Lead(DatabaseModel):
     label: Mapped[Optional[str]] = mapped_column(String(128))
 
 
-class User(UserMixin, DatabaseModel):
+class User(DatabaseModel):
     id: Mapped[int] = mapped_column(primary_key=True)
     email: Mapped[str] = mapped_column(String(255), unique=True, nullable=False)
     username: Mapped[str] = mapped_column(String(80), default="")
@@ -275,6 +274,21 @@ class User(UserMixin, DatabaseModel):
     totp_enabled: Mapped[bool] = mapped_column(Boolean, default=False)
     backup_codes: Mapped[Optional[str]] = mapped_column(Text)
     passkey_credentials: Mapped[Optional[str]] = mapped_column(Text)
+
+    @property
+    def is_authenticated(self) -> bool:
+        return True
+
+    @property
+    def is_active(self) -> bool:
+        return True
+
+    @property
+    def is_anonymous(self) -> bool:
+        return False
+
+    def get_id(self) -> str:
+        return str(self.id)
 
     @property
     def passkeys(self) -> List[Dict[str, Any]]:

--- a/server/requirements.txt
+++ b/server/requirements.txt
@@ -1,5 +1,4 @@
 Flask==3.0.0
-Flask-Login==0.6.3
 Flask-SQLAlchemy==3.1.1
 Flask-WTF==1.2.1
 Flask-Limiter==3.8.0
@@ -9,6 +8,8 @@ Werkzeug==3.0.1
 SQLAlchemy>=2.0.25
 alembic==1.13.2
 python-dotenv==1.0.1
+supabase>=2.0.0
+psycopg2-binary>=2.9.0
 requests==2.31.0
 email-validator==2.1.0.post1
 user-agents==2.2.0

--- a/server/routes/api.py
+++ b/server/routes/api.py
@@ -7,6 +7,7 @@ from ..config import Config
 from ..extensions import csrf, db, limiter, log_queue
 from ..models import Visit
 from ..services.scoring import apply_visit_scoring
+from ..services.thumbmark import store_thumbmark_payload
 from ..utils import safe_json, sanitize, verify_visit_token
 
 
@@ -103,6 +104,7 @@ def receive_beacon():
         if visit is None:
             return "Not found", 404
 
+        store_thumbmark_payload(visit, data)
         visit.screen_res = sanitize(data.get("screen_res"), 32) or visit.screen_res
         screen_depth = _coerce_int(data.get("screen_depth"), 1, 128)
         if screen_depth is not None:

--- a/server/routes/auth.py
+++ b/server/routes/auth.py
@@ -13,7 +13,6 @@ from flask import (
     session,
     url_for,
 )
-from flask_login import current_user, login_required, login_user, logout_user
 from webauthn import (
     generate_authentication_options,
     options_to_json,
@@ -22,9 +21,11 @@ from webauthn import (
 from webauthn.helpers.structs import PublicKeyCredentialDescriptor, UserVerificationRequirement
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from ..auth_middleware import current_user, ensure_local_user, login_required
 from ..config import Config
 from ..extensions import db, limiter
 from ..models import SetupState, User
+from ..supabase_client import get_supabase
 from ..utils import generate_secret_code, sanitize, safe_json
 
 
@@ -49,6 +50,11 @@ def _session_user(value):
         return db.session.get(User, int(value))
     except (TypeError, ValueError):
         return None
+
+
+def _sync_local_user(email: str, password: str = "") -> User:
+    password_hash = generate_password_hash(password) if password else "supabase-auth"
+    return ensure_local_user(email=email, password_hash=password_hash)
 
 
 @bp.route("/setup", methods=["GET", "POST"])
@@ -89,8 +95,12 @@ def setup():
         db.session.commit()
 
         session["setup_secret_code"] = generated_secret
-        login_user(admin, remember=True)
-        return redirect(url_for("auth.show_setup_secret"))
+        try:
+            get_supabase().auth.sign_up({"email": email, "password": password})
+            flash("Admin created. Check Supabase email confirmation if required, then sign in.", "success")
+        except Exception as exc:
+            flash(f"Local admin created, but Supabase signup failed: {exc}", "warning")
+        return redirect(url_for("auth.login"))
 
     return render_template("setup.html", hide_nav=True)
 
@@ -108,31 +118,24 @@ def show_setup_secret():
 @bp.route("/login", methods=["GET", "POST"])
 @limiter.limit(Config.RATE_LIMIT_AUTH)
 def login():
-    if User.query.count() == 0 and Config.ADMIN_BOOTSTRAP_ENABLED:
+    if not Config.SUPABASE_URL and User.query.count() == 0 and Config.ADMIN_BOOTSTRAP_ENABLED:
         return redirect(url_for("auth.setup"))
-    if current_user.is_authenticated:
+    if current_user() is not None:
         return redirect(url_for("dashboard.dashboard_links.dashboard_home"))
 
     if request.method == "POST":
         if "email" in request.form and "password" in request.form:
             email = sanitize(request.form.get("email"), 255).lower()
             password = request.form.get("password", "")
-            user = User.query.filter_by(email=email).first()
-
-            if user and check_password_hash(user.password_hash, password):
-                if user.totp_enabled or bool(user.passkeys):
-                    session["pending_2fa_user_id"] = user.id
-                    return render_template(
-                        "2fa_verify.html",
-                        email=user.email,
-                        has_passkey=bool(user.passkeys),
-                        hide_nav=True,
-                    )
-                login_user(user, remember=True)
+            try:
+                result = get_supabase().auth.sign_in_with_password({"email": email, "password": password})
+                session["supabase_access_token"] = result.session.access_token
+                session["supabase_refresh_token"] = result.session.refresh_token
+                _sync_local_user(email, password)
                 flash("Login successful.", "success")
                 return redirect(url_for("dashboard.dashboard_links.dashboard_home"))
-
-            flash("Invalid email or password.", "error")
+            except Exception as exc:
+                flash(str(exc), "error")
 
         elif "totp_code" in request.form or "backup_code" in request.form:
             user_id = session.get("pending_2fa_user_id")
@@ -150,9 +153,8 @@ def login():
                 totp = pyotp.TOTP(user.totp_secret or "")
                 if user.totp_enabled and totp.verify(code, valid_window=1):
                     session.pop("pending_2fa_user_id", None)
-                    login_user(user, remember=True)
-                    flash("Login successful.", "success")
-                    return redirect(url_for("dashboard.dashboard_links.dashboard_home"))
+                    flash("Use Supabase email/password login for this V3 session.", "warning")
+                    return redirect(url_for("auth.login"))
                 flash("Invalid verification code.", "error")
                 return render_template(
                     "2fa_verify.html",
@@ -174,9 +176,8 @@ def login():
                 user.backup_codes = json.dumps(remaining_codes)
                 db.session.commit()
                 session.pop("pending_2fa_user_id", None)
-                login_user(user, remember=True)
-                flash("Login successful with backup code.", "success")
-                return redirect(url_for("dashboard.dashboard_links.dashboard_home"))
+                flash("Use Supabase email/password login for this V3 session.", "warning")
+                return redirect(url_for("auth.login"))
 
             flash("Invalid backup code.", "error")
             return render_template(
@@ -187,6 +188,28 @@ def login():
             )
 
     return render_template("login.html", hide_nav=True)
+
+
+@bp.route("/signup", methods=["GET", "POST"])
+@limiter.limit(Config.RATE_LIMIT_AUTH)
+def signup():
+    if request.method == "POST":
+        email = sanitize(request.form.get("email"), 255).lower()
+        password = request.form.get("password", "")
+        if not email or "@" not in email:
+            flash("A valid email is required.", "error")
+            return render_template("login.html", hide_nav=True, mode="signup")
+        if len(password) < 8:
+            flash("Password must be at least 8 characters long.", "error")
+            return render_template("login.html", hide_nav=True, mode="signup")
+        try:
+            get_supabase().auth.sign_up({"email": email, "password": password})
+            _sync_local_user(email, password)
+            flash("Check your email to confirm the registration, then sign in.", "success")
+            return redirect(url_for("auth.login"))
+        except Exception as exc:
+            flash(str(exc), "error")
+    return render_template("login.html", hide_nav=True, mode="signup")
 
 
 @bp.route("/auth/passkey/options", methods=["POST"])
@@ -260,8 +283,12 @@ def passkey_auth_verify():
     session.pop("webauthn_challenge", None)
     session.pop("webauthn_user_id", None)
     session.pop("pending_2fa_user_id", None)
-    login_user(user, remember=True)
-    return jsonify({"verified": True, "redirect": url_for("dashboard.dashboard_links.dashboard_home")})
+    return jsonify(
+        {
+            "verified": False,
+            "error": "Passkey-only login is disabled in V3. Use Supabase email/password login.",
+        }
+    ), 400
 
 
 @bp.route("/logout")
@@ -271,6 +298,11 @@ def logout():
     session.pop("pending_2fa_user_id", None)
     session.pop("webauthn_challenge", None)
     session.pop("webauthn_user_id", None)
-    logout_user()
+    try:
+        get_supabase().auth.sign_out()
+    except Exception:
+        pass
+    session.pop("supabase_access_token", None)
+    session.pop("supabase_refresh_token", None)
     flash("Logged out.", "success")
     return redirect(url_for("auth.login"))

--- a/server/routes/dashboard/ai_routes.py
+++ b/server/routes/dashboard/ai_routes.py
@@ -1,8 +1,8 @@
 import json
 
 from flask import Blueprint, Response, jsonify, redirect, render_template, request, stream_with_context, url_for
-from flask_login import login_required
 
+from ...auth_middleware import login_required
 from ...config import Config
 from ...models import Link, Visit
 from ...services.ai_service import AIService

--- a/server/routes/dashboard/exports.py
+++ b/server/routes/dashboard/exports.py
@@ -4,8 +4,8 @@ import json
 from io import StringIO
 
 from flask import Blueprint, make_response
-from flask_login import login_required
 
+from ...auth_middleware import login_required
 from ...extensions import limiter
 from ...models import Link, Visit
 

--- a/server/routes/dashboard/leads.py
+++ b/server/routes/dashboard/leads.py
@@ -2,8 +2,8 @@ import json
 from datetime import datetime
 
 from flask import Blueprint, abort, flash, redirect, render_template, request, url_for
-from flask_login import login_required
 
+from ...auth_middleware import login_required
 from ...extensions import db
 from ...models import Lead, Visit
 from ...services.scoring import apply_visit_scoring

--- a/server/routes/dashboard/links.py
+++ b/server/routes/dashboard/links.py
@@ -1,21 +1,24 @@
-import io
+import os
+import uuid as uuid_lib
 from pathlib import Path
 
-import segno
 from dotenv import set_key
 from flask import Blueprint, current_app, flash, make_response, redirect, render_template, request, url_for
 from flask_login import login_required
 from sqlalchemy import distinct, func
+from werkzeug.utils import secure_filename
 
 from ...config import BASE_DIR, Config
 from ...extensions import cache, db
 from ...models import Link, Visit
+from ...services.qr_service import generate_qr_png, generate_qr_svg, parse_config
 from ...utils import invalidate_domain_cache, sanitize, shorten_with_isgd
 from ...validators import normalize_destination_url, normalize_optional_url, parse_bool, validate_slug
 
 
 bp = Blueprint("dashboard_links", __name__)
 SAFE_URL_DEFAULT = "https://www.google.com"
+UPLOAD_FOLDER_NAME = "qr_logos"
 
 
 def _mask_url_for_link(slug: str) -> str | None:
@@ -37,6 +40,18 @@ def _set_runtime_value(key: str, value):
 def _public_link_url(slug: str) -> str:
     base_url = current_app.config.get("SERVER_URL", "").rstrip("/")
     return f"{base_url}/{slug}" if base_url else f"/{slug}"
+
+
+def _qr_upload_dir() -> Path:
+    upload_dir = Path(current_app.root_path) / "data" / UPLOAD_FOLDER_NAME
+    upload_dir.mkdir(parents=True, exist_ok=True)
+    return upload_dir
+
+
+def _public_link_url_for_qr(link: Link) -> str:
+    if link.public_masked_url:
+        return link.public_masked_url
+    return _public_link_url(link.slug)
 
 
 def _coerce_int(value, default=0, minimum=None, maximum=None):
@@ -257,23 +272,93 @@ def edit_link(slug: str):
 @bp.route("/qr/<slug>")
 @login_required
 def qr_code(slug: str):
-    Link.query.filter_by(slug=slug).first_or_404()
-    full_url = _public_link_url(slug)
-    qr = segno.make(full_url)
-    buffer = io.BytesIO()
-    qr.save(buffer, kind="png", scale=10)
-    buffer.seek(0)
+    link = Link.query.filter_by(slug=slug).first_or_404()
+    config = parse_config(link.qr_config)
+    scale = min(_coerce_int(request.args.get("scale"), default=10, minimum=1, maximum=20), 20)
+    fmt = sanitize(request.args.get("format"), 10).lower() or "png"
 
-    response = make_response(buffer.getvalue())
+    for key in (
+        "fg_color",
+        "bg_color",
+        "gradient_color",
+        "gradient_direction",
+        "error_correction",
+        "dot_style",
+        "transparent_bg",
+    ):
+        val = request.args.get(key)
+        if val:
+            config[key] = val.lower() in {"1", "true", "yes", "on"} if key == "transparent_bg" else val
+
+    url = _public_link_url_for_qr(link)
+    if fmt == "svg":
+        svg_data = generate_qr_svg(url, config, scale=scale)
+        response = make_response(svg_data)
+        response.headers["Content-Type"] = "image/svg+xml"
+        response.headers["Content-Disposition"] = f"inline; filename=qr_{slug}.svg"
+        return response
+
+    png_data = generate_qr_png(url, config, scale=scale)
+    response = make_response(png_data)
     response.headers["Content-Type"] = "image/png"
-    response.headers["Content-Disposition"] = f"inline; filename={slug}_qr.png"
+    response.headers["Content-Disposition"] = f"inline; filename=qr_{slug}.png"
     return response
 
 
 @bp.route("/qr_view/<slug>")
 @login_required
 def qr_view(slug: str):
-    return render_template("qr_view.html", link=Link.query.filter_by(slug=slug).first_or_404())
+    link = Link.query.filter_by(slug=slug).first_or_404()
+    return render_template("qr_view.html", link=link, qr_config=parse_config(link.qr_config))
+
+
+@bp.route("/qr_save/<slug>", methods=["POST"])
+@login_required
+def qr_save(slug: str):
+    link = Link.query.filter_by(slug=slug).first_or_404()
+    config = parse_config(link.qr_config)
+
+    for key in ("fg_color", "bg_color", "gradient_direction", "error_correction", "dot_style"):
+        val = request.form.get(key, "").strip()
+        if val:
+            config[key] = val
+
+    gradient_enabled = "enable_gradient" in request.form
+    gradient_color = request.form.get("gradient_color", "").strip()
+    config["gradient_color"] = gradient_color if gradient_enabled and gradient_color else None
+    config["transparent_bg"] = "transparent_bg" in request.form
+
+    logo_file = request.files.get("logo_file")
+    if logo_file and logo_file.filename:
+        ext = Path(secure_filename(logo_file.filename)).suffix.lower()
+        if ext not in {".png", ".jpg", ".jpeg", ".webp", ".svg"}:
+            flash("Logo must be PNG, JPG, WEBP or SVG.", "error")
+            return redirect(url_for("dashboard.dashboard_links.qr_view", slug=slug))
+        fname = f"{slug}_{uuid_lib.uuid4().hex[:8]}{ext}"
+        save_path = _qr_upload_dir() / fname
+        logo_file.save(str(save_path))
+        if config.get("logo_path") and Path(config["logo_path"]).exists():
+            try:
+                os.remove(config["logo_path"])
+            except OSError:
+                pass
+        config["logo_path"] = str(save_path)
+        config["error_correction"] = "H"
+
+    if request.form.get("remove_logo") == "1":
+        if config.get("logo_path") and Path(config["logo_path"]).exists():
+            try:
+                os.remove(config["logo_path"])
+            except OSError:
+                pass
+        config["logo_path"] = None
+
+    import json as _json
+
+    link.qr_config = _json.dumps(parse_config(_json.dumps(config)), sort_keys=True)
+    db.session.commit()
+    flash("QR configuration saved.", "success")
+    return redirect(url_for("dashboard.dashboard_links.qr_view", slug=slug))
 
 
 @bp.route("/settings", methods=["GET", "POST"])

--- a/server/routes/dashboard/links.py
+++ b/server/routes/dashboard/links.py
@@ -4,10 +4,10 @@ from pathlib import Path
 
 from dotenv import set_key
 from flask import Blueprint, current_app, flash, make_response, redirect, render_template, request, url_for
-from flask_login import login_required
 from sqlalchemy import distinct, func
 from werkzeug.utils import secure_filename
 
+from ...auth_middleware import login_required
 from ...config import BASE_DIR, Config
 from ...extensions import cache, db
 from ...models import Link, Visit

--- a/server/routes/dashboard/links.py
+++ b/server/routes/dashboard/links.py
@@ -1,5 +1,6 @@
 import os
 import uuid as uuid_lib
+import json
 from pathlib import Path
 
 from dotenv import set_key
@@ -99,6 +100,32 @@ def _link_form_values(form):
     }
 
 
+def _flow_config_from_form(form, slug: str, destination: str) -> str | None:
+    raw_flow = sanitize(form.get("flow_config"), 20000)
+    if raw_flow:
+        try:
+            parsed = json.loads(raw_flow)
+        except (TypeError, ValueError):
+            parsed = None
+        if isinstance(parsed, dict):
+            return json.dumps(parsed, sort_keys=True)
+    return json.dumps(
+        {
+            "version": 1,
+            "nodes": [
+                {"id": "entry", "type": "entry", "label": f"/{slug}"},
+                {"id": "risk", "type": "decision", "label": "VPN / bot score"},
+                {"id": "route", "type": "route", "label": destination},
+            ],
+            "edges": [
+                {"source": "entry", "target": "risk"},
+                {"source": "risk", "target": "route"},
+            ],
+        },
+        sort_keys=True,
+    )
+
+
 @bp.route("/")
 @bp.route("")
 @login_required
@@ -176,6 +203,7 @@ def create_link():
         return redirect(url_for("dashboard.dashboard_links.dashboard_home"))
 
     link.public_masked_url = _mask_url_for_link(slug)
+    link.flow_config = _flow_config_from_form(request.form, slug, link.destination)
     db.session.add(link)
     db.session.commit()
     flash(f"Link created: {_public_link_url(slug)}", "success")
@@ -210,6 +238,7 @@ def create_full():
             return redirect(url_for("dashboard.dashboard_links.create_full"))
 
         link = Link(slug=slug, **values)
+        link.flow_config = _flow_config_from_form(request.form, slug, values["destination"])
         password = request.form.get("password", "")
         if sanitize(password, 255):
             import hashlib

--- a/server/routes/dashboard/passkey.py
+++ b/server/routes/dashboard/passkey.py
@@ -3,7 +3,6 @@ import json
 from datetime import datetime
 
 from flask import Blueprint, jsonify, request
-from flask_login import current_user, login_required
 from webauthn import generate_registration_options, options_to_json, verify_registration_response
 from webauthn.helpers.cose import COSEAlgorithmIdentifier
 from webauthn.helpers.structs import (
@@ -13,6 +12,7 @@ from webauthn.helpers.structs import (
     UserVerificationRequirement,
 )
 
+from ...auth_middleware import current_local_user, login_required
 from ...config import Config
 from ...extensions import db
 from ...models import User
@@ -26,10 +26,19 @@ def _passkey_rp_id() -> str:
     return Config.SERVER_URL.replace("https://", "").replace("http://", "").split(":")[0].split("/")[0]
 
 
+def _current_dashboard_user():
+    user = current_local_user()
+    if user is None:
+        return None
+    return user
+
+
 @bp.route("/passkey/register/options", methods=["POST"])
 @login_required
 def passkey_register_options():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return jsonify({"error": "Supabase session is not linked to a local security profile"}), 400
     existing_credentials = []
     for item in user.passkeys:
         try:
@@ -80,7 +89,9 @@ def passkey_register_verify():
     except Exception as exc:
         return jsonify({"status": "error", "message": str(exc)}), 400
 
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return jsonify({"status": "error", "message": "Supabase session is not linked to a local security profile"}), 400
     credentials = safe_json(user.passkey_credentials, []) or []
     credentials.append(
         {
@@ -100,14 +111,18 @@ def passkey_register_verify():
 @bp.route("/passkey/list")
 @login_required
 def passkey_list():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return jsonify([])
     return jsonify(user.passkeys)
 
 
 @bp.route("/passkey/delete/<credential_id>", methods=["POST"])
 @login_required
 def passkey_delete(credential_id):
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return jsonify({"success": False, "error": "Supabase session is not linked to a local security profile"}), 400
     credentials = [item for item in user.passkeys if item.get("id") != credential_id]
     user.passkey_credentials = json.dumps(credentials)
     db.session.commit()

--- a/server/routes/dashboard/security.py
+++ b/server/routes/dashboard/security.py
@@ -7,9 +7,9 @@ import bcrypt
 import pyotp
 import qrcode
 from flask import Blueprint, flash, redirect, render_template, request, session, url_for
-from flask_login import current_user, login_required
 from werkzeug.security import check_password_hash, generate_password_hash
 
+from ...auth_middleware import current_local_user, login_required
 from ...extensions import db
 from ...models import SetupState, User
 from ...utils import sanitize
@@ -27,10 +27,19 @@ def _setup_state() -> SetupState:
     return state
 
 
+def _current_dashboard_user():
+    user = current_local_user()
+    if user is None:
+        flash("Your Supabase session is not linked to a local security profile yet.", "error")
+    return user
+
+
 @bp.route("/security")
 @login_required
 def security_settings():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
     return render_template(
         "security_settings.html",
         user=user,
@@ -43,7 +52,9 @@ def security_settings():
 @bp.route("/security/2fa/setup")
 @login_required
 def setup_2fa():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
     if user.totp_enabled:
         flash("2FA is already enabled.", "warning")
         return redirect(url_for("dashboard.dashboard_security.security_settings"))
@@ -73,7 +84,9 @@ def setup_2fa():
 @bp.route("/security/2fa/verify_setup", methods=["POST"])
 @login_required
 def verify_2fa_setup():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
     secret = session.get("temp_totp_secret")
     if not secret:
         flash("Session expired. Please start setup again.", "error")
@@ -111,7 +124,9 @@ def show_backup_codes():
 @bp.route("/security/2fa/regenerate_backup", methods=["POST"])
 @login_required
 def regenerate_backup_codes():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
     if not user.totp_enabled:
         flash("2FA is not enabled.", "error")
         return redirect(url_for("dashboard.dashboard_security.security_settings"))
@@ -129,7 +144,9 @@ def regenerate_backup_codes():
 @bp.route("/security/2fa/disable", methods=["POST"])
 @login_required
 def disable_2fa():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
     password = request.form.get("password", "")
     if not check_password_hash(user.password_hash, password):
         flash("Incorrect password.", "error")
@@ -146,7 +163,9 @@ def disable_2fa():
 @bp.route("/security/password", methods=["POST"])
 @login_required
 def change_password():
-    user = db.session.get(User, current_user.id)
+    user = _current_dashboard_user()
+    if user is None:
+        return redirect(url_for("auth.login"))
     current_password = request.form.get("current_password", "")
     new_password = request.form.get("new_password", "")
     confirm_password = request.form.get("confirm_password", "")

--- a/server/routes/dashboard/stats.py
+++ b/server/routes/dashboard/stats.py
@@ -3,10 +3,10 @@ from collections import defaultdict
 from datetime import datetime, timedelta
 
 from flask import Blueprint, flash, redirect, render_template, request, url_for
-from flask_login import login_required
 from sqlalchemy import func
 from sqlalchemy.orm import joinedload
 
+from ...auth_middleware import login_required
 from ...extensions import db
 from ...models import Link, Visit, Visitor
 from ...services.scoring import SIGNAL_WEIGHTS

--- a/server/routes/dashboard/stats.py
+++ b/server/routes/dashboard/stats.py
@@ -8,7 +8,8 @@ from sqlalchemy import func
 from sqlalchemy.orm import joinedload
 
 from ...extensions import db
-from ...models import Link, Visit
+from ...models import Link, Visit, Visitor
+from ...services.scoring import SIGNAL_WEIGHTS
 from ...utils import safe_json, sanitize
 
 
@@ -36,6 +37,15 @@ def _visit_search_filter(search_term: str):
         Visit.webgl_renderer.ilike(search_term),
         Visit.webgl_vendor.ilike(search_term),
         Visit.fingerprint_composite_v1.ilike(search_term),
+        Visit.thumbmark_hash.ilike(search_term),
+        Visit.thumbmark_visitor_id.ilike(search_term),
+        Visit.fp_canvas_hash.ilike(search_term),
+        Visit.fp_audio_hash.ilike(search_term),
+        Visit.fp_webgl_hash.ilike(search_term),
+        Visit.fp_fonts_hash.ilike(search_term),
+        Visit.fp_screen_profile.ilike(search_term),
+        Visit.fp_hardware_profile.ilike(search_term),
+        Visit.fp_timezone.ilike(search_term),
         Visit.etag.ilike(search_term),
         Visit.review_label.ilike(search_term),
         Visit.match_reasons_json.ilike(search_term),
@@ -101,6 +111,7 @@ def _apply_visit_filters(visit_query, filters: dict):
         visit_query = visit_query.filter(
             db.or_(
                 Visit.fingerprint_composite_v1.isnot(None),
+                Visit.thumbmark_hash.isnot(None),
                 Visit.canvas_hash.isnot(None),
                 Visit.etag.isnot(None),
             )
@@ -459,93 +470,189 @@ def cross_tracking():
 @bp.route("/graph")
 @login_required
 def graph():
-    visits = (
-        Visit.query.options(joinedload(Visit.link))
-        .filter(
-            db.or_(
-                Visit.canvas_hash.isnot(None),
-                Visit.fingerprint_composite_v1.isnot(None),
-                Visit.etag.isnot(None),
-                Visit.email.isnot(None),
-                Visit.ip_address.isnot(None),
-            )
+    node_meta = {
+        "visitor": ("#00C853", "person"),
+        "email": ("#FF6D00", "email"),
+        "thumbmark_visitor_id": ("#00BCD4", "fingerprint"),
+        "thumbmark_hash": ("#26C6DA", "fingerprint"),
+        "canvas_hash": ("#AB47BC", "brush"),
+        "audio_hash": ("#EC407A", "music_note"),
+        "webgl_hash": ("#7E57C2", "cube"),
+        "fonts_hash": ("#5C6BC0", "font_download"),
+        "speech_hash": ("#29B6F6", "record_voice"),
+        "hardware_profile": ("#FFA726", "memory"),
+        "screen_profile": ("#FFCA28", "monitor"),
+        "timezone": ("#66BB6A", "schedule"),
+        "ip_address": ("#8D6E63", "dns"),
+        "webrtc_ip": ("#78909C", "router"),
+        "language": ("#9CCC65", "language"),
+        "math_hash": ("#26A69A", "functions"),
+        "media_devices": ("#FF7043", "devices"),
+        "visit": ("#455A64", "link"),
+    }
+    edge_labels = {
+        "thumbmark_visitor_id": "has api id",
+        "thumbmark_hash": "has fingerprint",
+        "email": "captured email",
+        "canvas_hash": "canvas signal",
+        "audio_hash": "audio signal",
+        "webgl_hash": "webgl signal",
+        "fonts_hash": "fonts signal",
+        "hardware_profile": "hardware signal",
+        "speech_hash": "speech signal",
+        "screen_profile": "screen signal",
+        "ip_address": "seen from ip",
+        "webrtc_ip": "webrtc signal",
+        "timezone": "timezone signal",
+        "language": "language signal",
+        "math_hash": "math signal",
+        "media_devices": "media devices",
+    }
+
+    def signal_label(signal_type: str, value: str) -> str:
+        prefixes = {
+            "thumbmark_visitor_id": "TM",
+            "thumbmark_hash": "FP",
+            "canvas_hash": "CVS",
+            "audio_hash": "AUD",
+            "webgl_hash": "WGL",
+            "fonts_hash": "FNT",
+            "speech_hash": "SPK",
+            "webrtc_ip": "LAN",
+        }
+        if signal_type in {"hardware_profile", "screen_profile", "timezone", "ip_address", "language", "media_devices"}:
+            return value
+        prefix = prefixes.get(signal_type)
+        if prefix:
+            return f"{prefix}-{value[:12] if signal_type == 'thumbmark_visitor_id' else value[:10]}"
+        return value[:18]
+
+    nodes = {}
+    edge_map = {}
+
+    def add_node(node_id: str, node_type: str, label: str, **extra):
+        color, icon = node_meta.get(node_type, ("#94a3b8", "circle"))
+        existing = nodes.get(node_id)
+        occurrence_count = int(extra.pop("occurrence_count", 1) or 1)
+        if existing:
+            existing["occurrence_count"] = existing.get("occurrence_count", 1) + occurrence_count
+            existing.update({key: value for key, value in extra.items() if value is not None})
+            return
+        nodes[node_id] = {
+            "id": node_id,
+            "type": node_type,
+            "label": label,
+            "color": color,
+            "icon": icon,
+            "occurrence_count": occurrence_count,
+            **extra,
+        }
+
+    def add_edge(source: str, target: str, label: str, weight: int = 1, **extra):
+        key = (source, target, label, bool(extra.get("dashed")))
+        edge = edge_map.setdefault(
+            key,
+            {
+                "source": source,
+                "target": target,
+                "label": label,
+                "weight": weight,
+                **extra,
+            },
         )
-        .order_by(Visit.timestamp.desc())
+        edge["weight"] = max(edge.get("weight") or 0, weight or 0)
+
+    visitors = (
+        Visitor.query.options(
+            joinedload(Visitor.signals),
+            joinedload(Visitor.visits),
+        )
+        .order_by(Visitor.last_seen.desc().nullslast(), Visitor.created_at.desc())
+        .limit(500)
         .all()
     )
 
-    nodes = {}
-    edge_weights = defaultdict(int)
+    for visitor in visitors:
+        visitor_id = f"visitor:{visitor.id}"
+        confidence = max((visit.identity_confidence or 0 for visit in visitor.visits), default=0)
+        add_node(
+            visitor_id,
+            "visitor",
+            f"VIS-{str(visitor.id)[:8]}",
+            confidence=confidence,
+            url=url_for("dashboard.dashboard_stats.global_timeline", q=visitor.id),
+        )
 
-    for visit in visits:
-        if not visit.link:
-            continue
+        if visitor.probable_match_id:
+            target_id = f"visitor:{visitor.probable_match_id}"
+            add_node(target_id, "visitor", f"VIS-{str(visitor.probable_match_id)[:8]}")
+            add_edge(visitor_id, target_id, "probable match", 1, dashed=True)
 
-        slug_value = visit.link.slug
-        slug_id = f"slug:{slug_value}"
-        nodes[slug_id] = {
-            "id": slug_id,
-            "type": "slug",
-            "label": slug_value,
-            "url": url_for("dashboard.dashboard_stats.stats", slug=slug_value),
-        }
-
-        signal_nodes = []
-        signal_values = [
-            ("hash", visit.canvas_hash, visit.canvas_hash),
-            ("composite", visit.fingerprint_composite_v1, visit.fingerprint_composite_v1),
-            ("etag", visit.etag, visit.etag),
-            ("ip", visit.ip_address, None),
-        ]
-        for signal_type, signal_value, profile_fingerprint in signal_values:
-            if not signal_value:
+        for signal in visitor.signals:
+            if signal.signal_type not in node_meta:
                 continue
-            signal_id = f"{signal_type}:{signal_value}"
-            nodes[signal_id] = {
-                "id": signal_id,
-                "type": signal_type,
-                "label": signal_value[:10] if signal_type != "ip" else signal_value,
-                "url": (
-                    url_for("dashboard.dashboard_stats.device_profile", fingerprint=profile_fingerprint)
-                    if profile_fingerprint
-                    else url_for("dashboard.dashboard_stats.global_timeline", q=signal_value)
-                ),
-            }
-            edge_weights[(signal_id, slug_id)] += 1
-            signal_nodes.append(signal_id)
+            signal_id = f"signal:{signal.signal_type}:{signal.signal_value}"
+            add_node(
+                signal_id,
+                signal.signal_type,
+                signal_label(signal.signal_type, signal.signal_value),
+                weight=signal.confidence_weight,
+                occurrence_count=signal.occurrence_count,
+                url=url_for("dashboard.dashboard_stats.global_timeline", q=signal.signal_value),
+            )
+            add_edge(
+                visitor_id,
+                signal_id,
+                edge_labels.get(signal.signal_type, f"{signal.signal_type} signal"),
+                signal.confidence_weight or SIGNAL_WEIGHTS.get(signal.signal_type, 1),
+            )
 
-        if visit.email:
-            email_value = visit.email
-            email_id = f"email:{email_value}"
-            nodes[email_id] = {
-                "id": email_id,
-                "type": "email",
-                "label": email_value,
-                "url": url_for("dashboard.dashboard_stats.global_search", q=email_value),
-            }
-            edge_weights[(email_id, slug_id)] += 1
-            for signal_id in signal_nodes:
-                edge_weights[(signal_id, email_id)] += 1
+        for visit in sorted(visitor.visits, key=lambda item: item.timestamp or datetime.min, reverse=True)[:25]:
+            visit_id = f"visit:{visit.id}"
+            label_date = (visit.timestamp or datetime.utcnow()).date()
+            add_node(
+                visit_id,
+                "visit",
+                f"Visit {label_date}",
+                occurrence_count=1,
+                url=url_for("dashboard.dashboard_stats.global_timeline", q=str(visit.id)),
+            )
+            if visit.probable_visitor_id:
+                add_edge(visitor_id, f"visitor:{visit.probable_visitor_id}", "probable match", 1, dashed=True)
+            if visit.thumbmark_hash:
+                signal_id = f"signal:thumbmark_hash:{visit.thumbmark_hash}"
+                add_node(
+                    signal_id,
+                    "thumbmark_hash",
+                    signal_label("thumbmark_hash", visit.thumbmark_hash),
+                    weight=SIGNAL_WEIGHTS["thumbmark_hash"],
+                    url=url_for("dashboard.dashboard_stats.global_timeline", q=visit.thumbmark_hash),
+                )
+                add_edge(signal_id, visit_id, "recorded in", 1)
 
     degrees = defaultdict(int)
-    for (source, target), weight in edge_weights.items():
-        degrees[source] += weight
-        degrees[target] += weight
+    for edge in edge_map.values():
+        weight = edge.get("weight") or 1
+        degrees[edge["source"]] += weight
+        degrees[edge["target"]] += weight
 
-    top_node_ids = {
-        node_id
-        for node_id, _degree in sorted(
-            degrees.items(),
-            key=lambda item: (-item[1], item[0]),
-        )[:500]
-    }
+    if degrees:
+        top_node_ids = {
+            node_id
+            for node_id, _degree in sorted(
+                degrees.items(),
+                key=lambda item: (-item[1], item[0]),
+            )[:700]
+        }
+    else:
+        top_node_ids = set(nodes)
 
     filtered_nodes = [node for node_id, node in nodes.items() if node_id in top_node_ids]
-    filtered_links = [
-        {"source": source, "target": target, "weight": weight}
-        for (source, target), weight in edge_weights.items()
-        if source in top_node_ids and target in top_node_ids
+    filtered_edges = [
+        edge
+        for edge in edge_map.values()
+        if edge["source"] in top_node_ids and edge["target"] in top_node_ids
     ]
 
-    graph_data = json.dumps({"nodes": filtered_nodes, "links": filtered_links})
+    graph_data = json.dumps({"nodes": filtered_nodes, "edges": filtered_edges, "links": filtered_edges})
     return render_template("graph.html", graph_data=graph_data)

--- a/server/routes/public.py
+++ b/server/routes/public.py
@@ -70,7 +70,7 @@ _CLOUD_KEYWORDS = (
 
 @bp.route("/", methods=["GET"])
 def index():
-    if Config.ADMIN_BOOTSTRAP_ENABLED and User.query.count() == 0:
+    if Config.ADMIN_BOOTSTRAP_ENABLED and not Config.SUPABASE_URL and User.query.count() == 0:
         return redirect(url_for("auth.setup"))
     return redirect(url_for("auth.login"))
 

--- a/server/routes/public.py
+++ b/server/routes/public.py
@@ -8,8 +8,9 @@ from flask import Blueprint, abort, current_app, make_response, redirect, render
 from user_agents import parse
 
 from ..config import Config
-from ..extensions import cache, db, limiter, log_queue
+from ..extensions import cache, csrf, db, limiter, log_queue
 from ..models import Link, User, Visit
+from ..services.thumbmark import store_thumbmark_payload
 from ..utils import (
     anonymize_ip,
     generate_slug,
@@ -22,6 +23,7 @@ from ..utils import (
     should_require_consent,
     sign_visit_token,
     validate_email_strict,
+    verify_visit_token,
     verify_turnstile,
 )
 from ..validators import get_client_ip, normalize_destination_url
@@ -101,7 +103,7 @@ def _visit_from_form(value):
 def _build_public_csp(nonce: str) -> str:
     return (
         "default-src 'self'; "
-        f"script-src 'self' 'nonce-{nonce}' https://challenges.cloudflare.com; "
+        f"script-src 'self' 'nonce-{nonce}' https://challenges.cloudflare.com https://cdn.jsdelivr.net; "
         "style-src 'self' 'unsafe-inline' https://cdnjs.cloudflare.com https://fonts.googleapis.com; "
         "font-src 'self' https://cdnjs.cloudflare.com https://fonts.gstatic.com; "
         "img-src 'self' data: blob: https://flagcdn.com https://*.gravatar.com; "
@@ -120,6 +122,41 @@ def _public_response(template_name: str, status: int = 200, **kwargs):
         response = make_response(render_template(template_name, **kwargs))
     response.status_code = status
     return response
+
+
+def enrich_visit_async(visit_id: int) -> None:
+    try:
+        log_queue.put({"type": "enrich_visit", "visit_id": visit_id, "notify": False, "thumbmark_api": True})
+    except Exception:
+        pass
+
+
+@csrf.exempt
+@bp.route("/fp", methods=["POST"])
+@limiter.limit("60 per minute")
+def collect_fingerprint():
+    data = request.get_json(silent=True) or {}
+    visit_id = verify_visit_token(data.get("visit_token") or data.get("token"), Config.VISIT_TOKEN_TTL_SECONDS)
+    if visit_id is None and not Config.REQUIRE_VISIT_TOKEN:
+        try:
+            visit_id = int(data.get("visit_id"))
+        except (TypeError, ValueError):
+            visit_id = None
+
+    visit = db.session.get(Visit, visit_id) if visit_id else None
+    if visit is None:
+        return "", 204
+
+    try:
+        store_thumbmark_payload(visit, data)
+        visit.beacon_received_at = datetime.utcnow()
+        visit.visit_complete = True
+        db.session.commit()
+        enrich_visit_async(visit.id)
+    except Exception as exc:
+        print(f"Fingerprint collect error: {exc}")
+        db.session.rollback()
+    return "", 204
 
 
 def _detect_vpn_or_cloud(geo: dict) -> bool:

--- a/server/services/qr_service.py
+++ b/server/services/qr_service.py
@@ -1,0 +1,206 @@
+"""
+QR code generation service.
+Uses segno for QR encoding and Pillow for gradients, dot styles, and logo compositing.
+"""
+
+import io
+import json
+import math
+import re
+from pathlib import Path
+from typing import Optional
+
+from PIL import Image, ImageDraw
+
+try:
+    import segno
+except ImportError:  # pragma: no cover - requirements include segno
+    segno = None
+
+
+DEFAULT_CONFIG = {
+    "fg_color": "#000000",
+    "bg_color": "#ffffff",
+    "gradient_color": None,
+    "gradient_direction": "diagonal",
+    "error_correction": "M",
+    "dot_style": "square",
+    "logo_path": None,
+    "transparent_bg": False,
+}
+
+ERROR_LEVELS = {"L", "M", "Q", "H"}
+GRADIENT_DIRECTIONS = {"horizontal", "vertical", "diagonal", "radial"}
+DOT_STYLES = {"square", "rounded", "circle"}
+LOGO_MIN_EC = "H"
+HEX_RE = re.compile(r"^#?(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$")
+
+
+def _normalize_hex(value: object, default: str) -> str:
+    if not isinstance(value, str) or not HEX_RE.match(value.strip()):
+        return default
+    value = value.strip()
+    if not value.startswith("#"):
+        value = f"#{value}"
+    if len(value) == 4:
+        value = "#" + "".join(ch * 2 for ch in value[1:])
+    return value.upper()
+
+
+def parse_config(qr_config_json: Optional[str]) -> dict:
+    """Parse and validate qr_config JSON, filling defaults for missing keys."""
+    cfg = dict(DEFAULT_CONFIG)
+    if qr_config_json:
+        try:
+            override = json.loads(qr_config_json)
+        except (json.JSONDecodeError, TypeError):
+            override = {}
+        if isinstance(override, dict):
+            for key in DEFAULT_CONFIG:
+                if key in override and override[key] is not None:
+                    cfg[key] = override[key]
+
+    cfg["fg_color"] = _normalize_hex(cfg.get("fg_color"), DEFAULT_CONFIG["fg_color"])
+    cfg["bg_color"] = _normalize_hex(cfg.get("bg_color"), DEFAULT_CONFIG["bg_color"])
+    cfg["gradient_color"] = (
+        _normalize_hex(cfg.get("gradient_color"), DEFAULT_CONFIG["fg_color"])
+        if cfg.get("gradient_color")
+        else None
+    )
+    cfg["gradient_direction"] = (
+        str(cfg.get("gradient_direction"))
+        if str(cfg.get("gradient_direction")) in GRADIENT_DIRECTIONS
+        else DEFAULT_CONFIG["gradient_direction"]
+    )
+    cfg["error_correction"] = (
+        str(cfg.get("error_correction", "M")).upper()
+        if str(cfg.get("error_correction", "M")).upper() in ERROR_LEVELS
+        else DEFAULT_CONFIG["error_correction"]
+    )
+    cfg["dot_style"] = (
+        str(cfg.get("dot_style"))
+        if str(cfg.get("dot_style")) in DOT_STYLES
+        else DEFAULT_CONFIG["dot_style"]
+    )
+    cfg["transparent_bg"] = bool(cfg.get("transparent_bg"))
+    cfg["logo_path"] = str(cfg.get("logo_path")) if cfg.get("logo_path") else None
+    return cfg
+
+
+def _hex_to_rgb(hex_color: str) -> tuple[int, int, int]:
+    hex_color = _normalize_hex(hex_color, "#000000").lstrip("#")
+    return tuple(int(hex_color[i : i + 2], 16) for i in (0, 2, 4))
+
+
+def _gradient_color_at(x: int, y: int, w: int, h: int, c1: tuple[int, int, int], c2: tuple[int, int, int], direction: str):
+    if direction == "horizontal":
+        t = x / max(w - 1, 1)
+    elif direction == "vertical":
+        t = y / max(h - 1, 1)
+    elif direction == "radial":
+        cx, cy = w / 2, h / 2
+        dist = math.sqrt((x - cx) ** 2 + (y - cy) ** 2)
+        t = min(dist / max(math.sqrt(cx**2 + cy**2), 1), 1.0)
+    else:
+        t = (x / max(w - 1, 1) + y / max(h - 1, 1)) / 2
+    return tuple(int(c1[idx] + (c2[idx] - c1[idx]) * t) for idx in range(3))
+
+
+def _render_matrix(qr, config: dict, scale: int) -> Image.Image:
+    matrix = tuple(qr.matrix)
+    module_count = len(matrix)
+    border = int(getattr(qr, "default_border_size", 4) or 4)
+    size = (module_count + border * 2) * scale
+    bg = (255, 255, 255, 0) if config.get("transparent_bg") else (*_hex_to_rgb(config["bg_color"]), 255)
+    img = Image.new("RGBA", (size, size), bg)
+    draw = ImageDraw.Draw(img)
+    c1 = _hex_to_rgb(config["fg_color"])
+    c2 = _hex_to_rgb(config["gradient_color"] or config["fg_color"])
+    direction = config.get("gradient_direction", "diagonal")
+    dot_style = config.get("dot_style", "square")
+    radius = max(1, int(scale * 0.36))
+
+    for row_idx, row in enumerate(matrix):
+        for col_idx, module in enumerate(row):
+            if not module:
+                continue
+            x0 = (col_idx + border) * scale
+            y0 = (row_idx + border) * scale
+            x1 = x0 + scale
+            y1 = y0 + scale
+            color = (*_gradient_color_at(x0, y0, size, size, c1, c2, direction), 255)
+            if dot_style == "circle":
+                inset = max(1, scale // 8)
+                draw.ellipse((x0 + inset, y0 + inset, x1 - inset, y1 - inset), fill=color)
+            elif dot_style == "rounded":
+                draw.rounded_rectangle((x0, y0, x1, y1), radius=radius, fill=color)
+            else:
+                draw.rectangle((x0, y0, x1, y1), fill=color)
+    return img
+
+
+def _apply_logo(img: Image.Image, logo_path: str) -> Image.Image:
+    try:
+        logo = Image.open(logo_path).convert("RGBA")
+    except Exception:
+        return img
+
+    qr_w, qr_h = img.size
+    max_logo = int(qr_w * 0.25)
+    lw, lh = logo.size
+    if not lw or not lh:
+        return img
+    scale = min(max_logo / lw, max_logo / lh)
+    logo = logo.resize((max(1, int(lw * scale)), max(1, int(lh * scale))), Image.LANCZOS)
+
+    pad = max(6, qr_w // 64)
+    bg = Image.new("RGBA", (logo.width + pad * 2, logo.height + pad * 2), (255, 255, 255, 255))
+    mask = Image.new("L", bg.size, 0)
+    ImageDraw.Draw(mask).rounded_rectangle((0, 0, bg.width - 1, bg.height - 1), radius=pad * 2, fill=255)
+    padded = Image.new("RGBA", bg.size, (255, 255, 255, 0))
+    padded.paste(bg, (0, 0), mask)
+    padded.paste(logo, (pad, pad), logo)
+
+    result = img.copy().convert("RGBA")
+    pos = ((qr_w - padded.width) // 2, (qr_h - padded.height) // 2)
+    result.paste(padded, pos, padded)
+    return result
+
+
+def _effective_error_correction(config: dict) -> str:
+    return LOGO_MIN_EC if config.get("logo_path") else config.get("error_correction", "M")
+
+
+def generate_qr_png(url: str, config: dict, scale: int = 10) -> bytes:
+    """Generate QR code as PNG bytes."""
+    if segno is None:
+        raise RuntimeError("segno is required to generate QR codes")
+    config = parse_config(json.dumps(config))
+    ec = _effective_error_correction(config)
+    qr = segno.make_qr(url, error=ec.lower())
+    img = _render_matrix(qr, config, max(1, min(int(scale), 20)))
+    logo_path = config.get("logo_path")
+    if logo_path and Path(logo_path).exists():
+        img = _apply_logo(img, logo_path)
+
+    out = io.BytesIO()
+    img.save(out, format="PNG")
+    return out.getvalue()
+
+
+def generate_qr_svg(url: str, config: dict, scale: int = 10) -> str:
+    """Generate QR code as SVG string. Gradients, dot styles, and logos are PNG-only."""
+    if segno is None:
+        raise RuntimeError("segno is required to generate QR codes")
+    config = parse_config(json.dumps(config))
+    ec = _effective_error_correction(config)
+    qr = segno.make_qr(url, error=ec.lower())
+    buffer = io.BytesIO()
+    qr.save(
+        buffer,
+        kind="svg",
+        scale=max(1, min(int(scale), 20)),
+        dark=config["fg_color"],
+        light=None if config.get("transparent_bg") else config["bg_color"],
+    )
+    return buffer.getvalue().decode("utf-8")

--- a/server/services/scoring.py
+++ b/server/services/scoring.py
@@ -517,6 +517,7 @@ def apply_visit_scoring(
     best_reasons: list[str] = []
     best_conflicts: list[str] = []
     matched_visit_id = None
+    legacy_visitor_id = None
 
     for candidate in _load_candidates(visit, visit.fingerprint_composite_v1):
         candidate_score, reasons, conflicts = _score_identity_against(visit, candidate, components)
@@ -530,9 +531,15 @@ def apply_visit_scoring(
         matched_visit = db.session.get(Visit, matched_visit_id)
         if matched_visit is not None:
             _ensure_visitor_for_visit(matched_visit)
+            legacy_visitor_id = matched_visit.visitor_id
 
     allow_signal_reassign = bool(visit.visitor_id and (visit.identity_confidence or 0) < PROBABLE_THRESHOLD)
     visitor_id, signal_score, signal_reasons = match_visitor(visit, allow_reassign=allow_signal_reassign)
+    if legacy_visitor_id and legacy_visitor_id != visitor_id:
+        best_score = 0
+        best_reasons = []
+        best_conflicts.append("identity_system_mismatch")
+        matched_visit_id = None
     identity_score = max(best_score, signal_score)
     identity_reasons = _ordered_unique(best_reasons + signal_reasons)
 

--- a/server/services/scoring.py
+++ b/server/services/scoring.py
@@ -1,16 +1,45 @@
 import ipaddress
 import json
+from datetime import datetime
 
 from sqlalchemy import or_
 
 from ..config import Config
-from ..models import Visit
+from ..extensions import db
+from ..models import Visit, Visitor, VisitorSignal
 from .fingerprint import FINGERPRINT_VERSION, composite_fingerprint, fingerprint_components
+from .thumbmark import maybe_enrich_thumbmark_api
 
 
 IDENTITY_STRONG_THRESHOLD = 70
 IDENTITY_POSSIBLE_THRESHOLD = 40
 RISK_ALERT_THRESHOLD = 50
+MATCH_THRESHOLD = 60
+PROBABLE_THRESHOLD = 30
+
+SIGNAL_WEIGHTS = {
+    "email": 40,
+    "thumbmark_visitor_id": 35,
+    "thumbmark_hash": 20,
+    "audio_hash": 18,
+    "canvas_hash": 18,
+    "webgl_hash": 15,
+    "fonts_hash": 12,
+    "hardware_profile": 10,
+    "speech_hash": 10,
+    "webrtc_ip": 10,
+    "math_hash": 8,
+    "screen_profile": 8,
+    "timezone": 6,
+    "language": 5,
+    "media_devices": 5,
+    "ip_address": 5,
+}
+
+PENALTIES = {
+    "vpn_datacenter": -10,
+    "known_bot": -50,
+}
 
 
 _COUNTRY_TIMEZONE_REGIONS = {
@@ -170,6 +199,265 @@ def _score_identity_against(visit: Visit, candidate: Visit, current_components: 
     return max(0, min(100, score)), reasons, conflicts
 
 
+def _ordered_unique(values: list[str]) -> list[str]:
+    seen = set()
+    result = []
+    for value in values:
+        if value not in seen:
+            seen.add(value)
+            result.append(value)
+    return result
+
+
+def _json_array_append(payload: str | None, value: str | None) -> str | None:
+    if not value:
+        return payload
+    try:
+        items = json.loads(payload or "[]")
+    except (TypeError, ValueError):
+        items = []
+    if not isinstance(items, list):
+        items = []
+    if value not in items:
+        items.append(value)
+    return json.dumps(items)
+
+
+def _normalize_signal_value(value) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        value = json.dumps(value, sort_keys=True, separators=(",", ":"))
+    value = str(value).strip()
+    return value if value else None
+
+
+def _first_csv(value: str | None) -> str | None:
+    if not value:
+        return None
+    return next((part.strip() for part in value.split(",") if part.strip()), None)
+
+
+def _legacy_screen_profile(visit: Visit) -> str | None:
+    if not visit.screen_res:
+        return None
+    depth = visit.screen_depth if visit.screen_depth is not None else 0
+    ratio = visit.pixel_ratio if visit.pixel_ratio is not None else 1
+    return f"{visit.screen_res}x{depth}@{ratio}"
+
+
+def _legacy_hardware_profile(visit: Visit) -> str | None:
+    if visit.cpu_cores is None and visit.ram_gb is None and visit.touch_points is None:
+        return None
+    cores = visit.cpu_cores or 0
+    memory = visit.ram_gb or 0
+    touch = visit.touch_points or 0
+    return f"{cores}c/{memory}gb/{touch}tp"
+
+
+def _legacy_webrtc_ip(visit: Visit) -> str | None:
+    if not visit.webrtc_ips:
+        return None
+    try:
+        values = json.loads(visit.webrtc_ips)
+    except (TypeError, ValueError):
+        values = visit.webrtc_ips.split(",")
+    if not isinstance(values, list):
+        return None
+    for value in values:
+        normalized = _normalize_signal_value(value)
+        if normalized:
+            return normalized
+    return None
+
+
+def _extract_signals_from_visit(visit: Visit) -> dict[str, str]:
+    signals = {
+        "thumbmark_visitor_id": visit.thumbmark_visitor_id,
+        "thumbmark_hash": visit.thumbmark_hash,
+        "canvas_hash": visit.fp_canvas_hash or visit.canvas_hash,
+        "audio_hash": visit.fp_audio_hash or visit.audio_fp,
+        "webgl_hash": visit.fp_webgl_hash or visit.webgl_extensions_hash,
+        "fonts_hash": visit.fp_fonts_hash or visit.fonts,
+        "screen_profile": visit.fp_screen_profile or _legacy_screen_profile(visit),
+        "hardware_profile": visit.fp_hardware_profile or _legacy_hardware_profile(visit),
+        "language": _first_csv(visit.fp_languages) or visit.browser_language,
+        "timezone": visit.fp_timezone or visit.timezone,
+        "speech_hash": visit.fp_speech_hash,
+        "math_hash": visit.fp_math_hash,
+        "media_devices": visit.fp_media_devices,
+        "webrtc_ip": _first_csv(visit.fp_webrtc_ips) or _legacy_webrtc_ip(visit),
+        "email": visit.email,
+        "ip_address": visit.ip_address,
+    }
+    return {
+        signal_type: normalized
+        for signal_type, value in signals.items()
+        if (normalized := _normalize_signal_value(value))
+    }
+
+
+def _update_visitor_rollups(visitor: Visitor, visit: Visit, signals: dict[str, str]) -> None:
+    visitor.primary_thumbmark_hash = visitor.primary_thumbmark_hash or signals.get("thumbmark_hash")
+    visitor.primary_thumbmark_visitor_id = visitor.primary_thumbmark_visitor_id or signals.get("thumbmark_visitor_id")
+    visitor.known_canvas_hashes = _json_array_append(visitor.known_canvas_hashes, signals.get("canvas_hash"))
+    visitor.known_audio_hashes = _json_array_append(visitor.known_audio_hashes, signals.get("audio_hash"))
+    visitor.known_webgl_vendors = _json_array_append(
+        visitor.known_webgl_vendors,
+        _normalize_signal_value(visit.fp_webgl_vendor or visit.webgl_vendor or visit.webgl_renderer),
+    )
+    visitor.known_screen_profiles = _json_array_append(visitor.known_screen_profiles, signals.get("screen_profile"))
+    visitor.known_timezones = _json_array_append(visitor.known_timezones, signals.get("timezone"))
+    visitor.known_languages = _json_array_append(visitor.known_languages, signals.get("language"))
+    visitor.known_thumbmark_visitor_ids = _json_array_append(
+        visitor.known_thumbmark_visitor_ids,
+        signals.get("thumbmark_visitor_id"),
+    )
+    timestamp = visit.timestamp or datetime.utcnow()
+    visitor.first_seen = min(filter(None, [visitor.first_seen, timestamp]), default=timestamp)
+    visitor.last_seen = max(filter(None, [visitor.last_seen, timestamp]), default=timestamp)
+    visitor.updated_at = datetime.utcnow()
+
+
+def _update_api_stats(visitor: Visitor) -> None:
+    db.session.flush()
+    api_visits = Visit.query.filter(
+        Visit.visitor_id == visitor.id,
+        Visit.thumbmark_api_called.is_(True),
+    ).all()
+    confidences = [
+        visit.thumbmark_api_confidence
+        for visit in api_visits
+        if isinstance(visit.thumbmark_api_confidence, (int, float))
+    ]
+    visitor.thumbmark_api_calls_count = len(api_visits)
+    visitor.thumbmark_api_confidence_avg = (sum(confidences) / len(confidences)) if confidences else None
+
+
+def _update_visitor_signals(visitor_id: str, visit: Visit, signals: dict[str, str]) -> Visitor:
+    visitor = db.session.get(Visitor, visitor_id)
+    if visitor is None:
+        visitor = Visitor(id=visitor_id)
+        db.session.add(visitor)
+        db.session.flush()
+
+    visit.visitor_id = visitor.id
+    timestamp = visit.timestamp or datetime.utcnow()
+    for signal_type, signal_value in signals.items():
+        weight = SIGNAL_WEIGHTS.get(signal_type, 0)
+        existing = VisitorSignal.query.filter_by(
+            visitor_id=visitor.id,
+            signal_type=signal_type,
+            signal_value=signal_value,
+        ).first()
+        if existing:
+            if existing.visit_id != visit.id:
+                existing.occurrence_count += 1
+            existing.visit_id = visit.id
+            existing.last_seen = timestamp
+            existing.confidence_weight = weight
+        else:
+            db.session.add(
+                VisitorSignal(
+                    visitor_id=visitor.id,
+                    visit_id=visit.id,
+                    signal_type=signal_type,
+                    signal_value=signal_value,
+                    confidence_weight=weight,
+                    first_seen=timestamp,
+                    last_seen=timestamp,
+                )
+            )
+
+    _update_visitor_rollups(visitor, visit, signals)
+    _update_api_stats(visitor)
+    return visitor
+
+
+def _create_new_visitor(visit: Visit, signals: dict[str, str]) -> Visitor:
+    timestamp = visit.timestamp or datetime.utcnow()
+    visitor = Visitor(first_seen=timestamp, last_seen=timestamp)
+    db.session.add(visitor)
+    db.session.flush()
+    return _update_visitor_signals(visitor.id, visit, signals)
+
+
+def _ensure_visitor_for_visit(visit: Visit) -> Visitor:
+    signals = _extract_signals_from_visit(visit)
+    if visit.visitor_id:
+        return _update_visitor_signals(visit.visitor_id, visit, signals)
+    return _create_new_visitor(visit, signals)
+
+
+def _candidate_scores(signals: dict[str, str], *, exclude_visitor_id: str | None = None) -> dict[str, int]:
+    candidates: dict[str, int] = {}
+    for signal_type, signal_value in signals.items():
+        weight = SIGNAL_WEIGHTS.get(signal_type, 0)
+        if not weight:
+            continue
+        matches = VisitorSignal.query.filter_by(signal_type=signal_type, signal_value=signal_value).all()
+        for match in matches:
+            if exclude_visitor_id and match.visitor_id == exclude_visitor_id:
+                continue
+            candidates[match.visitor_id] = candidates.get(match.visitor_id, 0) + weight
+    return candidates
+
+
+def _signal_match_reasons(visitor_id: str, signals: dict[str, str]) -> list[str]:
+    reasons = []
+    for signal_type, signal_value in signals.items():
+        if VisitorSignal.query.filter_by(
+            visitor_id=visitor_id,
+            signal_type=signal_type,
+            signal_value=signal_value,
+        ).first():
+            reasons.append(signal_type)
+    return reasons
+
+
+def match_visitor(visit: Visit, *, allow_reassign: bool = False) -> tuple[str, int, list[str]]:
+    signals = _extract_signals_from_visit(visit)
+    if visit.visitor_id and not allow_reassign:
+        _update_visitor_signals(visit.visitor_id, visit, signals)
+        return visit.visitor_id, visit.identity_confidence or 0, ["existing_visitor"]
+
+    candidates = _candidate_scores(signals, exclude_visitor_id=visit.visitor_id if allow_reassign else None)
+    if visit.is_vpn or visit.is_proxy or visit.is_hosting:
+        for visitor_id in candidates:
+            candidates[visitor_id] += PENALTIES["vpn_datacenter"]
+    if visit.browser_bot:
+        for visitor_id in candidates:
+            candidates[visitor_id] += PENALTIES["known_bot"]
+
+    if not candidates:
+        if visit.visitor_id:
+            _update_visitor_signals(visit.visitor_id, visit, signals)
+            return visit.visitor_id, 0, ["existing_visitor"]
+        visitor = _create_new_visitor(visit, signals)
+        return visitor.id, 0, ["new_visitor"]
+
+    best_id = max(candidates, key=candidates.get)
+    best_score = max(0, min(100, candidates[best_id]))
+    reasons = _signal_match_reasons(best_id, signals)
+
+    if best_score >= MATCH_THRESHOLD:
+        visit.probable_visitor_id = None
+        _update_visitor_signals(best_id, visit, signals)
+        return best_id, best_score, reasons
+
+    if best_score >= PROBABLE_THRESHOLD:
+        visitor = _create_new_visitor(visit, signals)
+        visitor.probable_match_id = best_id
+        visit.probable_visitor_id = best_id
+        return visitor.id, best_score, ["probable_match"] + reasons
+
+    if visit.visitor_id:
+        _update_visitor_signals(visit.visitor_id, visit, signals)
+        return visit.visitor_id, 0, ["existing_visitor"]
+    visitor = _create_new_visitor(visit, signals)
+    return visitor.id, 0, ["new_visitor"]
+
+
 def _risk_score(visit: Visit, missing_beacon: bool) -> tuple[int, list[str], list[str]]:
     score = 0
     reasons: list[str] = []
@@ -213,7 +501,13 @@ def _risk_score(visit: Visit, missing_beacon: bool) -> tuple[int, list[str], lis
     return min(100, score), reasons, conflicts
 
 
-def apply_visit_scoring(visit: Visit, *, missing_beacon: bool = False, secret: str | None = None) -> dict:
+def apply_visit_scoring(
+    visit: Visit,
+    *,
+    missing_beacon: bool = False,
+    secret: str | None = None,
+    use_thumbmark_api: bool = False,
+) -> dict:
     secret = secret or Config.FINGERPRINT_SECRET
     visit.fingerprint_version = FINGERPRINT_VERSION
     visit.fingerprint_composite_v1 = composite_fingerprint(visit, secret) or visit.fingerprint_composite_v1
@@ -232,27 +526,52 @@ def apply_visit_scoring(visit: Visit, *, missing_beacon: bool = False, secret: s
             best_conflicts = conflicts
             matched_visit_id = candidate.id
 
+    if matched_visit_id and "human_marked_false_match" not in best_conflicts:
+        matched_visit = db.session.get(Visit, matched_visit_id)
+        if matched_visit is not None:
+            _ensure_visitor_for_visit(matched_visit)
+
+    allow_signal_reassign = bool(visit.visitor_id and (visit.identity_confidence or 0) < PROBABLE_THRESHOLD)
+    visitor_id, signal_score, signal_reasons = match_visitor(visit, allow_reassign=allow_signal_reassign)
+    identity_score = max(best_score, signal_score)
+    identity_reasons = _ordered_unique(best_reasons + signal_reasons)
+
+    if use_thumbmark_api:
+        api_result = maybe_enrich_thumbmark_api(visit, identity_score)
+        if api_result is not None:
+            visitor_id, api_signal_score, api_reasons = match_visitor(visit, allow_reassign=True)
+            identity_score = max(identity_score, api_signal_score)
+            identity_reasons = _ordered_unique(identity_reasons + api_reasons)
+
+    if "human_marked_false_match" in best_conflicts:
+        identity_score = min(identity_score, best_score)
+
     risk_score, risk_reasons, risk_conflicts = _risk_score(visit, missing_beacon)
     conflicts = sorted(set(best_conflicts + risk_conflicts))
-    visit.identity_confidence = best_score
+    visit.identity_confidence = identity_score
     visit.risk_score = risk_score
     visit.cluster_conflict = bool(conflicts)
     visit.conflict_reason = ", ".join(conflicts) if conflicts else None
     visit.match_reasons_json = json.dumps(
         {
-            "identity": best_reasons,
+            "identity": identity_reasons,
             "risk": risk_reasons,
             "conflicts": conflicts,
             "matched_visit_id": matched_visit_id,
+            "visitor_id": visitor_id,
+            "probable_visitor_id": visit.probable_visitor_id,
+            "thumbmark_api_called": bool(visit.thumbmark_api_called),
+            "thumbmark_api_error": visit.thumbmark_api_error,
             "fingerprint_version": FINGERPRINT_VERSION,
         },
         sort_keys=True,
     )
     return {
-        "identity_confidence": best_score,
+        "identity_confidence": identity_score,
         "risk_score": risk_score,
-        "identity_reasons": best_reasons,
+        "identity_reasons": identity_reasons,
         "risk_reasons": risk_reasons,
         "conflicts": conflicts,
         "matched_visit_id": matched_visit_id,
+        "visitor_id": visitor_id,
     }

--- a/server/services/thumbmark.py
+++ b/server/services/thumbmark.py
@@ -1,0 +1,246 @@
+import json
+import re
+from datetime import datetime, timedelta
+from typing import Any
+
+import requests
+from flask import current_app
+
+from ..config import Config
+from ..models import Visit, Visitor
+
+
+def _config_value(name: str, default: str = "") -> str:
+    try:
+        return current_app.config.get(name, default)
+    except RuntimeError:
+        return getattr(Config, name, default)
+
+
+def _text(value: Any, max_len: int | None = None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, (dict, list)):
+        value = json.dumps(value, separators=(",", ":"), ensure_ascii=False)
+    value = str(value).strip()
+    if not value:
+        return None
+    return value[:max_len] if max_len else value
+
+
+def _float_0_1(value: Any) -> float | None:
+    if value is None or isinstance(value, bool):
+        return None
+    try:
+        number = float(value)
+    except (TypeError, ValueError):
+        return None
+    if number > 1 and number <= 100:
+        number = number / 100
+    if number < 0 or number > 1:
+        return None
+    return number
+
+
+def _first_csv(value: str | None, max_len: int = 32) -> str | None:
+    if not value:
+        return None
+    first = next((part.strip() for part in value.split(",") if part.strip()), "")
+    return first[:max_len] if first else None
+
+
+def _json_list_from_csv(value: str | None, *, limit: int = 12) -> str | None:
+    if not value:
+        return None
+    parts = [part.strip() for part in value.split(",") if part.strip()]
+    return json.dumps(parts[:limit]) if parts else None
+
+
+def _mirror_thumbmark_fields_to_legacy(visit: Visit) -> None:
+    if visit.fp_canvas_hash and not visit.canvas_hash:
+        visit.canvas_hash = visit.fp_canvas_hash[:64]
+    if visit.fp_audio_hash and not visit.audio_fp:
+        visit.audio_fp = visit.fp_audio_hash[:128]
+    if visit.fp_fonts_hash and not visit.fonts:
+        visit.fonts = visit.fp_fonts_hash
+    if visit.fp_webgl_vendor:
+        visit.webgl_renderer = visit.webgl_renderer or visit.fp_webgl_vendor[:256]
+        visit.webgl_vendor = visit.webgl_vendor or visit.fp_webgl_vendor[:256]
+    if visit.fp_webgl_hash and not visit.webgl_extensions_hash:
+        visit.webgl_extensions_hash = visit.fp_webgl_hash[:16]
+    if visit.fp_timezone and not visit.timezone:
+        visit.timezone = visit.fp_timezone[:64]
+    if visit.fp_languages and not visit.browser_language:
+        visit.browser_language = _first_csv(visit.fp_languages)
+    if visit.fp_webrtc_ips and not visit.webrtc_ips:
+        visit.webrtc_ips = _json_list_from_csv(visit.fp_webrtc_ips)
+
+    if visit.fp_screen_profile:
+        match = re.match(r"^(\d+)x(\d+)x(\d+)@([0-9.]+)$", visit.fp_screen_profile)
+        if match:
+            width, height, depth, ratio = match.groups()
+            visit.screen_res = visit.screen_res or f"{width}x{height}"
+            if visit.screen_depth is None:
+                visit.screen_depth = int(depth)
+            if visit.pixel_ratio is None:
+                try:
+                    visit.pixel_ratio = float(ratio)
+                except ValueError:
+                    pass
+
+    if visit.fp_hardware_profile:
+        match = re.match(r"^(\d+)c/([0-9.]+)gb/(\d+)tp$", visit.fp_hardware_profile)
+        if match:
+            cores, memory, touch = match.groups()
+            if visit.cpu_cores is None:
+                visit.cpu_cores = int(cores)
+            if visit.ram_gb is None:
+                try:
+                    visit.ram_gb = float(memory)
+                except ValueError:
+                    pass
+            if visit.touch_points is None:
+                visit.touch_points = int(touch)
+
+
+def store_thumbmark_payload(visit: Visit, data: dict[str, Any]) -> None:
+    if "thumbmark_hash" in data or "thumbmark" in data or "hash" in data:
+        visit.thumbmark_hash = _text(data.get("thumbmark_hash") or data.get("thumbmark") or data.get("hash"), 256)
+    if "thumbmark_raw" in data:
+        visit.thumbmark_raw = _text(data.get("thumbmark_raw"))
+    elif "components" in data:
+        visit.thumbmark_raw = _text(data)
+    if "thumbmark_visitor_id" in data or "visitorId" in data:
+        visit.thumbmark_visitor_id = _text(data.get("thumbmark_visitor_id") or data.get("visitorId"), 256)
+    if "thumbmark_api_confidence" in data or "confidence" in data:
+        visit.thumbmark_api_confidence = _float_0_1(
+            data.get("thumbmark_api_confidence") if "thumbmark_api_confidence" in data else data.get("confidence")
+        )
+
+    field_limits = {
+        "fp_audio_hash": 256,
+        "fp_canvas_hash": 256,
+        "fp_webgl_vendor": 512,
+        "fp_webgl_hash": 256,
+        "fp_fonts_hash": 512,
+        "fp_screen_profile": 128,
+        "fp_hardware_profile": 128,
+        "fp_languages": 512,
+        "fp_timezone": 128,
+        "fp_speech_hash": 256,
+        "fp_math_hash": 256,
+        "fp_permissions_profile": 4000,
+        "fp_media_devices": 128,
+        "fp_webrtc_ips": 512,
+    }
+    for field, limit in field_limits.items():
+        if field in data:
+            setattr(visit, field, _text(data.get(field), limit))
+
+    _mirror_thumbmark_fields_to_legacy(visit)
+
+
+def _raw_result(visit: Visit) -> dict[str, Any]:
+    if not visit.thumbmark_raw:
+        return {}
+    try:
+        parsed = json.loads(visit.thumbmark_raw)
+    except (TypeError, ValueError):
+        return {}
+    return parsed if isinstance(parsed, dict) else {}
+
+
+def _api_request_body(visit: Visit, api_key: str) -> dict[str, Any]:
+    raw = _raw_result(visit)
+    components = raw.get("components") or raw.get("data") or {}
+    body: dict[str, Any] = {
+        "components": components,
+        "options": {
+            "api_key": api_key,
+            "timeout": 3000,
+            "cache_api_call": True,
+            "cache_lifetime_in_ms": 0,
+            "experimental": True,
+            "logging": False,
+        },
+        "clientHash": visit.thumbmark_hash,
+    }
+    if raw.get("version"):
+        body["version"] = raw.get("version")
+    if visit.thumbmark_visitor_id:
+        body["visitorId"] = visit.thumbmark_visitor_id
+    return body
+
+
+def _confidence_from_api_result(result: dict[str, Any]) -> float | None:
+    confidence = _float_0_1(result.get("confidence") or result.get("confidenceScore"))
+    if confidence is not None:
+        return confidence
+    info = result.get("info") if isinstance(result.get("info"), dict) else {}
+    uniqueness = info.get("uniqueness") if isinstance(info.get("uniqueness"), dict) else {}
+    return _float_0_1(uniqueness.get("score"))
+
+
+def call_thumbmark_api(visit: Visit) -> dict[str, Any] | None:
+    api_key = _config_value("THUMBMARK_API_KEY")
+    api_url = _config_value("THUMBMARK_API_URL", "https://api.thumbmarkjs.com/thumbmark")
+    if not api_key or not visit.thumbmark_hash:
+        return None
+
+    try:
+        response = requests.post(
+            api_url,
+            headers={
+                "x-api-key": api_key,
+                "Authorization": "custom-authorized",
+                "Content-Type": "application/json",
+            },
+            json=_api_request_body(visit, api_key),
+            timeout=3,
+        )
+        visit.thumbmark_api_called = True
+        if response.status_code == 200:
+            result = response.json()
+            visit.thumbmark_visitor_id = _text(result.get("visitorId"), 256) or visit.thumbmark_visitor_id
+            visit.thumbmark_api_confidence = _confidence_from_api_result(result)
+            visit.thumbmark_api_error = None
+            return result
+        visit.thumbmark_api_error = f"HTTP {response.status_code}"
+    except Exception as exc:
+        visit.thumbmark_api_error = str(exc)
+    return None
+
+
+def maybe_enrich_thumbmark_api(visit: Visit, confidence_score: int) -> dict[str, Any] | None:
+    api_key = _config_value("THUMBMARK_API_KEY")
+    if not api_key or not visit.thumbmark_hash or confidence_score >= 40:
+        return None
+
+    if visit.visitor_id:
+        visitor = Visitor.query.get(visit.visitor_id)
+        if visitor and visitor.thumbmark_api_confidence_avg and visitor.thumbmark_api_confidence_avg > 0.85:
+            return None
+
+    cutoff = datetime.utcnow() - timedelta(days=7)
+    recent = (
+        Visit.query.filter(
+            Visit.id != visit.id,
+            Visit.thumbmark_hash == visit.thumbmark_hash,
+            Visit.thumbmark_api_called.is_(True),
+            Visit.timestamp >= cutoff,
+        )
+        .order_by(Visit.timestamp.desc())
+        .first()
+    )
+    if recent:
+        visit.thumbmark_visitor_id = recent.thumbmark_visitor_id
+        visit.thumbmark_api_confidence = recent.thumbmark_api_confidence
+        visit.thumbmark_api_called = True
+        visit.thumbmark_api_error = recent.thumbmark_api_error
+        return {"cached": True}
+
+    seen_hash = Visit.query.filter(Visit.id != visit.id, Visit.thumbmark_hash == visit.thumbmark_hash).first()
+    if seen_hash:
+        return None
+
+    return call_thumbmark_api(visit)

--- a/server/services/thumbmark.py
+++ b/server/services/thumbmark.py
@@ -7,6 +7,7 @@ import requests
 from flask import current_app
 
 from ..config import Config
+from ..extensions import db
 from ..models import Visit, Visitor
 
 
@@ -150,13 +151,12 @@ def _raw_result(visit: Visit) -> dict[str, Any]:
     return parsed if isinstance(parsed, dict) else {}
 
 
-def _api_request_body(visit: Visit, api_key: str) -> dict[str, Any]:
+def _api_request_body(visit: Visit) -> dict[str, Any]:
     raw = _raw_result(visit)
     components = raw.get("components") or raw.get("data") or {}
     body: dict[str, Any] = {
         "components": components,
         "options": {
-            "api_key": api_key,
             "timeout": 3000,
             "cache_api_call": True,
             "cache_lifetime_in_ms": 0,
@@ -192,10 +192,9 @@ def call_thumbmark_api(visit: Visit) -> dict[str, Any] | None:
             api_url,
             headers={
                 "x-api-key": api_key,
-                "Authorization": "custom-authorized",
                 "Content-Type": "application/json",
             },
-            json=_api_request_body(visit, api_key),
+            json=_api_request_body(visit),
             timeout=3,
         )
         visit.thumbmark_api_called = True
@@ -217,7 +216,7 @@ def maybe_enrich_thumbmark_api(visit: Visit, confidence_score: int) -> dict[str,
         return None
 
     if visit.visitor_id:
-        visitor = Visitor.query.get(visit.visitor_id)
+        visitor = db.session.get(Visitor, visit.visitor_id)
         if visitor and visitor.thumbmark_api_confidence_avg and visitor.thumbmark_api_confidence_avg > 0.85:
             return None
 
@@ -238,9 +237,5 @@ def maybe_enrich_thumbmark_api(visit: Visit, confidence_score: int) -> dict[str,
         visit.thumbmark_api_called = True
         visit.thumbmark_api_error = recent.thumbmark_api_error
         return {"cached": True}
-
-    seen_hash = Visit.query.filter(Visit.id != visit.id, Visit.thumbmark_hash == visit.thumbmark_hash).first()
-    if seen_hash:
-        return None
 
     return call_thumbmark_api(visit)

--- a/server/static/css/urltrack.css
+++ b/server/static/css/urltrack.css
@@ -22,7 +22,17 @@
 
 * { box-sizing: border-box; }
 html { background: var(--bg); color: var(--fg); font-family: var(--font-body); }
-body { margin: 0; min-width: 0; background: linear-gradient(180deg, oklch(17% 0.018 250), var(--bg) 420px); color: var(--fg); }
+body {
+  margin: 0;
+  min-width: 0;
+  min-height: 100vh;
+  height: auto;
+  display: block;
+  overflow-x: clip;
+  overflow-y: auto;
+  background: linear-gradient(180deg, oklch(17% 0.018 250), var(--bg) 420px);
+  color: var(--fg);
+}
 a { color: inherit; text-decoration: none; }
 button, input, select, textarea { font: inherit; }
 

--- a/server/static/css/urltrack.css
+++ b/server/static/css/urltrack.css
@@ -73,6 +73,10 @@ tbody tr:hover { background: oklch(27% 0.03 250 / 0.7); }
 tr[onclick] { cursor: pointer; }
 .mono { font-family: var(--font-mono); font-size: 12px; }
 .muted { color: var(--muted); }
+.project-cell { display: flex; align-items: center; gap: 10px; min-width: 0; }
+.project-cell .name { font-weight: 700; letter-spacing: -0.01em; }
+.project-cell .desc { color: var(--muted); font-size: 11px; margin-top: 2px; max-width: 240px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.project-icon-badge { width: 30px; height: 30px; display: grid; place-items: center; flex: 0 0 auto; border-radius: 7px; color: var(--accent-contrast); background: linear-gradient(135deg, var(--accent), var(--green)); font-weight: 850; }
 .badge { display: inline-flex; align-items: center; gap: 6px; min-height: 24px; padding: 3px 8px; border-radius: 999px; border: 1px solid var(--border); color: var(--fg); background: var(--surface-2); font-size: 12px; }
 .badge.success { color: var(--success); background: oklch(70% 0.16 150 / 0.1); border-color: oklch(70% 0.16 150 / 0.25); }
 .badge.warn { color: var(--warn); background: oklch(76% 0.15 78 / 0.1); border-color: oklch(76% 0.15 78 / 0.24); }
@@ -94,6 +98,9 @@ tr[onclick] { cursor: pointer; }
 .input:focus, .select:focus, .textarea:focus { border-color: var(--primary); }
 .toggle-list { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
 .toggle { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); cursor: pointer; }
+.toggle h3 { font-size: 13px; margin: 0 0 2px; }
+.toggle p { margin: 0; font-size: 12px; color: var(--muted); }
+.toggle input[type="checkbox"] { width: 18px; height: 18px; flex: 0 0 auto; accent-color: var(--primary); }
 .switch { width: 38px; height: 22px; border-radius: 999px; padding: 3px; background: var(--surface-3); border: 1px solid var(--border); }
 .switch::after { content: ""; display: block; width: 14px; height: 14px; border-radius: 50%; background: var(--muted); transition: transform .16s ease, background .16s ease; }
 .toggle.enabled .switch { background: oklch(62% 0.16 250 / 0.22); border-color: oklch(62% 0.16 250 / 0.45); }

--- a/server/static/css/urltrack.css
+++ b/server/static/css/urltrack.css
@@ -1166,3 +1166,280 @@ html[data-theme="light"] .topbar-item.active { background: oklch(0% 0 0/0.04); }
     grid-template-columns: 1fr;
   }
 }
+
+/* ===== Open Design integration: real shell, page headers, responsive polish ===== */
+html {
+  background: var(--page-bg, var(--bg));
+  overflow-x: hidden;
+}
+
+body {
+  min-width: 0;
+  overflow-x: clip;
+}
+
+body > .topbar {
+  width: min(1180px, calc(100vw - 40px));
+  margin: 20px auto 0;
+  flex-direction: row !important;
+  align-items: center !important;
+  justify-content: flex-start !important;
+}
+
+body > .page.app-page {
+  width: min(1180px, calc(100vw - 40px));
+  height: auto;
+  min-height: calc(100vh - 92px);
+  margin: 0 auto;
+  padding: 44px 0 88px;
+  overflow: visible;
+}
+
+.workspace-bar {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 22px;
+}
+
+.app-search,
+.search-bar {
+  display: flex;
+  align-items: center;
+  border: 1px solid var(--border);
+  background: var(--surface);
+  min-height: 40px;
+  padding: 0 14px;
+  width: min(360px, 100%);
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+
+.app-search:focus-within,
+.search-bar:focus-within {
+  border-color: var(--accent);
+  box-shadow: 0 0 0 2px var(--accent-soft);
+}
+
+.app-search i,
+.search-bar i {
+  color: var(--muted);
+  font-size: 13px;
+  flex: 0 0 auto;
+}
+
+.app-search input,
+.search-bar input {
+  flex: 1;
+  min-width: 0;
+  border: 0 !important;
+  background: transparent;
+  color: var(--fg);
+  padding: 10px;
+  outline: 0;
+  font-size: 12px;
+  box-shadow: none !important;
+}
+
+.page-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 18px;
+  margin-bottom: 28px;
+}
+
+.page-header h1 {
+  font-family: var(--font-display);
+  font-size: clamp(26px, 3vw, 40px);
+  font-weight: 650;
+  line-height: 1.04;
+  margin: 3px 0 0;
+  letter-spacing: -0.035em;
+}
+
+.page-header p {
+  margin: 0;
+  font-size: 12px;
+}
+
+.project-actions {
+  flex-wrap: nowrap;
+}
+
+.topbar a,
+.topbar button {
+  color: inherit !important;
+}
+
+.topbar .topbar-item {
+  color: var(--muted) !important;
+  gap: 0;
+}
+
+.topbar .topbar-item:hover,
+.topbar .topbar-item.active {
+  color: var(--fg) !important;
+}
+
+.topbar-logo {
+  color: var(--accent-contrast) !important;
+}
+
+.more-wrap,
+.avatar-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+.more-dropdown .more-dropdown-item,
+.avatar-dropdown .dd-item {
+  color: var(--muted) !important;
+  text-decoration: none;
+}
+
+.more-dropdown .more-dropdown-item:hover,
+.more-dropdown .more-dropdown-item.active,
+.avatar-dropdown .dd-item:hover {
+  color: var(--fg) !important;
+}
+
+.avatar-dropdown .dd-item.danger {
+  color: var(--red) !important;
+}
+
+.flash-list {
+  display: grid;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.chat-bubble {
+  position: fixed;
+  right: 18px;
+  bottom: 18px;
+  z-index: 80;
+  width: 44px;
+  height: 44px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: var(--accent);
+  color: var(--accent-contrast);
+  display: grid;
+  place-items: center;
+  box-shadow: var(--shadow-card);
+  cursor: pointer;
+}
+
+.toast-stack {
+  position: fixed;
+  right: 18px;
+  bottom: 74px;
+  z-index: 79;
+  display: grid;
+  gap: 8px;
+  max-width: 340px;
+}
+
+.table-wrap {
+  max-width: 100%;
+}
+
+.btn,
+.plus-btn,
+.action-btn {
+  border-radius: 8px;
+  text-decoration: none;
+}
+
+.plus-btn {
+  color: var(--accent-contrast) !important;
+}
+
+html[data-theme="light"] body {
+  background:
+    linear-gradient(180deg, var(--page-grad-a) 0, var(--page-bg) 320px),
+    var(--page-bg);
+}
+
+@media (max-width: 980px) {
+  .topbar-nav {
+    overflow-x: auto;
+    scrollbar-width: none;
+  }
+  .topbar-nav::-webkit-scrollbar {
+    display: none;
+  }
+  .project-actions {
+    flex-wrap: wrap;
+    justify-content: flex-start;
+  }
+}
+
+@media (max-width: 720px) {
+  body > .topbar {
+    top: 8px;
+    width: calc(100vw - 16px);
+    margin-top: 8px;
+    height: 48px;
+  }
+
+  body > .page.app-page {
+    width: calc(100vw - 16px);
+    padding-top: 28px;
+  }
+
+  .topbar-logo {
+    margin-right: 6px;
+  }
+
+  .topbar-nav {
+    justify-content: flex-end;
+  }
+
+  .topbar-item {
+    display: none;
+  }
+
+  .theme-pill {
+    display: none;
+  }
+
+  .workspace-bar,
+  .page-header {
+    align-items: stretch;
+    flex-direction: column;
+  }
+
+  .app-search,
+  .search-bar,
+  .project-actions,
+  .page-header .actions {
+    width: 100%;
+  }
+
+  .project-actions > *,
+  .page-header .actions > * {
+    width: 100%;
+    justify-content: center;
+  }
+
+  .plus-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    gap: 8px;
+    color: var(--accent-contrast) !important;
+    background: var(--accent);
+    border-color: transparent;
+  }
+
+  .metrics {
+    grid-template-columns: 1fr;
+  }
+
+  .panel,
+  .table-wrap {
+    min-width: 0;
+  }
+}

--- a/server/static/css/urltrack.css
+++ b/server/static/css/urltrack.css
@@ -1,0 +1,1151 @@
+:root {
+  --bg: oklch(15% 0.018 250);
+  --surface: oklch(20% 0.022 250);
+  --surface-2: oklch(24% 0.025 250);
+  --surface-3: oklch(28% 0.028 250);
+  --fg: oklch(94% 0.01 245);
+  --muted: oklch(68% 0.025 245);
+  --border: oklch(32% 0.028 250);
+  --accent: oklch(56% 0.12 170);
+  --primary: oklch(62% 0.16 250);
+  --success: oklch(70% 0.16 150);
+  --warn: oklch(76% 0.15 78);
+  --danger: oklch(64% 0.2 25);
+  --info: oklch(70% 0.13 225);
+  --font-display: 'Sohne', 'Avenir Next', -apple-system, BlinkMacSystemFont, system-ui, sans-serif;
+  --font-body: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+  --font-mono: ui-monospace, 'JetBrains Mono', 'IBM Plex Mono', Menlo, monospace;
+  --radius: 12px;
+  --radius-sm: 8px;
+  --sidebar: 248px;
+}
+
+* { box-sizing: border-box; }
+html { background: var(--bg); color: var(--fg); font-family: var(--font-body); }
+body { margin: 0; min-width: 0; background: linear-gradient(180deg, oklch(17% 0.018 250), var(--bg) 420px); color: var(--fg); }
+a { color: inherit; text-decoration: none; }
+button, input, select, textarea { font: inherit; }
+
+.app-shell { min-height: 100vh; display: grid; grid-template-columns: var(--sidebar) minmax(0, 1fr); }
+.sidebar { position: sticky; top: 0; height: 100vh; padding: 20px 16px; border-right: 1px solid var(--border); background: oklch(16% 0.018 250 / 0.98); }
+.brand { display: flex; align-items: center; gap: 10px; padding: 6px 8px 22px; font-weight: 720; letter-spacing: -0.01em; }
+.brand-mark { width: 30px; height: 30px; border-radius: 9px; display: grid; place-items: center; color: var(--bg); background: linear-gradient(135deg, var(--accent), var(--primary)); font-weight: 800; }
+.nav { display: grid; gap: 5px; }
+.nav a { display: flex; align-items: center; gap: 10px; min-height: 38px; padding: 9px 10px; border-radius: 10px; color: var(--muted); font-size: 14px; }
+.nav a:hover, .nav a.active { color: var(--fg); background: var(--surface-2); }
+.nav-section { margin: 18px 8px 7px; color: var(--muted); font-size: 10px; letter-spacing: .09em; text-transform: uppercase; font-weight: 800; }
+.sidebar-footer { position: absolute; left: 16px; right: 16px; bottom: 18px; padding: 12px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); font-size: 12px; color: var(--muted); }
+.status-dot { width: 8px; height: 8px; border-radius: 50%; background: var(--success); box-shadow: 0 0 0 4px oklch(70% 0.16 150 / 0.12); display: inline-block; margin-right: 7px; }
+
+.main { min-width: 0; padding: 22px; padding-bottom: 86px; }
+.topbar { display: flex; align-items: center; justify-content: space-between; gap: 16px; margin-bottom: 18px; }
+.eyebrow { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.08em; font-weight: 700; }
+h1 { margin: 3px 0 0; font-family: var(--font-display); font-size: clamp(28px, 3vw, 42px); line-height: 1.08; letter-spacing: -0.02em; }
+h2 { margin: 0; font-size: 18px; letter-spacing: -0.01em; }
+h3 { margin: 0; font-size: 15px; }
+p { color: var(--muted); line-height: 1.5; }
+.actions { display: flex; gap: 10px; align-items: center; flex-wrap: wrap; }
+.btn { border: 1px solid var(--border); border-radius: 10px; min-height: 38px; padding: 9px 13px; background: var(--surface-2); color: var(--fg); cursor: pointer; }
+.btn:hover { border-color: oklch(45% 0.035 250); background: var(--surface-3); }
+.btn.primary { border-color: transparent; color: oklch(99% 0 0); background: var(--primary); }
+.btn.ghost { background: transparent; }
+.icon-btn { width: 38px; height: 38px; padding: 0; display: inline-grid; place-items: center; }
+
+.grid { display: grid; gap: 14px; }
+.metrics { grid-template-columns: repeat(6, minmax(130px, 1fr)); }
+.panel { border: 1px solid var(--border); border-radius: var(--radius); background: oklch(20% 0.022 250 / 0.92); overflow: hidden; }
+.panel.pad { padding: 16px; }
+.panel-head { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 14px 16px; border-bottom: 1px solid var(--border); }
+.metric { padding: 14px; min-height: 98px; }
+.metric.compact { min-height: 82px; }
+.metric .label { color: var(--muted); font-size: 12px; }
+.metric .value { margin-top: 10px; font-size: clamp(24px, 2.4vw, 34px); letter-spacing: -0.03em; font-weight: 740; }
+.metric .delta { margin-top: 7px; font-size: 12px; color: var(--muted); }
+.split { grid-template-columns: minmax(0, 1.55fr) minmax(320px, 0.85fr); align-items: start; }
+.triple { grid-template-columns: minmax(0, 1.15fr) minmax(280px, .75fr) minmax(280px, .75fr); align-items: start; }
+.two-col { grid-template-columns: repeat(2, minmax(0, 1fr)); align-items: start; }
+
+.table-wrap { overflow: auto; }
+table { width: 100%; border-collapse: collapse; min-width: 760px; }
+th, td { padding: 11px 12px; border-bottom: 1px solid var(--border); text-align: left; font-size: 13px; white-space: nowrap; }
+th { color: var(--muted); font-size: 11px; text-transform: uppercase; letter-spacing: 0.07em; background: oklch(18% 0.018 250); }
+tbody tr:hover { background: oklch(27% 0.03 250 / 0.7); }
+tr[onclick] { cursor: pointer; }
+.mono { font-family: var(--font-mono); font-size: 12px; }
+.muted { color: var(--muted); }
+.badge { display: inline-flex; align-items: center; gap: 6px; min-height: 24px; padding: 3px 8px; border-radius: 999px; border: 1px solid var(--border); color: var(--fg); background: var(--surface-2); font-size: 12px; }
+.badge.success { color: var(--success); background: oklch(70% 0.16 150 / 0.1); border-color: oklch(70% 0.16 150 / 0.25); }
+.badge.warn { color: var(--warn); background: oklch(76% 0.15 78 / 0.1); border-color: oklch(76% 0.15 78 / 0.24); }
+.badge.danger { color: var(--danger); background: oklch(64% 0.2 25 / 0.12); border-color: oklch(64% 0.2 25 / 0.28); }
+.badge.info { color: var(--info); background: oklch(70% 0.13 225 / 0.1); border-color: oklch(70% 0.13 225 / 0.24); }
+
+.queue { display: grid; gap: 10px; padding: 12px; }
+.queue-item { display: grid; gap: 7px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+.queue-item:hover { border-color: oklch(45% 0.035 250); background: var(--surface-2); }
+.queue-top { display: flex; justify-content: space-between; gap: 10px; align-items: start; }
+.queue-title { font-weight: 680; font-size: 14px; }
+.queue-meta { color: var(--muted); font-size: 12px; }
+
+.form-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 14px; }
+.field { display: grid; gap: 7px; }
+.field label { color: var(--muted); font-size: 12px; text-transform: uppercase; letter-spacing: 0.07em; font-weight: 700; }
+.input, .select, .textarea { width: 100%; border: 1px solid var(--border); border-radius: 10px; background: oklch(16% 0.018 250); color: var(--fg); padding: 11px 12px; outline: none; }
+.textarea { min-height: 84px; resize: vertical; }
+.input:focus, .select:focus, .textarea:focus { border-color: var(--primary); }
+.toggle-list { display: grid; grid-template-columns: repeat(3, minmax(0, 1fr)); gap: 10px; }
+.toggle { display: flex; justify-content: space-between; align-items: center; gap: 10px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); cursor: pointer; }
+.switch { width: 38px; height: 22px; border-radius: 999px; padding: 3px; background: var(--surface-3); border: 1px solid var(--border); }
+.switch::after { content: ""; display: block; width: 14px; height: 14px; border-radius: 50%; background: var(--muted); transition: transform .16s ease, background .16s ease; }
+.toggle.enabled .switch { background: oklch(62% 0.16 250 / 0.22); border-color: oklch(62% 0.16 250 / 0.45); }
+.toggle.enabled .switch::after { transform: translateX(16px); background: var(--primary); }
+
+.mode-strip { display: flex; flex-wrap: wrap; gap: 8px; margin: -4px 0 16px; }
+.mode-chip { min-height: 32px; display: inline-flex; align-items: center; gap: 8px; padding: 6px 10px; border: 1px solid var(--border); border-radius: 999px; color: var(--muted); background: var(--surface); font-size: 12px; cursor: pointer; }
+.mode-chip.active, .mode-chip:hover { color: var(--fg); border-color: oklch(62% 0.16 250 / .48); background: oklch(62% 0.16 250 / .14); }
+.mode-chip strong { color: var(--fg); }
+
+.creator-shell { display: grid; grid-template-columns: minmax(0, 1fr) 300px; gap: 14px; align-items: start; }
+.creator-toolbar { display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 12px; border-bottom: 1px solid var(--border); background: oklch(18% 0.018 250); }
+.palette-rail { display: flex; flex-wrap: wrap; gap: 8px; }
+.palette-chip { min-height: 34px; border: 1px solid var(--border); border-radius: 999px; padding: 7px 10px; color: var(--muted); background: var(--surface); cursor: pointer; font-size: 12px; }
+.palette-chip:hover, .palette-chip.active { color: var(--fg); border-color: oklch(62% 0.16 250 / .48); background: oklch(62% 0.16 250 / .13); }
+.flow-canvas { min-height: 650px; position: relative; overflow: hidden; background-color: oklch(16% 0.018 250); background-image: radial-gradient(oklch(44% 0.035 250 / .38) 1px, transparent 1px); background-size: 22px 22px; }
+.canvas-lane { position: absolute; inset: 18px; border: 1px solid oklch(32% 0.028 250 / .72); border-radius: 18px; background: linear-gradient(180deg, oklch(18% 0.02 250 / .88), oklch(15% 0.018 250 / .68)); }
+.flow-node { position: absolute; width: 178px; min-height: 112px; display: grid; gap: 8px; padding: 12px; border: 1px solid var(--border); border-radius: 14px; background: oklch(21% 0.024 250 / .98); box-shadow: 0 12px 30px oklch(8% 0.02 250 / .34); cursor: pointer; transition: transform .16s ease, border-color .16s ease, background .16s ease; }
+.flow-node:hover { transform: translateY(-2px); border-color: oklch(62% 0.16 250 / .45); background: var(--surface-2); }
+.flow-node.selected { border-color: var(--primary); box-shadow: 0 0 0 3px oklch(62% 0.16 250 / .15), 0 12px 30px oklch(8% 0.02 250 / .34); }
+.flow-node .node-top { display: flex; justify-content: space-between; gap: 8px; align-items: center; }
+.node-kind { color: var(--muted); font-size: 10px; text-transform: uppercase; letter-spacing: .08em; font-weight: 800; }
+.node-title { font-weight: 760; letter-spacing: -.01em; }
+.node-detail { color: var(--muted); font-size: 12px; line-height: 1.4; }
+.node-port { width: 10px; height: 10px; border-radius: 50%; border: 2px solid oklch(16% 0.018 250); background: var(--primary); position: absolute; right: -5px; top: 50%; }
+.node-port.in { left: -5px; right: auto; background: var(--accent); }
+.flow-edge { position: absolute; height: 2px; transform-origin: left center; background: linear-gradient(90deg, oklch(62% 0.16 250 / .72), oklch(56% 0.12 170 / .72)); border-radius: 999px; }
+.flow-edge::after { content: ""; position: absolute; right: -4px; top: -3px; width: 8px; height: 8px; transform: rotate(45deg); border-top: 2px solid oklch(56% 0.12 170 / .86); border-right: 2px solid oklch(56% 0.12 170 / .86); }
+.flow-edge.dashed { background: repeating-linear-gradient(90deg, oklch(76% 0.15 78 / .76) 0 10px, transparent 10px 16px); }
+.canvas-note { position: absolute; left: 22px; bottom: 22px; max-width: 310px; padding: 12px; border: 1px solid var(--border); border-radius: 14px; background: oklch(20% 0.022 250 / .96); color: var(--muted); font-size: 12px; }
+.inspector { display: grid; gap: 14px; }
+.node-inspector { display: grid; gap: 12px; }
+.inspector-title { display: grid; gap: 4px; }
+.rule-row { display: grid; grid-template-columns: 1fr auto; gap: 12px; align-items: center; padding: 10px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+.run-preview { display: grid; gap: 8px; }
+.run-step { display: grid; grid-template-columns: 22px 1fr auto; gap: 9px; align-items: center; padding: 9px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); font-size: 12px; }
+.run-index { width: 22px; height: 22px; display: grid; place-items: center; border-radius: 50%; background: var(--surface-3); color: var(--muted); font: 700 11px var(--font-mono); }
+.template-grid { display: grid; grid-template-columns: repeat(4, minmax(0, 1fr)); gap: 10px; }
+.template-card { display: grid; gap: 8px; padding: 12px; border: 1px solid var(--border); border-radius: 14px; background: var(--surface); cursor: pointer; }
+.template-card:hover, .template-card.active { border-color: oklch(62% 0.16 250 / .5); background: oklch(62% 0.16 250 / .1); }
+
+.stepper { display: grid; gap: 10px; }
+.step { display: grid; grid-template-columns: 30px 1fr auto; gap: 10px; align-items: start; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+.step-number { width: 26px; height: 26px; display: grid; place-items: center; border-radius: 50%; background: var(--surface-3); color: var(--muted); font: 700 12px var(--font-mono); }
+.step.active { border-color: oklch(62% 0.16 250 / .55); background: oklch(62% 0.16 250 / .09); }
+.step.active .step-number { color: var(--fg); background: var(--primary); }
+
+.insight-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 10px; padding: 12px; }
+.insight { display: grid; gap: 7px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+.insight strong { font-size: 14px; }
+.quality-bar { height: 7px; border-radius: 999px; overflow: hidden; background: var(--surface-3); }
+.quality-bar span { display: block; height: 100%; border-radius: inherit; background: linear-gradient(90deg, var(--success), var(--warn), var(--danger)); }
+.qr-preview { aspect-ratio: 1; display: grid; place-items: center; border: 1px solid var(--border); border-radius: 12px; background: repeating-linear-gradient(45deg, oklch(88% 0.01 245), oklch(88% 0.01 245) 6px, oklch(20% 0.022 250) 6px, oklch(20% 0.022 250) 12px); color: var(--bg); font-weight: 900; }
+.mini-tabs { display: flex; flex-wrap: wrap; gap: 6px; }
+.mini-tabs button { min-height: 30px; border: 1px solid var(--border); border-radius: 999px; padding: 5px 9px; color: var(--muted); background: var(--surface); cursor: pointer; font-size: 12px; }
+.mini-tabs button.active, .mini-tabs button:hover { color: var(--fg); background: var(--surface-2); }
+.technical-panel[hidden], .tab-panel[hidden] { display: none; }
+
+.graph-layout { display: grid; grid-template-columns: minmax(0, 1fr) 340px; gap: 14px; }
+.graph-canvas { min-height: 560px; position: relative; background-image: linear-gradient(var(--border) 1px, transparent 1px), linear-gradient(90deg, var(--border) 1px, transparent 1px); background-size: 42px 42px; }
+.node { position: absolute; min-width: 92px; padding: 9px 11px; border: 1px solid var(--border); border-radius: 999px; background: var(--surface-2); font-size: 12px; cursor: pointer; box-shadow: 0 8px 28px oklch(8% 0.02 250 / .28); }
+.node.active { border-color: var(--primary); background: oklch(62% 0.16 250 / 0.2); }
+.edge { position: absolute; height: 1px; background: oklch(50% 0.035 245); transform-origin: left center; }
+
+.chat { display: grid; gap: 12px; }
+.answer { padding: 14px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); }
+.command-row { display: flex; flex-wrap: wrap; gap: 8px; }
+.command { font-family: var(--font-mono); font-size: 12px; border: 1px solid var(--border); border-radius: 999px; padding: 6px 9px; color: var(--info); background: var(--surface-2); }
+.evidence { display: grid; gap: 8px; margin-top: 12px; }
+.evidence a { display: flex; justify-content: space-between; gap: 10px; padding: 9px; border: 1px solid var(--border); border-radius: 10px; color: var(--muted); }
+
+.timeline { display: grid; gap: 10px; }
+.timeline-item { display: grid; grid-template-columns: 120px 1fr auto; gap: 12px; padding: 12px; border: 1px solid var(--border); border-radius: 12px; background: var(--surface); }
+.event-dot { width: 8px; height: 8px; border-radius: 50%; display: inline-block; margin-right: 7px; background: var(--info); box-shadow: 0 0 0 4px oklch(70% 0.13 225 / .1); }
+
+.mobile-nav { display: none; position: fixed; left: 10px; right: 10px; bottom: 10px; z-index: 5; border: 1px solid var(--border); border-radius: 18px; background: oklch(17% 0.018 250 / .96); padding: 8px; grid-template-columns: repeat(5, 1fr); gap: 4px; }
+.mobile-nav a { min-height: 44px; display: grid; place-items: center; color: var(--muted); border-radius: 12px; font-size: 11px; }
+.mobile-nav a.active { color: var(--fg); background: var(--surface-2); }
+.mobile-nav .create { color: var(--bg); background: var(--accent); font-weight: 800; }
+
+.launcher { min-height: 100vh; padding: clamp(18px, 3vw, 42px); display: grid; align-content: center; }
+.launcher-grid { display: grid; grid-template-columns: minmax(0, .8fr) minmax(0, 1.2fr); gap: 24px; max-width: 1180px; margin: 0 auto; }
+.screen-grid { display: grid; grid-template-columns: repeat(2, minmax(0, 1fr)); gap: 12px; }
+.screen-card { display: grid; gap: 12px; padding: 16px; border: 1px solid var(--border); border-radius: var(--radius); background: var(--surface); }
+
+@media (max-width: 1400px) {
+  .creator-shell { grid-template-columns: 1fr; }
+  .flow-canvas { min-height: auto; display: grid; gap: 10px; padding: 12px; }
+  .canvas-lane, .flow-edge, .node-port, .canvas-note { display: none; }
+  .flow-node { position: static; width: 100%; min-height: 0; }
+}
+
+@media (max-width: 1180px) {
+  .metrics { grid-template-columns: repeat(3, minmax(0, 1fr)); }
+  .split, .triple, .two-col, .graph-layout, .creator-shell { grid-template-columns: 1fr; }
+  .toggle-list { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .template-grid { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+}
+
+@media (max-width: 820px) {
+  .app-shell { grid-template-columns: 1fr; }
+  .sidebar { display: none; }
+  .main { padding: 16px; padding-bottom: 88px; }
+  .mobile-nav { display: grid; }
+  .topbar { align-items: flex-start; flex-direction: column; }
+  .metrics { grid-template-columns: repeat(2, minmax(0, 1fr)); }
+  .form-grid, .launcher-grid, .screen-grid, .insight-grid { grid-template-columns: 1fr; }
+  .timeline-item { grid-template-columns: 1fr; }
+  .graph-canvas { min-height: auto; display: grid; gap: 10px; padding: 12px; background-size: 32px 32px; }
+  .edge { display: none; }
+  .node { position: static; width: 100%; border-radius: 12px; text-align: left; }
+  .creator-toolbar { align-items: flex-start; flex-direction: column; }
+  .flow-canvas { min-height: auto; display: grid; gap: 10px; padding: 12px; }
+  .canvas-lane, .flow-edge, .node-port, .canvas-note { display: none; }
+  .flow-node { position: static; width: 100%; min-height: 0; }
+}
+
+@media (max-width: 430px) {
+  .main { padding: 12px; padding-bottom: 88px; }
+  .metrics { grid-template-columns: 1fr; }
+  .toggle-list { grid-template-columns: 1fr; }
+  .template-grid { grid-template-columns: 1fr; }
+  .actions { width: 100%; }
+  .actions .btn { flex: 1; }
+  .panel-head { align-items: flex-start; flex-direction: column; }
+}
+
+
+/* ===== UrlTrack V3 polish import ===== */
+/*
+  UrlTrack — shared visual polish layer
+  Loaded after page-local styles to keep dark/light/system coherent.
+  All theme-aware tokens are here; pages only need page-specific classes.
+*/
+
+/* ===== Custom scrollbar ===== */
+::-webkit-scrollbar {
+  width: 5px;
+  height: 5px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: color-mix(in oklch, var(--border) 70%, transparent);
+  border-radius: 999px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: color-mix(in oklch, var(--border-strong) 70%, transparent);
+}
+
+/* ===== Selection ===== */
+::selection {
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+::-moz-selection {
+  background: var(--accent-soft);
+  color: var(--fg);
+}
+
+/* ===== Focus visible ===== */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+}
+button:focus:not(:focus-visible),
+input:focus:not(:focus-visible),
+select:focus:not(:focus-visible),
+textarea:focus:not(:focus-visible) {
+  outline: none;
+}
+
+/* ===== Root tokens ===== */
+:root {
+  color-scheme: dark;
+
+  --bg: oklch(8% 0.018 260);
+  --page-bg: oklch(7% 0.018 260);
+  --page-grad-a: oklch(12% 0.022 260);
+  --surface: oklch(13.5% 0.022 260);
+  --surface2: oklch(17% 0.026 260);
+  --surface3: oklch(21% 0.03 260);
+  --surface-raised: oklch(18% 0.028 260 / 0.86);
+  --fg: oklch(94% 0.008 260);
+  --muted: oklch(68% 0.022 260);
+  --subtle: oklch(51% 0.024 260);
+  --border: oklch(29% 0.032 260);
+  --border-strong: oklch(38% 0.04 260);
+
+  --accent: oklch(65% 0.18 45);
+  --accent-strong: oklch(58% 0.19 42);
+  --accent-soft: oklch(65% 0.18 45 / 0.14);
+  --accent-contrast: oklch(10% 0.02 260);
+  --accent-glow: 0 0 20px oklch(65% 0.18 45 / 0.25);
+  --green: oklch(66% 0.16 145);
+  --green-strong: oklch(55% 0.15 145);
+  --green-soft: oklch(66% 0.16 145 / 0.13);
+  --green-contrast: oklch(9% 0.018 260);
+  --blue: oklch(70% 0.15 245);
+  --blue-soft: oklch(70% 0.15 245 / 0.13);
+  --amber: oklch(72% 0.15 82);
+  --red: oklch(63% 0.19 28);
+
+  --glass: oklch(16% 0.026 260 / 0.78);
+  --glass-border: oklch(42% 0.04 260 / 0.34);
+  --shadow-soft: 0 18px 64px oklch(0% 0 0 / 0.34);
+  --shadow-card: 0 10px 34px oklch(0% 0 0 / 0.22);
+  --ring: 0 0 0 3px oklch(65% 0.18 45 / 0.22);
+
+  --radius-panel: 12px;
+  --radius-card: 10px;
+  --radius-control: 8px;
+
+  --font-display: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, sans-serif;
+  --font-body:    -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+  --font-mono:    'SF Mono', ui-monospace, Menlo, monospace;
+}
+
+html[data-theme="light"] {
+  color-scheme: light;
+
+  --bg: oklch(97.5% 0.006 250);
+  --page-bg: oklch(96.5% 0.008 250);
+  --page-grad-a: oklch(100% 0 0);
+  --surface: oklch(100% 0 0);
+  --surface2: oklch(94.5% 0.012 250);
+  --surface3: oklch(90% 0.017 250);
+  --surface-raised: oklch(100% 0 0 / 0.9);
+  --fg: oklch(17% 0.02 260);
+  --muted: oklch(42% 0.026 260);
+  --subtle: oklch(55% 0.026 260);
+  --border: oklch(82% 0.018 250);
+  --border-strong: oklch(68% 0.024 250);
+
+  --accent: oklch(58% 0.18 45);
+  --accent-strong: oklch(51% 0.18 42);
+  --accent-soft: oklch(58% 0.18 45 / 0.12);
+  --accent-contrast: oklch(99% 0 0);
+  --accent-glow: 0 0 20px oklch(58% 0.18 45 / 0.18);
+
+  --font-display: -apple-system, BlinkMacSystemFont, 'SF Pro Display', system-ui, sans-serif;
+  --font-body:    -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+  --font-mono:    'SF Mono', ui-monospace, Menlo, monospace;
+  --green: oklch(46% 0.14 145);
+  --green-strong: oklch(40% 0.13 145);
+  --green-soft: oklch(46% 0.14 145 / 0.11);
+  --green-contrast: oklch(99% 0 0);
+  --blue: oklch(50% 0.16 245);
+  --blue-soft: oklch(50% 0.16 245 / 0.11);
+  --amber: oklch(55% 0.14 82);
+  --red: oklch(50% 0.18 28);
+
+  --glass: oklch(100% 0 0 / 0.82);
+  --glass-border: oklch(78% 0.018 250 / 0.72);
+  --shadow-soft: 0 18px 58px oklch(20% 0.035 260 / 0.14);
+  --shadow-card: 0 8px 28px oklch(20% 0.035 260 / 0.09);
+  --ring: 0 0 0 3px oklch(58% 0.18 45 / 0.18);
+
+  --menu-bg: oklch(100% 0 0 / 0.88);
+  --menu-border: oklch(82% 0.018 250 / 0.6);
+}
+
+/* ===== Body & typography base ===== */
+html, body {
+  color: var(--fg);
+  text-rendering: optimizeLegibility;
+  -webkit-font-smoothing: antialiased;
+  -moz-osx-font-smoothing: grayscale;
+}
+
+body {
+  font-family: -apple-system, BlinkMacSystemFont, 'SF Pro Text', system-ui, sans-serif;
+  font-size: 14px;
+  background:
+    linear-gradient(180deg, var(--page-grad-a) 0, var(--page-bg) 320px),
+    var(--page-bg);
+  line-height: 1.55;
+}
+
+/* Home page — dot-grid hero variant */
+body:has(> .hero) {
+  background-color: var(--page-bg);
+  background-image:
+    radial-gradient(circle, color-mix(in oklch, var(--fg) 18%, transparent) 1px, transparent 1px),
+    radial-gradient(circle at 50% 38%, var(--accent-soft), transparent 34%),
+    linear-gradient(180deg, var(--page-grad-a), var(--page-bg));
+  background-size: 24px 24px, auto, auto;
+}
+
+/* Topbar clearance for app page content, not the body itself */
+body > .page { padding-top: 76px; }
+body:has(.login-card) .page,
+body:has(.mfa-card) .page { padding-top: 0; }
+
+/* Auth pages — centred card variant */
+body:has(.login-card),
+body:has(.mfa-card) {
+  background:
+    radial-gradient(circle at 22% 18%, var(--accent-soft), transparent 26%),
+    radial-gradient(circle at 78% 82%, var(--green-soft), transparent 26%),
+    linear-gradient(155deg, var(--page-grad-a), var(--page-bg));
+}
+
+/* ===== Typography scale ===== */
+h1, .page-header h1, .hero h1 {
+  color: var(--fg);
+  letter-spacing: -0.045em;
+}
+h2, h3, .card-header h2, .panel-head h2, .section-header h2 {
+  color: var(--fg);
+  letter-spacing: -0.02em;
+}
+p, .desc, .hint, .muted, .sub, .page-header p, .hero p, .panel-head p, .card-header p {
+  color: var(--muted);
+}
+a, code, .mono, .t-fp, .intel-blue {
+  color: var(--blue) !important;
+}
+
+/* ===== Menu drawer ===== */
+.menu-overlay {
+  background: oklch(0% 0 0 / 0.42) !important;
+}
+html[data-theme="light"] .menu-overlay {
+  background: oklch(18% 0.03 260 / 0.18) !important;
+}
+
+.menu-drawer {
+  width: min(292px, calc(100vw - 40px)) !important;
+  background: var(--glass) !important;
+  border-right: 1px solid var(--glass-border) !important;
+  box-shadow: var(--shadow-soft) !important;
+}
+
+.menu-header h2, .theme-label {
+  color: var(--subtle) !important;
+}
+.menu-header p {
+  color: var(--fg) !important;
+}
+
+.menu-item {
+  color: var(--muted) !important;
+  border-radius: var(--radius-control) !important;
+}
+.menu-item:hover {
+  color: var(--fg) !important;
+  background: var(--surface2) !important;
+}
+.menu-item.active {
+  color: var(--accent) !important;
+  background: var(--accent-soft) !important;
+}
+.menu-item svg {
+  color: currentColor !important;
+  background: transparent !important;
+  stroke: currentColor;
+  fill: none;
+  filter: none !important;
+  box-shadow: none !important;
+}
+
+.menu-footer {
+  border-top: 1px solid var(--border) !important;
+}
+
+.hamburger {
+  color: var(--fg) !important;
+}
+.hamburger span {
+  background: currentColor !important;
+  filter: none !important;
+  box-shadow: none !important;
+}
+
+/* ===== Theme toggle ===== */
+.theme-toggle {
+  background: var(--surface2) !important;
+  border-color: var(--border-strong) !important;
+  border-radius: var(--radius-control) !important;
+}
+.theme-toggle-indicator {
+  background: linear-gradient(135deg, var(--accent), var(--green)) !important;
+  box-shadow: none !important;
+  border-radius: calc(var(--radius-control) - 2px) !important;
+}
+.theme-option {
+  color: var(--muted) !important;
+}
+.theme-option[aria-pressed="true"],
+.theme-option.is-active,
+html[data-theme-choice="dark"] .theme-option[data-theme-option="dark"],
+html[data-theme-choice="light"] .theme-option[data-theme-option="light"],
+html[data-theme-choice="system"] .theme-option[data-theme-option="system"] {
+  color: var(--accent-contrast) !important;
+}
+
+/* ===== Cards & panels ===== */
+.card,
+.panel,
+.kpi-card,
+.chart-card,
+.filter-panel,
+.data-table-wrap,
+.table-wrap,
+.overlay-panel,
+.intel-panel,
+.intel-card,
+.intel-kpi-card,
+.hub-card,
+.detail-card,
+.template-card,
+.event,
+.info-panel,
+.modal-card,
+.login-card,
+.mfa-card,
+.chat-panel {
+  background: var(--surface-raised) !important;
+  border: 1px solid var(--glass-border) !important;
+  border-radius: var(--radius-panel) !important;
+  box-shadow: var(--shadow-card) !important;
+  transition: border-color 0.2s, box-shadow 0.2s;
+}
+.card:focus-within,
+.panel:focus-within {
+  border-color: var(--accent) !important;
+  box-shadow: var(--ring), var(--shadow-card) !important;
+}
+
+.card-header, .panel-head, .table-header, .intel-card-header, .nc-panel-header {
+  border-bottom-color: var(--border) !important;
+  background: color-mix(in oklch, var(--surface2) 60%, transparent) !important;
+}
+.card-body, .panel-body {
+  color: var(--fg);
+}
+
+/* ===== Form controls ===== */
+input, select, textarea,
+.env-input, .code-input,
+.search-bar input,
+.chat-input-wrap input,
+.composer textarea,
+.nc-field-input,
+.nc-field-select {
+  background: var(--surface) !important;
+  border: 1px solid var(--border-strong) !important;
+  color: var(--fg) !important;
+  border-radius: var(--radius-control) !important;
+  transition: border-color 0.16s, box-shadow 0.16s;
+}
+input::placeholder, textarea::placeholder {
+  color: var(--subtle) !important;
+  opacity: 1 !important;
+}
+input:focus, select:focus, textarea:focus,
+.nc-field-input:focus, .nc-field-select:focus {
+  border-color: var(--accent) !important;
+  box-shadow: var(--ring) !important;
+  outline: none !important;
+}
+
+/* ===== Buttons ===== */
+button, .btn, .btn-sm, .ctrl-btn, .action-btn,
+.graph-btn, .filter-btn, .starter-chip, .chip,
+.btn-secondary, .passkey-btn,
+.filter, .pill, .tag, .count-badge, .confidence-badge,
+.confidence-pill, .identity-tab, .mini-btn, .reason-chip,
+.ip-chip, .fp-chip, .link-chip {
+  border-radius: var(--radius-control) !important;
+  transition: background 0.15s, border-color 0.15s, color 0.15s, transform 0.12s;
+  cursor: pointer;
+}
+.btn:active, .btn-sm:active, .ctrl-btn:active,
+.action-btn:active, .graph-btn:active, .filter-btn:active,
+.starter-chip:active, .chip:active, .passkey-btn:active {
+  transform: scale(0.96) !important;
+}
+
+.btn, .btn-sm, .ctrl-btn, .action-btn,
+.graph-btn, .filter-btn, .starter-chip, .chip,
+.btn-secondary, .passkey-btn {
+  background: var(--surface2) !important;
+  border: 1px solid var(--border) !important;
+  color: var(--fg) !important;
+}
+.btn:hover, .btn-sm:hover, .ctrl-btn:hover,
+.action-btn:hover, .graph-btn:hover, .filter-btn:hover,
+.starter-chip:hover, .chip:hover, .passkey-btn:hover {
+  border-color: var(--accent) !important;
+  color: var(--accent) !important;
+  background: var(--accent-soft) !important;
+}
+
+.btn-primary, .primary, button.primary,
+.ctrl-btn.primary, .np-actions button.primary,
+.edit-modal-actions button.primary,
+.chat-send, .chat-bubble, .chat-bubble-btn {
+  background: var(--accent) !important;
+  border-color: var(--accent) !important;
+  color: var(--accent-contrast) !important;
+}
+.chat-bubble-btn,
+.chat-bubble {
+  border-radius: 50% !important;
+}
+.chat-analyst-link {
+  margin-left: auto;
+  margin-right: 8px;
+  padding: 5px 8px !important;
+  border: 1px solid var(--border) !important;
+  background: var(--surface2) !important;
+  color: var(--accent) !important;
+  border-radius: var(--radius-control) !important;
+  font-size: 10px !important;
+  font-weight: 800 !important;
+  letter-spacing: .04em;
+  text-transform: uppercase;
+}
+.chat-analyst-link:hover {
+  border-color: var(--accent) !important;
+  background: var(--accent-soft) !important;
+}
+.btn-primary:hover, .primary:hover, button.primary:hover,
+.ctrl-btn.primary:hover, .np-actions button.primary:hover,
+.edit-modal-actions button.primary:hover {
+  background: var(--accent-strong) !important;
+  border-color: var(--accent-strong) !important;
+  color: var(--accent-contrast) !important;
+}
+
+.btn-danger, .nc-actions button.nc-del {
+  background: color-mix(in oklch, var(--red) 14%, transparent) !important;
+  border-color: color-mix(in oklch, var(--red) 42%, var(--border)) !important;
+  color: var(--red) !important;
+}
+
+/* ===== Tables ===== */
+table {
+  color: var(--fg);
+}
+th {
+  color: var(--subtle) !important;
+  background: var(--surface2) !important;
+  border-bottom: 1px solid var(--border) !important;
+  font-size: 11px !important;
+  letter-spacing: 0.08em !important;
+  text-transform: uppercase !important;
+  font-weight: 600 !important;
+}
+td {
+  color: var(--fg) !important;
+  border-bottom-color: var(--border) !important;
+}
+tbody tr:hover,
+.event:hover,
+.folder-card:hover,
+.context-card:hover,
+.intent-card:hover,
+.template-card:hover {
+  background: color-mix(in oklch, var(--surface2) 78%, var(--accent-soft)) !important;
+}
+
+/* ===== Pills & badges ===== */
+.td-pill, .pill, .tag, .source-pill, .intel-badge, .app-pill, .hook-chip {
+  border: 1px solid var(--border) !important;
+  background: var(--surface2) !important;
+  color: var(--fg) !important;
+}
+.trend-up, .green, .up, .kpi-delta.up {
+  color: var(--green) !important;
+}
+.trend-down, .down, .risk, .kpi-delta.down {
+  color: var(--red) !important;
+}
+.metric-num, .kpi-value, .ik-value, .num, .dc-value {
+  color: var(--fg) !important;
+}
+.metric-pct, .kpi-sub, .kpi-label, .dc-label,
+.ik-label, .label, .time, .event-time {
+  color: var(--muted) !important;
+}
+
+/* ===== Settings nav ===== */
+.settings-nav {
+  background: var(--surface-raised) !important;
+  border: 1px solid var(--glass-border) !important;
+  border-radius: var(--radius-panel) !important;
+  box-shadow: var(--shadow-card) !important;
+  display: flex;
+  gap: 2px;
+  padding: 4px 6px;
+  width: fit-content;
+  margin: 0 auto;
+}
+.settings-nav-item {
+  color: var(--muted) !important;
+  border-radius: var(--radius-control) !important;
+  padding: 6px 16px;
+  font-size: 12px;
+  font-weight: 600;
+  transition: background 0.15s, color 0.15s;
+}
+.settings-nav-item.active,
+.settings-nav-item:hover {
+  color: var(--accent) !important;
+  background: var(--accent-soft) !important;
+}
+
+.nav-pref-row {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 10px 12px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius-control);
+  background: var(--surface2);
+  cursor: grab;
+  transition: border-color 0.16s, background 0.16s, transform 0.16s;
+}
+.nav-pref-row:hover,
+.nav-pref-row.is-over {
+  border-color: var(--accent);
+  background: var(--accent-soft);
+}
+.nav-pref-row.is-dragging {
+  opacity: 0.45;
+  transform: scale(0.985);
+}
+.drag-handle {
+  color: var(--subtle);
+  font-size: 14px;
+  line-height: 1;
+}
+.nav-pref-label {
+  flex: 1;
+  color: var(--fg);
+  font-weight: 650;
+  font-size: 13px;
+}
+.nav-pref-meta {
+  color: var(--muted);
+  font-size: 10px;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+/* ===== Folder cards ===== */
+.folder-card {
+  background: var(--surface-raised) !important;
+  border-color: var(--glass-border) !important;
+}
+.folder-icon, .folder-mini {
+  color: var(--accent) !important;
+  background: var(--accent-soft) !important;
+}
+
+/* ===== Chat ===== */
+.chat-msg {
+  background: var(--surface2) !important;
+  border-color: var(--border) !important;
+  color: var(--fg) !important;
+}
+.chat-msg.user {
+  background: var(--accent) !important;
+  color: var(--accent-contrast) !important;
+  border-color: var(--accent) !important;
+}
+.chat-msg.ai {
+  background: var(--green-soft) !important;
+  color: var(--fg) !important;
+}
+
+/* ===== Toast ===== */
+.toast {
+  background: var(--surface-raised) !important;
+  border-color: var(--glass-border) !important;
+  color: var(--fg) !important;
+  box-shadow: var(--shadow-card) !important;
+}
+
+/* ===== Intel ===== */
+.intel-actions button.primary,
+.intel-blue, .t-fp,
+.intel-summary-item .si-value.blue {
+  color: var(--blue) !important;
+}
+.intel-actions button.primary {
+  background: var(--blue) !important;
+  color: oklch(99% 0 0) !important;
+  border-color: var(--blue) !important;
+}
+.intel-badge.id {
+  background: var(--blue-soft) !important;
+  color: var(--blue) !important;
+}
+.intel-badge.risk, .intel-badge.os {
+  background: var(--accent-soft) !important;
+  color: var(--accent) !important;
+}
+
+/* ===== Node creator (operational dark surface, stays dark in light mode) ===== */
+.nc-wrap {
+  --bg: oklch(7% 0.016 260);
+  --surface: oklch(12% 0.02 260);
+  --surface2: oklch(17% 0.025 260);
+  --surface3: oklch(21% 0.03 260);
+  --fg: oklch(94% 0.008 260);
+  --muted: oklch(68% 0.022 260);
+  --border: oklch(31% 0.035 260);
+  --glass: oklch(13% 0.022 260 / 0.88);
+  --glass-border: oklch(45% 0.04 260 / 0.34);
+  background: linear-gradient(180deg, oklch(8% 0.016 260), oklch(5% 0.012 260)) !important;
+  color: var(--fg) !important;
+}
+.nc-sidebar, .nc-panel, .nc-topbar {
+  background: var(--glass) !important;
+  border-color: var(--glass-border) !important;
+}
+.nc-pill {
+  background: var(--surface2) !important;
+  border-color: var(--border) !important;
+  color: var(--fg) !important;
+}
+.nc-pill:hover {
+  background: color-mix(in oklch, var(--surface3) 76%, var(--accent-soft)) !important;
+}
+.nc-miniviewport {
+  stroke: color-mix(in oklch, var(--fg) 34%, transparent) !important;
+}
+
+html[data-theme="light"] .qr-placeholder,
+html[data-theme="light"] .qr-preview {
+  background: oklch(100% 0 0) !important;
+  color: var(--fg) !important;
+}
+
+/* ===== Animations ===== */
+@keyframes fadeIn {
+  from { opacity: 0; transform: translateY(6px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes fadeScale {
+  from { opacity: 0; transform: scale(0.92); }
+  to { opacity: 1; transform: scale(1); }
+}
+@keyframes slideUp {
+  from { opacity: 0; transform: translateY(16px); }
+  to { opacity: 1; transform: translateY(0); }
+}
+@keyframes toastSlide {
+  from { opacity: 0; transform: translateY(12px) scale(0.94); }
+  to { opacity: 1; transform: translateY(0) scale(1); }
+}
+@keyframes pulseGlow {
+  0%, 100% { box-shadow: 0 0 0 0 var(--accent-soft); }
+  50% { box-shadow: 0 0 20px 4px var(--accent-soft); }
+}
+
+.page-fade-in {
+  animation: fadeIn 0.45s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.toast.show {
+  animation: toastSlide 0.3s cubic-bezier(0.16, 1, 0.3, 1);
+}
+.overlay-panel {
+  animation: fadeScale 0.28s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.chat-panel {
+  animation: slideUp 0.25s cubic-bezier(0.22, 1, 0.36, 1);
+}
+.chat-bubble-btn {
+  animation: pulseGlow 3s ease-in-out infinite;
+}
+
+/* ===== Floating Top Bar ===== */
+.topbar {
+  position: sticky; top: 20px; z-index: 110;
+  width: min(1180px, calc(100vw - 40px));
+  min-width: 0;
+  margin: 20px auto 0;
+  display: flex; align-items: center;
+  height: 50px; padding: 0 8px;
+  background: oklch(13% 0.025 260/0.72);
+  backdrop-filter: blur(20px) saturate(1.4);
+  -webkit-backdrop-filter: blur(20px) saturate(1.4);
+  border: 1px solid oklch(42% 0.04 260/0.2);
+  border-radius: 12px;
+  box-shadow: 0 8px 40px oklch(0% 0 0/0.3), inset 0 1px 0 oklch(100% 0 0/0.04);
+}
+
+.topbar-logo {
+  display: flex; align-items: center; justify-content: center;
+  width: 32px; height: 32px; border-radius: 8px;
+  background: var(--accent); color: var(--accent-contrast);
+  font-family: var(--font-display); font-size: 16px; font-weight: 700;
+  margin: 0 12px 0 4px; flex-shrink: 0;
+  text-decoration: none; border: none; cursor: pointer;
+}
+
+.topbar-nav {
+  display: flex; align-items: center; gap: 2px;
+  flex: 1;
+  min-width: 0;
+  overflow: hidden;
+}
+
+.topbar-item {
+  position: relative;
+  display: flex; align-items: center; height: 32px;
+  padding: 0 14px; border-radius: 8px;
+  font-size: 13.5px; font-weight: 450; color: var(--muted);
+  cursor: pointer; white-space: nowrap;
+  background: transparent; border: none;
+  transition: color 0.2s, background 0.2s;
+}
+.topbar-item:hover { color: var(--fg); background: oklch(100% 0 0/0.04); }
+.topbar-item.active {
+  color: var(--fg); background: oklch(100% 0 0/0.06);
+}
+.topbar-item.active::after {
+  content: ''; position: absolute; bottom: 0; left: 10px; right: 10px;
+  height: 2px; border-radius: 1px;
+  background: var(--accent);
+  box-shadow: 0 0 8px var(--accent);
+}
+
+.more-btn {
+  display: flex; align-items: center; height: 32px;
+  padding: 0 10px; border-radius: 8px;
+  font-size: 13.5px; font-weight: 450; color: var(--subtle);
+  cursor: pointer; background: transparent; border: none;
+  transition: color 0.2s, background 0.2s;
+  gap: 3px;
+}
+.more-btn:hover { color: var(--fg); background: oklch(100% 0 0/0.04); }
+.more-btn svg { width: 14px; height: 14px; opacity: 0.6; }
+
+.more-dropdown {
+  position: absolute; top: calc(100% + 4px); right: 0;
+  background: oklch(16% 0.028 260/0.9);
+  backdrop-filter: blur(24px); -webkit-backdrop-filter: blur(24px);
+  border: 1px solid var(--glass-border);
+  border-radius: 10px; padding: 6px;
+  min-width: 190px;
+  box-shadow: 0 16px 48px oklch(0% 0 0/0.5);
+  opacity: 0; visibility: hidden;
+  transform: translateY(-6px); transition: all 0.25s cubic-bezier(0.22,1,0.36,1);
+}
+.more-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+.more-dropdown-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 9px 12px; border-radius: 8px;
+  font-size: 13.5px; color: var(--muted); cursor: pointer;
+  transition: all 0.15s; border: none; background: none; width: 100%; text-align: left;
+}
+.more-dropdown-item:hover { background: oklch(100% 0 0/0.05); color: var(--fg); }
+.more-dropdown-item.active {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.more-dropdown-item svg { width: 16px; height: 16px; opacity: 0.5; flex-shrink: 0; }
+.more-dropdown-item span { font-size: 11px; color: var(--subtle); margin-left: auto; }
+
+.topbar-right {
+  display: flex; align-items: center; gap: 4px; margin-left: auto;
+  flex-shrink: 0;
+}
+
+/* Theme pill */
+.theme-pill {
+  display: flex; align-items: center; gap: 0;
+  height: 28px; padding: 2px; border-radius: 8px;
+  background: oklch(100% 0 0/0.04);
+  border: 1px solid oklch(42% 0.04 260/0.12);
+  position: relative;
+}
+.theme-opt {
+  position: relative; z-index: 2;
+  display: flex; align-items: center; justify-content: center;
+  width: 30px; height: 24px; border-radius: 6px;
+  cursor: pointer; border: none; background: none;
+  color: var(--subtle); transition: color 0.2s;
+}
+.theme-opt svg { width: 14px; height: 14px; }
+.theme-opt.active { color: var(--fg); }
+.theme-slider {
+  position: absolute; z-index: 1; top: 2px; bottom: 2px;
+  width: 30px; border-radius: 6px;
+  background: var(--accent-soft);
+  border: 1px solid oklch(65% 0.18 45/0.2);
+  transition: transform 0.25s cubic-bezier(0.22,1,0.36,1);
+}
+.theme-slider.pos-0 { transform: translateX(0); }
+.theme-slider.pos-1 { transform: translateX(30px); }
+.theme-slider.pos-2 { transform: translateX(60px); }
+
+/* Avatar */
+.topbar-avatar {
+  position: relative;
+  width: 30px; height: 30px; border-radius: 8px;
+  display: flex; align-items: center; justify-content: center;
+  cursor: pointer; border: none; background: var(--accent-soft);
+  color: var(--accent); margin-left: 4px;
+  transition: background 0.2s;
+}
+.topbar-avatar:hover { background: oklch(65% 0.18 45/0.22); }
+.topbar-avatar svg { width: 16px; height: 16px; }
+
+.avatar-dropdown {
+  position: absolute; top: calc(100% + 6px); right: 0;
+  background: oklch(16% 0.028 260/0.92);
+  backdrop-filter: blur(24px); -webkit-backdrop-filter: blur(24px);
+  border: 1px solid var(--glass-border);
+  border-radius: 10px; padding: 6px;
+  min-width: 160px;
+  box-shadow: 0 16px 48px oklch(0% 0 0/0.5);
+  opacity: 0; visibility: hidden;
+  transform: translateY(-4px); transition: all 0.2s cubic-bezier(0.22,1,0.36,1);
+}
+.avatar-dropdown.open { opacity: 1; visibility: visible; transform: translateY(0); }
+.avatar-dropdown .user-info {
+  padding: 8px 12px 10px; border-bottom: 1px solid var(--border);
+  margin-bottom: 4px;
+}
+.avatar-dropdown .user-info .name { font-size: 14px; font-weight: 500; }
+.avatar-dropdown .user-info .email { font-size: 12px; color: var(--subtle); margin-top: 1px; }
+.avatar-dropdown .dd-item {
+  display: flex; align-items: center; gap: 10px;
+  padding: 8px 12px; border-radius: 6px;
+  font-size: 13px; color: var(--muted); cursor: pointer;
+  transition: all 0.15s; border: none; background: none; width: 100%; text-align: left;
+}
+.avatar-dropdown .dd-item:hover { background: oklch(100% 0 0/0.05); color: var(--fg); }
+.avatar-dropdown .dd-item.active {
+  color: var(--accent);
+  background: var(--accent-soft);
+}
+.avatar-dropdown .dd-item svg { width: 15px; height: 15px; opacity: 0.5; flex-shrink: 0; }
+
+/* Light theme overrides for topbar */
+html[data-theme="light"] .topbar {
+  background: oklch(98% 0.006 250/0.78);
+  border-color: oklch(80% 0.02 250/0.3);
+  box-shadow: 0 4px 24px oklch(0% 0 0/0.06), inset 0 1px 0 oklch(100% 0 0/0.6);
+}
+html[data-theme="light"] .theme-pill { background: oklch(0% 0 0/0.04); }
+html[data-theme="light"] .more-dropdown,
+html[data-theme="light"] .avatar-dropdown {
+  background: oklch(98% 0.006 250/0.92);
+}
+html[data-theme="light"] .topbar-item:hover { background: oklch(0% 0 0/0.03); }
+html[data-theme="light"] .topbar-item.active { background: oklch(0% 0 0/0.04); }
+
+/* More wrap — responsive overflow container */
+.more-wrap {
+  position: relative;
+  flex-shrink: 0;
+}
+
+/* ===== Responsive radius tightening ===== */
+@media (max-width: 720px) {
+  .card, .panel, .kpi-card, .chart-card, .filter-panel,
+  .data-table-wrap, .table-wrap, .overlay-panel, .hub-card {
+    border-radius: var(--radius-panel) !important;
+  }
+}
+
+/* ===== UrlTrack V3 feature overrides ===== */
+.qr-editor-grid {
+  display: grid;
+  grid-template-columns: minmax(280px, 0.9fr) minmax(320px, 1.1fr);
+  gap: 16px;
+  align-items: start;
+}
+
+.qr-preview-stage {
+  display: grid;
+  place-items: center;
+  min-height: 360px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background: color-mix(in oklch, var(--surface2) 74%, transparent);
+}
+
+.signal-badge {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  min-height: 24px;
+  padding: 3px 8px;
+  border-radius: 999px;
+  border: 1px solid var(--border);
+  color: var(--fg);
+  background: var(--surface2);
+  font-size: 12px;
+  font-weight: 650;
+}
+
+.signal-badge[data-signal="thumbmark"],
+.signal-badge.thumbmark {
+  color: var(--blue);
+  background: var(--blue-soft);
+  border-color: color-mix(in oklch, var(--blue) 32%, transparent);
+}
+
+.signal-badge[data-signal="risk"],
+.signal-badge.risk {
+  color: var(--red);
+  background: color-mix(in oklch, var(--red) 14%, transparent);
+  border-color: color-mix(in oklch, var(--red) 32%, transparent);
+}
+
+.confidence-ring {
+  --confidence: 0;
+  width: 44px;
+  height: 44px;
+  border-radius: 50%;
+  display: grid;
+  place-items: center;
+  background:
+    radial-gradient(circle at center, var(--surface) 54%, transparent 55%),
+    conic-gradient(var(--green) calc(var(--confidence) * 1%), var(--border) 0);
+  color: var(--fg);
+  font-size: 12px;
+  font-weight: 800;
+}
+
+.nc-wrap {
+  min-height: 520px;
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  background:
+    linear-gradient(color-mix(in oklch, var(--border) 28%, transparent) 1px, transparent 1px),
+    linear-gradient(90deg, color-mix(in oklch, var(--border) 28%, transparent) 1px, transparent 1px),
+    var(--surface);
+  background-size: 28px 28px;
+  overflow: hidden;
+}
+
+.nc-node {
+  border: 1px solid var(--glass-border);
+  border-radius: 10px;
+  background: var(--glass);
+  box-shadow: var(--shadow-card);
+  color: var(--fg);
+}
+
+@media (max-width: 920px) {
+  .qr-editor-grid {
+    grid-template-columns: 1fr;
+  }
+}

--- a/server/static/js/urltrack.js
+++ b/server/static/js/urltrack.js
@@ -1,0 +1,169 @@
+function setActiveNav() {
+  const current = location.pathname.split('/').pop() || 'index.html';
+  const aliases = {
+    'lead-detail.html': 'leads.html',
+    'visit-detail.html': 'dashboard.html'
+  };
+  const active = aliases[current] || current;
+  document.querySelectorAll('[data-nav]').forEach((link) => {
+    const href = link.getAttribute('href');
+    if (href === active) link.classList.add('active');
+  });
+}
+
+function bindToggles() {
+  document.querySelectorAll('.toggle').forEach((toggle) => {
+    toggle.addEventListener('click', () => toggle.classList.toggle('enabled'));
+  });
+}
+
+function bindModeChips() {
+  document.querySelectorAll('.mode-chip').forEach((chip) => {
+    chip.addEventListener('click', () => {
+      const group = chip.closest('.mode-strip');
+      if (!group) return;
+      group.querySelectorAll('.mode-chip').forEach((item) => item.classList.remove('active'));
+      chip.classList.add('active');
+    });
+  });
+}
+
+function bindTabs() {
+  document.querySelectorAll('[data-tab-target]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const target = button.dataset.tabTarget;
+      const scope = button.closest('[data-tabs]') || document;
+      scope.querySelectorAll('[data-tab-target]').forEach((item) => item.classList.remove('active'));
+      button.classList.add('active');
+      scope.querySelectorAll('.tab-panel').forEach((panel) => {
+        panel.hidden = panel.id !== target;
+      });
+    });
+  });
+}
+
+function bindTechnicalToggle() {
+  document.querySelectorAll('[data-toggle-technical]').forEach((button) => {
+    button.addEventListener('click', () => {
+      const panel = document.querySelector(button.dataset.toggleTechnical);
+      if (!panel) return;
+      panel.hidden = !panel.hidden;
+      button.textContent = panel.hidden ? 'Show technical fingerprint' : 'Hide technical fingerprint';
+    });
+  });
+}
+
+function bindGraph() {
+  const nodes = document.querySelectorAll('.node');
+  const title = document.querySelector('[data-node-title]');
+  const body = document.querySelector('[data-node-body]');
+  nodes.forEach((node) => {
+    node.addEventListener('click', () => {
+      nodes.forEach((item) => item.classList.remove('active'));
+      node.classList.add('active');
+      if (title) title.textContent = node.dataset.title || node.textContent.trim();
+      if (body) body.textContent = node.dataset.body || 'Supporting visits loaded from shared identifiers and campaign overlap.';
+    });
+  });
+}
+
+const nodeCopy = {
+  entry: {
+    title: 'Short link entry',
+    body: 'Owns the public URL, domain, slug, UTM tags, and first-touch event. It should stay readable because this is what the operator shares.',
+    rules: ['Domain: go.urltrack.io', 'Slug: investor-pack', 'Campaign: Investor access']
+  },
+  gate: {
+    title: 'Access gate',
+    body: 'Decides who can continue. Combine email capture, password, captcha, consent, max clicks, expiration, and country rules without hiding the visitor path.',
+    rules: ['Email required for unknown visitors', 'Captcha only when risk > 65', 'Consent shown before fingerprinting']
+  },
+  risk: {
+    title: 'Risk decision',
+    body: 'Scores traffic using VPN, hosting ASN, missing JS, repeated fingerprint, impossible travel, and failed gate attempts.',
+    rules: ['Block VPN + failed captcha', 'Safe-route hosting ASN', 'Watch repeated canvas hash']
+  },
+  route: {
+    title: 'Smart routing',
+    body: 'Sends visitors to the right destination by device, country, campaign family, or risk. Safe URLs keep suspicious traffic away from protected assets.',
+    rules: ['iOS -> TestFlight landing', 'Desktop -> secure demo room', 'Risk > 80 -> safe URL']
+  },
+  capture: {
+    title: 'Lead capture',
+    body: 'Turns repeated visits into people or entities. Captured fields feed Lead Intelligence and AI evidence citations.',
+    rules: ['Fields: email, name, company', 'Score +18 after second visit', 'Webhook to CRM enrichment']
+  },
+  qr: {
+    title: 'Dynamic QR',
+    body: 'Shares the same link rules while separating scan analytics from regular clicks. Useful for events, print, and field sales.',
+    rules: ['Scan source: booth-qr', 'Export SVG', 'Event segment retained']
+  },
+  alert: {
+    title: 'Alert and evidence',
+    body: 'Creates the audit trail: notifications, database events, journey graph edges, and AI Analyst citations.',
+    rules: ['Telegram for hot leads', 'Webhook for blocked traffic', 'Evidence saved to visit file']
+  }
+};
+
+function bindCreatorCanvas() {
+  const nodes = document.querySelectorAll('[data-flow-node]');
+  const title = document.querySelector('[data-inspector-title]');
+  const body = document.querySelector('[data-inspector-body]');
+  const rules = document.querySelector('[data-inspector-rules]');
+  if (!nodes.length || !title || !body || !rules) return;
+
+  const selectNode = (node) => {
+    const id = node.dataset.flowNode;
+    const copy = nodeCopy[id] || nodeCopy.entry;
+    nodes.forEach((item) => item.classList.remove('selected'));
+    node.classList.add('selected');
+    title.textContent = copy.title;
+    body.textContent = copy.body;
+    rules.innerHTML = copy.rules.map((rule) => '<div class="rule-row"><span>' + rule + '</span><span class="badge info">Live</span></div>').join('');
+  };
+
+  nodes.forEach((node) => {
+    node.addEventListener('click', () => selectNode(node));
+  });
+  selectNode(document.querySelector('[data-flow-node].selected') || nodes[0]);
+}
+
+function bindRunPreview() {
+  const button = document.querySelector('[data-run-flow]');
+  const output = document.querySelector('[data-run-output]');
+  if (!button || !output) return;
+  button.addEventListener('click', () => {
+    const rows = [
+      ['1', 'Visitor opens go.urltrack.io/investor-pack', 'Tracked'],
+      ['2', 'Email gate appears because identity is unknown', 'Gate'],
+      ['3', 'Captcha skipped after low-risk browser signal', 'Clean'],
+      ['4', 'Desktop route sends visitor to secure demo room', 'Routed'],
+      ['5', 'Lead score increases and Telegram alert fires', 'Alert']
+    ];
+    output.innerHTML = rows.map((row) => '<div class="run-step"><span class="run-index">' + row[0] + '</span><span>' + row[1] + '</span><span class="badge success">' + row[2] + '</span></div>').join('');
+  });
+}
+
+function bindAiConsole() {
+  const input = document.querySelector('[data-ai-input]');
+  const output = document.querySelector('[data-ai-output]');
+  const button = document.querySelector('[data-ai-run]');
+  if (!input || !output || !button) return;
+  button.addEventListener('click', () => {
+    const query = input.value.trim() || '@hash:cv-9a81 explain related visits';
+    output.innerHTML = '<strong>Analyst result</strong><p>' +
+      'Query "' + query.replace(/[<>&]/g, '') + '" matches 4 visits across 2 campaigns. Highest confidence link is repeated canvas hash plus a shared MacBook browser profile. Review VT-1049 before releasing the gate block.</p>';
+  });
+}
+
+document.addEventListener('DOMContentLoaded', () => {
+  setActiveNav();
+  bindToggles();
+  bindModeChips();
+  bindTabs();
+  bindTechnicalToggle();
+  bindGraph();
+  bindCreatorCanvas();
+  bindRunPreview();
+  bindAiConsole();
+});

--- a/server/supabase_client.py
+++ b/server/supabase_client.py
@@ -1,0 +1,21 @@
+import os
+from typing import Any
+
+
+_client: Any | None = None
+
+
+def get_supabase() -> Any:
+    global _client
+    if _client is None:
+        try:
+            from supabase import create_client
+        except ImportError as exc:
+            raise RuntimeError("Install server requirements to enable Supabase Auth") from exc
+
+        url = os.environ.get("SUPABASE_URL")
+        key = os.environ.get("SUPABASE_SERVICE_ROLE_KEY") or os.environ.get("SUPABASE_ANON_KEY")
+        if not url or not key:
+            raise RuntimeError("SUPABASE_URL and SUPABASE_SERVICE_ROLE_KEY must be set")
+        _client = create_client(url, key)
+    return _client

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -1,173 +1,187 @@
 <!DOCTYPE html>
-<html lang="en">
+<html lang="en" data-theme="dark">
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>UrlTrack Dashboard</title>
+    <title>{% block title %}UrlTrack V3{% endblock %}</title>
+    <script nonce="{{ csp_nonce|default('') }}">
+    (function(){
+      function normalizeTheme(value) {
+        if (value === 'white') return 'light';
+        if (value === 'dark' || value === 'light' || value === 'system') return value;
+        return 'system';
+      }
+      try {
+        var raw = localStorage.getItem('urltrack-theme') || localStorage.getItem('urltrack-theme-choice');
+        var choice = normalizeTheme(raw);
+        localStorage.setItem('urltrack-theme', choice);
+        localStorage.setItem('urltrack-theme-choice', choice);
+        var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+        var resolved = choice === 'system' ? (prefersDark ? 'dark' : 'light') : choice;
+        document.documentElement.dataset.themeChoice = choice;
+        document.documentElement.dataset.theme = resolved;
+      } catch (err) {
+        document.documentElement.dataset.themeChoice = 'system';
+        document.documentElement.dataset.theme = 'dark';
+      }
+    })();
+    </script>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet">
     <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/6.5.2/css/all.min.css">
     <link rel="stylesheet" href="{{ url_for('static', filename='css/dashboard.css') }}">
+    <link rel="stylesheet" href="{{ url_for('static', filename='css/urltrack.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js" nonce="{{ csp_nonce|default('') }}"></script>
     <meta name="csrf-token" content="{{ csrf_token() }}">
+    <style>
+      .v3-shell { min-height: 100vh; background: var(--page-bg, var(--bg)); color: var(--fg); }
+      .v3-topbar {
+        position: sticky; top: 12px; z-index: 100; margin: 0 auto 18px; width: min(1440px, calc(100% - 24px));
+        display: flex; align-items: center; gap: 8px; min-height: 52px; padding: 6px 8px;
+        background: var(--glass, oklch(16% 0.026 260 / 0.78)); border: 1px solid var(--glass-border, var(--border));
+        border-radius: 12px; box-shadow: var(--shadow-card, 0 10px 34px rgba(0,0,0,.22)); backdrop-filter: blur(22px) saturate(1.3);
+      }
+      .v3-logo { width: 34px; height: 34px; border-radius: 9px; display: grid; place-items: center; color: var(--accent-contrast, #111); background: var(--accent); font-weight: 800; flex: 0 0 auto; }
+      .v3-nav { display: flex; align-items: center; gap: 2px; flex: 1; min-width: 0; overflow-x: auto; scrollbar-width: none; }
+      .v3-nav::-webkit-scrollbar { display: none; }
+      .v3-nav a, .v3-menu-btn, .v3-avatar-btn {
+        min-height: 34px; border: 0; border-radius: 8px; background: transparent; color: var(--muted);
+        display: inline-flex; align-items: center; gap: 8px; padding: 0 12px; font-size: 13px; cursor: pointer; white-space: nowrap;
+      }
+      .v3-nav a:hover, .v3-nav a.active, .v3-menu-btn:hover, .v3-avatar-btn:hover { color: var(--fg); background: color-mix(in oklch, var(--surface3) 45%, transparent); }
+      .v3-nav a.active { box-shadow: inset 0 -2px 0 var(--accent); }
+      .v3-right { position: relative; display: flex; align-items: center; gap: 6px; margin-left: auto; }
+      .v3-dropdown { position: absolute; right: 0; top: calc(100% + 8px); min-width: 210px; padding: 6px; display: none; background: var(--glass); border: 1px solid var(--glass-border); border-radius: 10px; box-shadow: var(--shadow-card); }
+      .v3-dropdown.open { display: grid; gap: 2px; }
+      .v3-dropdown a, .v3-dropdown button { width: 100%; justify-content: flex-start; min-height: 36px; border: 0; border-radius: 8px; padding: 0 10px; color: var(--muted); background: transparent; display: flex; align-items: center; gap: 9px; font-size: 13px; cursor: pointer; text-align: left; }
+      .v3-dropdown a:hover, .v3-dropdown button:hover { color: var(--fg); background: color-mix(in oklch, var(--surface3) 45%, transparent); }
+      .theme-pill { display: flex; align-items: center; gap: 2px; padding: 2px; border: 1px solid var(--border); border-radius: 8px; background: color-mix(in oklch, var(--surface2) 70%, transparent); }
+      .theme-opt { width: 28px; min-height: 26px; display: grid; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--subtle, var(--muted)); cursor: pointer; }
+      .theme-opt.active { color: var(--accent); background: var(--accent-soft); }
+      .v3-main { width: min(1440px, calc(100% - 24px)); margin: 0 auto; padding: 0 0 88px; }
+      .v3-page-head { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin: 12px 0 14px; }
+      .v3-search { width: min(360px, 38vw); min-height: 36px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface); color: var(--fg); padding: 0 12px; }
+      .v3-flash { display: grid; gap: 8px; margin-bottom: 14px; }
+      .chat-bubble { position: fixed; right: 18px; bottom: 18px; z-index: 80; width: 44px; height: 44px; border-radius: 12px; border: 1px solid var(--border); background: var(--accent); color: var(--accent-contrast, #111); display: grid; place-items: center; box-shadow: var(--shadow-card); }
+      .toast-stack { position: fixed; right: 18px; bottom: 74px; z-index: 79; display: grid; gap: 8px; max-width: 340px; }
+      @media (max-width: 860px) {
+        .v3-topbar { top: 8px; width: calc(100% - 16px); }
+        .v3-main { width: calc(100% - 16px); }
+        .v3-page-head { align-items: stretch; flex-direction: column; }
+        .v3-search { width: 100%; }
+      }
+    </style>
     <script nonce="{{ csp_nonce|default('') }}">
-        const originalFetch = window.fetch;
-        window.fetch = async (...args) => {
-            let [resource, config] = args;
-            config = config || {};
-            config.headers = config.headers || {};
-            const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
-            if (csrfToken && !config.headers['X-CSRFToken']) {
-                config.headers['X-CSRFToken'] = csrfToken;
-                config.headers['X-Requested-With'] = 'XMLHttpRequest';
-            }
-            return originalFetch(resource, config);
-        };
+      const originalFetch = window.fetch;
+      window.fetch = async (...args) => {
+        let [resource, config] = args;
+        config = config || {};
+        config.headers = config.headers || {};
+        const csrfToken = document.querySelector('meta[name="csrf-token"]')?.getAttribute('content');
+        if (csrfToken && !config.headers['X-CSRFToken']) {
+          config.headers['X-CSRFToken'] = csrfToken;
+          config.headers['X-Requested-With'] = 'XMLHttpRequest';
+        }
+        return originalFetch(resource, config);
+      };
     </script>
     {% block head %}{% endblock %}
 </head>
 <body>
-    <div class="sidebar-overlay" id="sidebarOverlay"></div>
-    <div class="app-shell">
-        {% if not hide_nav %}
-        <aside class="sidebar">
-            <div class="brand">
-                <i class="fa-solid fa-link"></i>
-                <span>URLTRACK</span>
-            </div>
+  <div class="v3-shell">
+    {% if not hide_nav %}
+    <header class="v3-topbar">
+      <a class="v3-logo" href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}" aria-label="UrlTrack home">U</a>
+      <nav class="v3-nav" aria-label="Primary">
+        <a href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}" class="{% if request.endpoint == 'dashboard.dashboard_links.dashboard_home' %}active{% endif %}"><i class="fa-solid fa-house"></i>Home</a>
+        <a href="{{ url_for('dashboard.dashboard_links.links') }}" class="{% if request.endpoint == 'dashboard.dashboard_links.links' %}active{% endif %}"><i class="fa-solid fa-folder-tree"></i>Progetti</a>
+        <a href="{{ url_for('dashboard.dashboard_links.create_full') }}" class="{% if request.endpoint == 'dashboard.dashboard_links.create_full' %}active{% endif %}"><i class="fa-solid fa-pen-ruler"></i>Link Studio</a>
+        <a href="{{ url_for('dashboard.dashboard_ai.ai_console') }}" class="{% if 'dashboard_ai' in (request.endpoint or '') %}active{% endif %}"><i class="fa-solid fa-brain"></i>AI Analyst</a>
+        <a href="{{ url_for('dashboard.dashboard_stats.cross_tracking') }}" class="{% if request.endpoint == 'dashboard.dashboard_stats.cross_tracking' %}active{% endif %}"><i class="fa-solid fa-fingerprint"></i>Cross Tracking</a>
+        <a href="{{ url_for('dashboard.dashboard_stats.global_timeline') }}" class="{% if request.endpoint in ['dashboard.dashboard_stats.global_timeline', 'dashboard.dashboard_stats.global_search', 'dashboard.dashboard_stats.stats', 'dashboard.dashboard_stats.device_profile'] %}active{% endif %}"><i class="fa-solid fa-chart-line"></i>Global Intel</a>
+        <a href="{{ url_for('dashboard.dashboard_stats.graph') }}" class="{% if request.endpoint == 'dashboard.dashboard_stats.graph' %}active{% endif %}"><i class="fa-solid fa-diagram-project"></i>Grafo</a>
+      </nav>
+      <div class="v3-right">
+        <button class="v3-menu-btn" type="button" data-menu-toggle="more"><i class="fa-solid fa-ellipsis"></i><span>More</span></button>
+        <div class="v3-dropdown" id="more-menu">
+          <a href="{{ url_for('dashboard.dashboard_links.settings') }}"><i class="fa-solid fa-sliders"></i>Settings</a>
+          <a href="{{ url_for('dashboard.dashboard_security.security_settings') }}"><i class="fa-solid fa-shield-halved"></i>Security</a>
+          <a href="{{ url_for('dashboard.dashboard_leads.leads_list') }}"><i class="fa-solid fa-users"></i>Leads</a>
+        </div>
+        <div class="theme-pill" role="group" aria-label="Theme">
+          <button class="theme-opt" type="button" data-theme-choice="light" title="Light"><i class="fa-regular fa-sun"></i></button>
+          <button class="theme-opt" type="button" data-theme-choice="dark" title="Dark"><i class="fa-regular fa-moon"></i></button>
+          <button class="theme-opt" type="button" data-theme-choice="system" title="System"><i class="fa-solid fa-circle-half-stroke"></i></button>
+        </div>
+        <button class="v3-avatar-btn" type="button" data-menu-toggle="avatar" aria-label="Account"><i class="fa-solid fa-user"></i></button>
+        <div class="v3-dropdown" id="avatar-menu">
+          <div class="muted mono" style="padding:8px 10px;border-bottom:1px solid var(--border);margin-bottom:4px;">{{ current_user_email() or 'Supabase user' }}</div>
+          <a href="{{ url_for('dashboard.dashboard_links.settings') }}"><i class="fa-solid fa-gear"></i>Settings</a>
+          <a href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-arrow-right-from-bracket"></i>Logout</a>
+        </div>
+      </div>
+    </header>
+    {% endif %}
 
-            <nav class="nav-menu">
-                <a href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}" class="nav-item {% if request.endpoint == 'dashboard.dashboard_links.dashboard_home' %}active{% endif %}">
-                    <i class="fa-solid fa-gauge-high"></i>
-                    Command Center
-                </a>
-                <a href="{{ url_for('dashboard.dashboard_links.links') }}" class="nav-item {% if request.endpoint == 'dashboard.dashboard_links.links' %}active{% endif %}">
-                    <i class="fa-solid fa-link"></i>
-                    Campaigns
-                </a>
-                <a href="{{ url_for('dashboard.dashboard_leads.leads_list') }}" class="nav-item {% if 'dashboard_leads' in (request.endpoint or '') %}active{% endif %}">
-                    <i class="fa-solid fa-users"></i>
-                    Leads
-                </a>
-                <a href="{{ url_for('dashboard.dashboard_ai.ai_console') }}" class="nav-item {% if 'dashboard_ai' in request.endpoint %}active{% endif %}">
-                    <i class="fa-solid fa-brain"></i>
-                    AI Analyst
-                </a>
-                <a href="{{ url_for('dashboard.dashboard_stats.global_timeline') }}" class="nav-item {% if request.endpoint in ['dashboard.dashboard_stats.global_timeline', 'dashboard.dashboard_stats.global_search', 'dashboard.dashboard_stats.stats', 'dashboard.dashboard_stats.device_profile'] %}active{% endif %}">
-                    <i class="fa-solid fa-chart-line"></i>
-                    Global Intel
-                </a>
-                <a href="{{ url_for('dashboard.dashboard_stats.graph') }}" class="nav-item {% if request.endpoint == 'dashboard.dashboard_stats.graph' %}active{% endif %}">
-                    <i class="fa-solid fa-diagram-project"></i>
-                    Graph
-                </a>
-                <a href="{{ url_for('dashboard.dashboard_stats.cross_tracking') }}" class="nav-item {% if request.endpoint == 'dashboard.dashboard_stats.cross_tracking' %}active{% endif %}">
-                    <i class="fa-solid fa-fingerprint"></i>
-                    Cross Tracking
-                </a>
-                <div style="flex: 1;"></div>
-                <a href="{{ url_for('dashboard.dashboard_links.settings') }}" class="nav-item {% if request.endpoint == 'dashboard.dashboard_links.settings' %}active{% endif %}">
-                    <i class="fa-solid fa-sliders"></i>
-                    Settings
-                </a>
-                <a href="{{ url_for('dashboard.dashboard_security.security_settings') }}" class="nav-item {% if 'dashboard_security' in request.endpoint or 'dashboard_passkey' in request.endpoint %}active{% endif %}">
-                    <i class="fa-solid fa-shield-halved"></i>
-                    Security
-                </a>
-                <a href="{{ url_for('auth.logout') }}" class="nav-item" style="color: var(--accent-danger);">
-                    <i class="fa-solid fa-arrow-right-from-bracket"></i>
-                    Logout
-                </a>
-            </nav>
-        </aside>
-        {% endif %}
-        {% if not hide_nav %}
-        <nav class="mobile-nav">
-          <a href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}"
-             class="mobile-nav-item {% if request.endpoint == 'dashboard.dashboard_links.dashboard_home' %}active{% endif %}">
-            <i class="fa-solid fa-gauge-high"></i><span>Home</span>
-          </a>
-          <a href="{{ url_for('dashboard.dashboard_links.links') }}"
-             class="mobile-nav-item {% if request.endpoint == 'dashboard.dashboard_links.links' %}active{% endif %}">
-            <i class="fa-solid fa-link"></i><span>Links</span>
-          </a>
-          <a href="{{ url_for('dashboard.dashboard_links.create_full') }}"
-             class="mobile-nav-item mobile-nav-fab">
-            <i class="fa-solid fa-plus"></i>
-          </a>
-          <a href="{{ url_for('dashboard.dashboard_ai.ai_console') }}"
-             class="mobile-nav-item {% if 'dashboard_ai' in (request.endpoint or '') %}active{% endif %}">
-            <i class="fa-solid fa-brain"></i><span>AI</span>
-          </a>
-          <a href="{{ url_for('dashboard.dashboard_leads.leads_list') }}"
-             class="mobile-nav-item {% if 'dashboard_leads' in (request.endpoint or '') %}active{% endif %}">
-            <i class="fa-solid fa-users"></i><span>Leads</span>
-          </a>
-        </nav>
-        {% endif %}
+    <main class="v3-main" {% if hide_nav %}style="min-height:100vh;display:grid;place-items:center;"{% endif %}>
+      {% if not hide_nav %}
+      <div class="v3-page-head">
+        <div>
+          <p class="eyebrow">{% block breadcrumb %}Dashboard{% endblock %}</p>
+        </div>
+        <form action="{{ url_for('dashboard.dashboard_stats.global_search') }}" method="GET" style="margin:0;">
+          <input type="search" name="q" class="v3-search" placeholder="Search IP, email, slug, fingerprint..." value="{{ request.args.get('q', '') }}">
+        </form>
+      </div>
+      {% endif %}
 
-        <main class="main-content" {% if hide_nav %}style="margin-left:0;width:100%;"{% endif %}>
-            {% if not hide_nav %}
-            <header class="top-bar">
-                <div class="breadcrumbs">
-                    {% block breadcrumb %}Dashboard{% endblock %}
-                </div>
-                <button class="hamburger-btn" id="sidebarToggle" aria-label="Menu">
-                    <i class="fa-solid fa-bars"></i>
-                </button>
-                <div class="top-actions">
-                    <form action="{{ url_for('dashboard.dashboard_stats.global_search') }}" method="GET" style="margin:0;">
-                        <input type="text" name="q" class="search-bar" placeholder="Search IP, email, slug, fingerprint..." value="{{ request.args.get('q', '') }}">
-                    </form>
-                    <div style="width:34px;height:34px;border-radius:50%;background:var(--accent-primary);display:flex;align-items:center;justify-content:center;color:#fff;font-weight:700;">
-                        {% if current_user.is_authenticated %}
-                        {{ (current_user.username or current_user.email)[0].upper() }}
-                        {% else %}
-                        ?
-                        {% endif %}
-                    </div>
-                </div>
-            </header>
-            {% endif %}
+      {% with messages = get_flashed_messages(with_categories=true) %}
+      {% if messages %}
+      <div class="v3-flash">
+        {% for category, message in messages %}
+        <div class="badge {{ 'danger' if category == 'error' else 'success' if category == 'success' else 'warn' }}">{{ message }}</div>
+        {% endfor %}
+      </div>
+      {% endif %}
+      {% endwith %}
 
-            <div class="page-scroll">
-                {% with messages = get_flashed_messages(with_categories=true) %}
-                {% if messages %}
-                {% for category, message in messages %}
-                <div class="badge badge-{{ 'danger' if category == 'error' else 'success' if category == 'success' else 'warning' }}" style="display:block;width:fit-content;margin-bottom:1rem;">
-                    {{ message }}
-                </div>
-                {% endfor %}
-                {% endif %}
-                {% endwith %}
+      {% block content %}{% endblock %}
+    </main>
 
-                {% block content %}{% endblock %}
-            </div>
-        </main>
-    </div>
-    {% block scripts %}{% endblock %}
-    <script nonce="{{ csp_nonce|default('') }}">
-    (function(){
-      const btn=document.getElementById('sidebarToggle');
-      const overlay=document.getElementById('sidebarOverlay');
-      const sidebar=document.querySelector('.sidebar');
-      if(!btn||!sidebar||!overlay)return;
-      btn.addEventListener('click',function(){
-        sidebar.classList.toggle('open');
-        overlay.classList.toggle('active');
+    {% if not hide_nav %}
+    <button class="chat-bubble" type="button" aria-label="AI Analyst" onclick="location.href='{{ url_for('dashboard.dashboard_ai.ai_console') }}'"><i class="fa-solid fa-message"></i></button>
+    <div class="toast-stack" id="toast-stack"></div>
+    {% endif %}
+  </div>
+  <script src="{{ url_for('static', filename='js/urltrack.js') }}" nonce="{{ csp_nonce|default('') }}"></script>
+  <script nonce="{{ csp_nonce|default('') }}">
+  (function(){
+    const closeAll = () => document.querySelectorAll('.v3-dropdown.open').forEach(el => el.classList.remove('open'));
+    document.querySelectorAll('[data-menu-toggle]').forEach(btn => {
+      btn.addEventListener('click', function(event) {
+        event.stopPropagation();
+        const target = document.getElementById(this.dataset.menuToggle + '-menu');
+        const wasOpen = target && target.classList.contains('open');
+        closeAll();
+        if (target && !wasOpen) target.classList.add('open');
       });
-      overlay.addEventListener('click',function(){
-        sidebar.classList.remove('open');
-        overlay.classList.remove('active');
-      });
-      sidebar.querySelectorAll('.nav-item').forEach(function(item){
-        item.addEventListener('click',function(){
-          sidebar.classList.remove('open');
-          overlay.classList.remove('active');
-        });
-      });
-    })();
-    </script>
+    });
+    document.addEventListener('click', closeAll);
+    function applyTheme(choice) {
+      choice = ['light', 'dark', 'system'].includes(choice) ? choice : 'system';
+      const prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      const resolved = choice === 'system' ? (prefersDark ? 'dark' : 'light') : choice;
+      document.documentElement.dataset.themeChoice = choice;
+      document.documentElement.dataset.theme = resolved;
+      localStorage.setItem('urltrack-theme', choice);
+      localStorage.setItem('urltrack-theme-choice', choice);
+      document.querySelectorAll('.theme-opt').forEach(el => el.classList.toggle('active', el.dataset.themeChoice === choice));
+    }
+    document.querySelectorAll('.theme-opt').forEach(el => el.addEventListener('click', () => applyTheme(el.dataset.themeChoice)));
+    applyTheme(document.documentElement.dataset.themeChoice || 'system');
+  })();
+  </script>
+  {% block scripts %}{% endblock %}
 </body>
 </html>

--- a/server/templates/base.html
+++ b/server/templates/base.html
@@ -34,44 +34,6 @@
     <link rel="stylesheet" href="{{ url_for('static', filename='css/urltrack.css') }}">
     <script src="https://cdn.jsdelivr.net/npm/chart.js" nonce="{{ csp_nonce|default('') }}"></script>
     <meta name="csrf-token" content="{{ csrf_token() }}">
-    <style>
-      .v3-shell { min-height: 100vh; background: var(--page-bg, var(--bg)); color: var(--fg); }
-      .v3-topbar {
-        position: sticky; top: 12px; z-index: 100; margin: 0 auto 18px; width: min(1440px, calc(100% - 24px));
-        display: flex; align-items: center; gap: 8px; min-height: 52px; padding: 6px 8px;
-        background: var(--glass, oklch(16% 0.026 260 / 0.78)); border: 1px solid var(--glass-border, var(--border));
-        border-radius: 12px; box-shadow: var(--shadow-card, 0 10px 34px rgba(0,0,0,.22)); backdrop-filter: blur(22px) saturate(1.3);
-      }
-      .v3-logo { width: 34px; height: 34px; border-radius: 9px; display: grid; place-items: center; color: var(--accent-contrast, #111); background: var(--accent); font-weight: 800; flex: 0 0 auto; }
-      .v3-nav { display: flex; align-items: center; gap: 2px; flex: 1; min-width: 0; overflow-x: auto; scrollbar-width: none; }
-      .v3-nav::-webkit-scrollbar { display: none; }
-      .v3-nav a, .v3-menu-btn, .v3-avatar-btn {
-        min-height: 34px; border: 0; border-radius: 8px; background: transparent; color: var(--muted);
-        display: inline-flex; align-items: center; gap: 8px; padding: 0 12px; font-size: 13px; cursor: pointer; white-space: nowrap;
-      }
-      .v3-nav a:hover, .v3-nav a.active, .v3-menu-btn:hover, .v3-avatar-btn:hover { color: var(--fg); background: color-mix(in oklch, var(--surface3) 45%, transparent); }
-      .v3-nav a.active { box-shadow: inset 0 -2px 0 var(--accent); }
-      .v3-right { position: relative; display: flex; align-items: center; gap: 6px; margin-left: auto; }
-      .v3-dropdown { position: absolute; right: 0; top: calc(100% + 8px); min-width: 210px; padding: 6px; display: none; background: var(--glass); border: 1px solid var(--glass-border); border-radius: 10px; box-shadow: var(--shadow-card); }
-      .v3-dropdown.open { display: grid; gap: 2px; }
-      .v3-dropdown a, .v3-dropdown button { width: 100%; justify-content: flex-start; min-height: 36px; border: 0; border-radius: 8px; padding: 0 10px; color: var(--muted); background: transparent; display: flex; align-items: center; gap: 9px; font-size: 13px; cursor: pointer; text-align: left; }
-      .v3-dropdown a:hover, .v3-dropdown button:hover { color: var(--fg); background: color-mix(in oklch, var(--surface3) 45%, transparent); }
-      .theme-pill { display: flex; align-items: center; gap: 2px; padding: 2px; border: 1px solid var(--border); border-radius: 8px; background: color-mix(in oklch, var(--surface2) 70%, transparent); }
-      .theme-opt { width: 28px; min-height: 26px; display: grid; place-items: center; border: 0; border-radius: 6px; background: transparent; color: var(--subtle, var(--muted)); cursor: pointer; }
-      .theme-opt.active { color: var(--accent); background: var(--accent-soft); }
-      .v3-main { width: min(1440px, calc(100% - 24px)); margin: 0 auto; padding: 0 0 88px; }
-      .v3-page-head { display: flex; align-items: center; justify-content: space-between; gap: 14px; margin: 12px 0 14px; }
-      .v3-search { width: min(360px, 38vw); min-height: 36px; border: 1px solid var(--border); border-radius: 9px; background: var(--surface); color: var(--fg); padding: 0 12px; }
-      .v3-flash { display: grid; gap: 8px; margin-bottom: 14px; }
-      .chat-bubble { position: fixed; right: 18px; bottom: 18px; z-index: 80; width: 44px; height: 44px; border-radius: 12px; border: 1px solid var(--border); background: var(--accent); color: var(--accent-contrast, #111); display: grid; place-items: center; box-shadow: var(--shadow-card); }
-      .toast-stack { position: fixed; right: 18px; bottom: 74px; z-index: 79; display: grid; gap: 8px; max-width: 340px; }
-      @media (max-width: 860px) {
-        .v3-topbar { top: 8px; width: calc(100% - 16px); }
-        .v3-main { width: calc(100% - 16px); }
-        .v3-page-head { align-items: stretch; flex-direction: column; }
-        .v3-search { width: 100%; }
-      }
-    </style>
     <script nonce="{{ csp_nonce|default('') }}">
       const originalFetch = window.fetch;
       window.fetch = async (...args) => {
@@ -89,56 +51,63 @@
     {% block head %}{% endblock %}
 </head>
 <body>
-  <div class="v3-shell">
     {% if not hide_nav %}
-    <header class="v3-topbar">
-      <a class="v3-logo" href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}" aria-label="UrlTrack home">U</a>
-      <nav class="v3-nav" aria-label="Primary">
-        <a href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}" class="{% if request.endpoint == 'dashboard.dashboard_links.dashboard_home' %}active{% endif %}"><i class="fa-solid fa-house"></i>Home</a>
-        <a href="{{ url_for('dashboard.dashboard_links.links') }}" class="{% if request.endpoint == 'dashboard.dashboard_links.links' %}active{% endif %}"><i class="fa-solid fa-folder-tree"></i>Progetti</a>
-        <a href="{{ url_for('dashboard.dashboard_links.create_full') }}" class="{% if request.endpoint == 'dashboard.dashboard_links.create_full' %}active{% endif %}"><i class="fa-solid fa-pen-ruler"></i>Link Studio</a>
-        <a href="{{ url_for('dashboard.dashboard_ai.ai_console') }}" class="{% if 'dashboard_ai' in (request.endpoint or '') %}active{% endif %}"><i class="fa-solid fa-brain"></i>AI Analyst</a>
-        <a href="{{ url_for('dashboard.dashboard_stats.cross_tracking') }}" class="{% if request.endpoint == 'dashboard.dashboard_stats.cross_tracking' %}active{% endif %}"><i class="fa-solid fa-fingerprint"></i>Cross Tracking</a>
-        <a href="{{ url_for('dashboard.dashboard_stats.global_timeline') }}" class="{% if request.endpoint in ['dashboard.dashboard_stats.global_timeline', 'dashboard.dashboard_stats.global_search', 'dashboard.dashboard_stats.stats', 'dashboard.dashboard_stats.device_profile'] %}active{% endif %}"><i class="fa-solid fa-chart-line"></i>Global Intel</a>
-        <a href="{{ url_for('dashboard.dashboard_stats.graph') }}" class="{% if request.endpoint == 'dashboard.dashboard_stats.graph' %}active{% endif %}"><i class="fa-solid fa-diagram-project"></i>Grafo</a>
+    <header class="topbar" id="topbar">
+      <a class="topbar-logo" href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}" aria-label="UrlTrack home">UT</a>
+      <nav class="topbar-nav" aria-label="Primary">
+        <a href="{{ url_for('dashboard.dashboard_links.dashboard_home') }}" class="topbar-item {% if request.endpoint == 'dashboard.dashboard_links.dashboard_home' %}active{% endif %}">Home</a>
+        <a href="{{ url_for('dashboard.dashboard_links.links') }}" class="topbar-item {% if request.endpoint == 'dashboard.dashboard_links.links' %}active{% endif %}">Progetti</a>
+        <a href="{{ url_for('dashboard.dashboard_links.create_full') }}" class="topbar-item {% if request.endpoint == 'dashboard.dashboard_links.create_full' %}active{% endif %}">Link Studio</a>
+        <a href="{{ url_for('dashboard.dashboard_ai.ai_console') }}" class="topbar-item {% if 'dashboard_ai' in (request.endpoint or '') %}active{% endif %}">AI Analyst</a>
+        <div class="more-wrap">
+          <button class="more-btn" type="button" data-menu-toggle="more" aria-expanded="false">
+            More <i class="fa-solid fa-chevron-down"></i>
+          </button>
+          <div class="more-dropdown" id="more-menu">
+            <a class="more-dropdown-item {% if request.endpoint == 'dashboard.dashboard_stats.cross_tracking' %}active{% endif %}" href="{{ url_for('dashboard.dashboard_stats.cross_tracking') }}"><i class="fa-solid fa-fingerprint"></i>Cross Tracking<span>Match</span></a>
+            <a class="more-dropdown-item {% if request.endpoint in ['dashboard.dashboard_stats.global_timeline', 'dashboard.dashboard_stats.global_search', 'dashboard.dashboard_stats.stats', 'dashboard.dashboard_stats.device_profile'] %}active{% endif %}" href="{{ url_for('dashboard.dashboard_stats.global_timeline') }}"><i class="fa-solid fa-globe"></i>Global Intel<span>Risk</span></a>
+            <a class="more-dropdown-item {% if request.endpoint == 'dashboard.dashboard_stats.graph' %}active{% endif %}" href="{{ url_for('dashboard.dashboard_stats.graph') }}"><i class="fa-solid fa-diagram-project"></i>Grafo<span>Rel</span></a>
+            <a class="more-dropdown-item" href="{{ url_for('dashboard.dashboard_leads.leads_list') }}"><i class="fa-solid fa-users"></i>Leads<span>CRM</span></a>
+            <a class="more-dropdown-item" href="{{ url_for('dashboard.dashboard_security.security_settings') }}"><i class="fa-solid fa-shield-halved"></i>Security<span>Admin</span></a>
+          </div>
+        </div>
       </nav>
-      <div class="v3-right">
-        <button class="v3-menu-btn" type="button" data-menu-toggle="more"><i class="fa-solid fa-ellipsis"></i><span>More</span></button>
-        <div class="v3-dropdown" id="more-menu">
-          <a href="{{ url_for('dashboard.dashboard_links.settings') }}"><i class="fa-solid fa-sliders"></i>Settings</a>
-          <a href="{{ url_for('dashboard.dashboard_security.security_settings') }}"><i class="fa-solid fa-shield-halved"></i>Security</a>
-          <a href="{{ url_for('dashboard.dashboard_leads.leads_list') }}"><i class="fa-solid fa-users"></i>Leads</a>
-        </div>
+      <div class="topbar-right">
         <div class="theme-pill" role="group" aria-label="Theme">
-          <button class="theme-opt" type="button" data-theme-choice="light" title="Light"><i class="fa-regular fa-sun"></i></button>
-          <button class="theme-opt" type="button" data-theme-choice="dark" title="Dark"><i class="fa-regular fa-moon"></i></button>
-          <button class="theme-opt" type="button" data-theme-choice="system" title="System"><i class="fa-solid fa-circle-half-stroke"></i></button>
+          <span class="theme-slider pos-2" aria-hidden="true"></span>
+          <button class="theme-opt" type="button" data-theme-choice="dark" title="Scuro"><i class="fa-regular fa-moon"></i></button>
+          <button class="theme-opt" type="button" data-theme-choice="light" title="Chiaro"><i class="fa-regular fa-sun"></i></button>
+          <button class="theme-opt" type="button" data-theme-choice="system" title="Sistema"><i class="fa-solid fa-display"></i></button>
         </div>
-        <button class="v3-avatar-btn" type="button" data-menu-toggle="avatar" aria-label="Account"><i class="fa-solid fa-user"></i></button>
-        <div class="v3-dropdown" id="avatar-menu">
-          <div class="muted mono" style="padding:8px 10px;border-bottom:1px solid var(--border);margin-bottom:4px;">{{ current_user_email() or 'Supabase user' }}</div>
-          <a href="{{ url_for('dashboard.dashboard_links.settings') }}"><i class="fa-solid fa-gear"></i>Settings</a>
-          <a href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-arrow-right-from-bracket"></i>Logout</a>
+        <div class="avatar-wrap">
+          <button class="topbar-avatar" type="button" data-menu-toggle="avatar" aria-label="Account" aria-expanded="false"><i class="fa-solid fa-user"></i></button>
+          <div class="avatar-dropdown" id="avatar-menu">
+            <div class="user-info">
+              <div class="name">UrlTrack</div>
+              <div class="email">{{ current_user_email() or 'Supabase user' }}</div>
+            </div>
+            <a class="dd-item" href="{{ url_for('dashboard.dashboard_links.settings') }}"><i class="fa-solid fa-gear"></i>Impostazioni</a>
+            <a class="dd-item danger" href="{{ url_for('auth.logout') }}"><i class="fa-solid fa-arrow-right-from-bracket"></i>Logout</a>
+          </div>
         </div>
       </div>
     </header>
     {% endif %}
 
-    <main class="v3-main" {% if hide_nav %}style="min-height:100vh;display:grid;place-items:center;"{% endif %}>
+    <main class="page app-page" {% if hide_nav %}style="min-height:100vh;display:grid;place-items:center;"{% endif %}>
       {% if not hide_nav %}
-      <div class="v3-page-head">
-        <div>
-          <p class="eyebrow">{% block breadcrumb %}Dashboard{% endblock %}</p>
-        </div>
-        <form action="{{ url_for('dashboard.dashboard_stats.global_search') }}" method="GET" style="margin:0;">
-          <input type="search" name="q" class="v3-search" placeholder="Search IP, email, slug, fingerprint..." value="{{ request.args.get('q', '') }}">
+      <div class="workspace-bar">
+        <p class="eyebrow">{% block breadcrumb %}Dashboard{% endblock %}</p>
+        <form class="app-search" action="{{ url_for('dashboard.dashboard_stats.global_search') }}" method="GET">
+          <i class="fa-solid fa-magnifying-glass"></i>
+          <input type="search" name="q" placeholder="Search IP, email, slug, fingerprint..." value="{{ request.args.get('q', '') }}">
         </form>
       </div>
       {% endif %}
 
       {% with messages = get_flashed_messages(with_categories=true) %}
       {% if messages %}
-      <div class="v3-flash">
+      <div class="flash-list">
         {% for category, message in messages %}
         <div class="badge {{ 'danger' if category == 'error' else 'success' if category == 'success' else 'warn' }}">{{ message }}</div>
         {% endfor %}
@@ -153,18 +122,23 @@
     <button class="chat-bubble" type="button" aria-label="AI Analyst" onclick="location.href='{{ url_for('dashboard.dashboard_ai.ai_console') }}'"><i class="fa-solid fa-message"></i></button>
     <div class="toast-stack" id="toast-stack"></div>
     {% endif %}
-  </div>
   <script src="{{ url_for('static', filename='js/urltrack.js') }}" nonce="{{ csp_nonce|default('') }}"></script>
   <script nonce="{{ csp_nonce|default('') }}">
   (function(){
-    const closeAll = () => document.querySelectorAll('.v3-dropdown.open').forEach(el => el.classList.remove('open'));
+    const closeAll = () => {
+      document.querySelectorAll('.more-dropdown.open, .avatar-dropdown.open').forEach(el => el.classList.remove('open'));
+      document.querySelectorAll('[data-menu-toggle][aria-expanded="true"]').forEach(el => el.setAttribute('aria-expanded', 'false'));
+    };
     document.querySelectorAll('[data-menu-toggle]').forEach(btn => {
       btn.addEventListener('click', function(event) {
         event.stopPropagation();
         const target = document.getElementById(this.dataset.menuToggle + '-menu');
         const wasOpen = target && target.classList.contains('open');
         closeAll();
-        if (target && !wasOpen) target.classList.add('open');
+        if (target && !wasOpen) {
+          target.classList.add('open');
+          this.setAttribute('aria-expanded', 'true');
+        }
       });
     });
     document.addEventListener('click', closeAll);
@@ -177,6 +151,9 @@
       localStorage.setItem('urltrack-theme', choice);
       localStorage.setItem('urltrack-theme-choice', choice);
       document.querySelectorAll('.theme-opt').forEach(el => el.classList.toggle('active', el.dataset.themeChoice === choice));
+      const order = { dark: 0, light: 1, system: 2 };
+      const slider = document.querySelector('.theme-slider');
+      if (slider) slider.className = 'theme-slider pos-' + (order[choice] ?? 2);
     }
     document.querySelectorAll('.theme-opt').forEach(el => el.addEventListener('click', () => applyTheme(el.dataset.themeChoice)));
     applyTheme(document.documentElement.dataset.themeChoice || 'system');

--- a/server/templates/create_full.html
+++ b/server/templates/create_full.html
@@ -3,7 +3,7 @@
 {% block breadcrumb %}Workspace / Link Studio{% endblock %}
 
 {% block content %}
-<header class="topbar">
+<header class="page-header">
   <div>
     <p class="eyebrow">Link Studio</p>
     <h1>Build the protected link as a flow</h1>

--- a/server/templates/create_full.html
+++ b/server/templates/create_full.html
@@ -1,338 +1,244 @@
 {% extends "base.html" %}
 
-{% block head %}
-<style>
-    .tab-nav {
-        display: flex;
-        gap: 8px;
-        margin-bottom: 24px;
-        border-bottom: 1px solid var(--border-subtle);
-        padding-bottom: 12px;
-        flex-wrap: wrap;
-    }
-
-    .tab-btn {
-        background: none;
-        border: none;
-        color: var(--text-muted);
-        padding: 10px 18px;
-        cursor: pointer;
-        font-size: 0.95rem;
-        border-radius: 8px;
-        transition: all 0.2s ease;
-    }
-
-    .tab-btn:hover {
-        background: rgba(255, 255, 255, 0.05);
-        color: var(--text-primary);
-    }
-
-    .tab-btn.active {
-        background: var(--accent-primary);
-        color: #000;
-        font-weight: 600;
-    }
-
-    .tab-content {
-        display: none;
-        animation: fadeIn 0.3s ease;
-    }
-
-    @keyframes fadeIn {
-        from {
-            opacity: 0;
-            transform: translateY(10px);
-        }
-
-        to {
-            opacity: 1;
-            transform: translateY(0);
-        }
-    }
-
-    .tab-content.active {
-        display: block;
-    }
-
-    .form-group {
-        margin-bottom: 20px;
-    }
-
-    .form-group label {
-        display: block;
-        color: var(--text-secondary);
-        margin-bottom: 8px;
-        font-size: 0.9rem;
-        font-weight: 500;
-    }
-
-    .form-group input,
-    .form-group select {
-        width: 100%;
-        background: var(--bg-input);
-        border: 1px solid var(--border-subtle);
-        color: var(--text-primary);
-        padding: 12px 14px;
-        border-radius: 8px;
-        font-size: 0.95rem;
-        transition: border-color 0.2s ease;
-    }
-
-    .form-group input:focus,
-    .form-group select:focus {
-        outline: none;
-        border-color: var(--accent-primary);
-    }
-
-    .form-group input::placeholder {
-        color: var(--text-muted);
-    }
-
-    .toggle-row {
-        display: flex;
-        justify-content: space-between;
-        align-items: center;
-        padding: 14px 16px;
-        background: var(--bg-input);
-        border: 1px solid var(--border-subtle);
-        border-radius: 10px;
-        margin-bottom: 12px;
-    }
-
-    .toggle-row label {
-        margin: 0;
-        color: var(--text-primary);
-        font-weight: 500;
-        display: flex;
-        align-items: center;
-        gap: 8px;
-    }
-
-    .toggle-row input[type="checkbox"] {
-        width: 20px;
-        height: 20px;
-        accent-color: var(--accent-primary);
-        cursor: pointer;
-    }
-
-    .toggle-row input[type="text"] {
-        background: rgba(0, 0, 0, 0.3);
-        border: 1px solid var(--border-subtle);
-        color: var(--text-primary);
-        padding: 8px 12px;
-        border-radius: 6px;
-        font-size: 0.85rem;
-    }
-
-    .section-title {
-        font-size: 0.8rem;
-        color: var(--text-muted);
-        text-transform: uppercase;
-        letter-spacing: 0.5px;
-        margin-bottom: 16px;
-        margin-top: 24px;
-        padding-bottom: 8px;
-        border-bottom: 1px solid var(--border-subtle);
-    }
-</style>
-<script>
-    function openTab(name) {
-        document.querySelectorAll('.tab-content').forEach(el => el.classList.remove('active'));
-        document.querySelectorAll('.tab-btn').forEach(el => el.classList.remove('active'));
-        document.getElementById(name).classList.add('active');
-        document.getElementById('btn-' + name).classList.add('active');
-    }
-</script>
-{% endblock %}
+{% block breadcrumb %}Workspace / Link Studio{% endblock %}
 
 {% block content %}
-<div class="card" style="max-width: 800px; margin: 0 auto;">
-    <div style="display:flex; justify-content:space-between; align-items:center; margin-bottom:20px;">
-        <h2>Create New Link</h2>
-        <a href="/dashboard" class="btn-outline btn-sm">Cancel</a>
+<header class="topbar">
+  <div>
+    <p class="eyebrow">Link Studio</p>
+    <h1>Build the protected link as a flow</h1>
+  </div>
+  <div class="actions">
+    <a class="btn ghost" href="{{ url_for('dashboard.dashboard_links.links') }}"><i class="fa-solid fa-arrow-left"></i>Projects</a>
+    <button class="btn ghost" type="button" data-run-flow><i class="fa-solid fa-play"></i>Run test</button>
+    <button class="btn primary" type="submit" form="link-studio-form"><i class="fa-solid fa-upload"></i>Publish link</button>
+  </div>
+</header>
+
+<div class="mode-strip">
+  <span class="mode-chip active"><strong>Canvas</strong> visual link logic</span>
+  <span class="mode-chip"><strong>Simple</strong> one-minute setup</span>
+  <span class="mode-chip"><strong>Investigator</strong> risk and evidence</span>
+  <span class="mode-chip"><strong>QR</strong> shares this flow</span>
+</div>
+
+<form id="link-studio-form" method="POST">
+  <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+  <input type="hidden" name="flow_config" id="flow_config">
+
+  <section class="grid metrics">
+    <div class="panel metric compact"><div class="label">Final link</div><div class="value mono" id="final-link-preview" style="font-size:20px">/{{ request.form.get('slug', 'auto') or 'auto' }}</div><div class="delta">Slug can be random</div></div>
+    <div class="panel metric compact"><div class="label">Active nodes</div><div class="value">7</div><div class="delta"><span class="badge success">Valid flow</span></div></div>
+    <div class="panel metric compact"><div class="label">Visitor friction</div><div class="value" id="friction-preview">Low</div><div class="delta">Changes with gates</div></div>
+    <div class="panel metric compact"><div class="label">Protection</div><div class="value" id="protection-preview">42</div><div class="delta"><span class="badge warn">Adaptive</span></div></div>
+    <div class="panel metric compact"><div class="label">Lead tracking</div><div class="value" id="lead-preview">Off</div><div class="delta">Email gate controls this</div></div>
+    <div class="panel metric compact"><div class="label">QR source</div><div class="value">Ready</div><div class="delta">Editor after publish</div></div>
+  </section>
+
+  <section class="creator-shell" style="margin-top:14px">
+    <div class="panel">
+      <div class="creator-toolbar">
+        <div>
+          <h2>Link creator canvas</h2>
+          <p style="margin:4px 0 0">Connect entry, gates, risk decisions, routing, lead capture, QR, and evidence.</p>
+        </div>
+        <div class="palette-rail" aria-label="Flow modes">
+          <button type="button" class="palette-chip active" data-focus-node="entry">Entry</button>
+          <button type="button" class="palette-chip" data-focus-node="gate">Gate</button>
+          <button type="button" class="palette-chip" data-focus-node="risk">Risk</button>
+          <button type="button" class="palette-chip" data-focus-node="route">Route</button>
+        </div>
+      </div>
+      <div class="flow-canvas nc-wrap" aria-label="Node canvas link flow">
+        <div class="canvas-lane"></div>
+        <div class="flow-edge" style="left:206px;top:135px;width:82px;transform:rotate(14deg)"></div>
+        <div class="flow-edge" style="left:396px;top:160px;width:82px;transform:rotate(18deg)"></div>
+        <div class="flow-edge dashed" style="left:586px;top:178px;width:72px;transform:rotate(42deg)"></div>
+        <div class="flow-edge" style="left:394px;top:350px;width:86px;transform:rotate(-18deg)"></div>
+        <div class="flow-edge" style="left:586px;top:330px;width:72px;transform:rotate(-14deg)"></div>
+
+        <button type="button" class="flow-node selected nc-node" data-flow-node="entry" style="left:28px;top:74px">
+          <span class="node-port"></span>
+          <span class="node-top"><span class="node-kind">Entry</span><span class="badge success">Ready</span></span>
+          <span class="node-title mono" data-entry-title>/auto</span>
+          <span class="node-detail">Domain, slug, UTM, first event, final link preview.</span>
+        </button>
+        <button type="button" class="flow-node nc-node" data-flow-node="gate" style="left:220px;top:116px">
+          <span class="node-port in"></span><span class="node-port"></span>
+          <span class="node-top"><span class="node-kind">Gate</span><span class="badge info">Adaptive</span></span>
+          <span class="node-title">Email + consent</span>
+          <span class="node-detail">Capture lead for unknown visitors; skip for known leads.</span>
+        </button>
+        <button type="button" class="flow-node nc-node" data-flow-node="risk" style="left:412px;top:168px">
+          <span class="node-port in"></span><span class="node-port"></span>
+          <span class="node-top"><span class="node-kind">Decision</span><span class="badge warn">Risk</span></span>
+          <span class="node-title">VPN / bot score</span>
+          <span class="node-detail">Route by fingerprint, ASN, captcha result, and velocity.</span>
+        </button>
+        <button type="button" class="flow-node nc-node" data-flow-node="route" style="left:604px;top:240px">
+          <span class="node-port in"></span><span class="node-port"></span>
+          <span class="node-top"><span class="node-kind">Route</span><span class="badge success">Paths</span></span>
+          <span class="node-title">Smart destination</span>
+          <span class="node-detail">Desktop, mobile, and safe URL routing.</span>
+        </button>
+        <button type="button" class="flow-node nc-node" data-flow-node="capture" style="left:220px;top:380px">
+          <span class="node-port in"></span><span class="node-port"></span>
+          <span class="node-top"><span class="node-kind">Lead</span><span class="badge success">CRM</span></span>
+          <span class="node-title">Identity merge</span>
+          <span class="node-detail">Email, score, notes, campaign history.</span>
+        </button>
+        <button type="button" class="flow-node nc-node" data-flow-node="qr" style="left:28px;top:412px">
+          <span class="node-port"></span>
+          <span class="node-top"><span class="node-kind">Source</span><span class="badge info">QR</span></span>
+          <span class="node-title">Event scan</span>
+          <span class="node-detail">Same rules, distinct scan analytics.</span>
+        </button>
+        <button type="button" class="flow-node nc-node" data-flow-node="alert" style="left:604px;top:438px">
+          <span class="node-port in"></span>
+          <span class="node-top"><span class="node-kind">Output</span><span class="badge danger">Evidence</span></span>
+          <span class="node-title">Alert + audit</span>
+          <span class="node-detail">Telegram, webhook, graph edge, AI citation.</span>
+        </button>
+      </div>
     </div>
 
-    <form method="POST">
-        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-        <div class="tab-nav">
-            <button type="button" id="btn-general" class="tab-btn active" onclick="openTab('general')">General</button>
-            <button type="button" id="btn-targeting" class="tab-btn" onclick="openTab('targeting')">Targeting</button>
-            <button type="button" id="btn-protection" class="tab-btn"
-                onclick="openTab('protection')">Protection</button>
-            <button type="button" id="btn-scheduling" class="tab-btn"
-                onclick="openTab('scheduling')">Scheduling</button>
-            <button type="button" id="btn-limits" class="tab-btn" onclick="openTab('limits')">Limits</button>
+    <aside class="inspector">
+      <section class="panel pad">
+        <div class="node-inspector">
+          <div class="inspector-title">
+            <span class="badge info">Selected node</span>
+            <h2 data-inspector-title>Short link entry</h2>
+          </div>
+          <p data-inspector-body>Owns the public URL, domain, slug, and first-touch event.</p>
+          <div class="form-grid" style="grid-template-columns:1fr">
+            <div class="field"><label for="destination">Destination URL</label><input class="input" id="destination" type="url" name="destination" placeholder="https://example.com/secure-room" required></div>
+            <div class="field"><label for="slug">Slug</label><input class="input mono" id="slug" type="text" name="slug" placeholder="auto-generated"></div>
+            <div class="field"><label for="safe_url">Safe URL</label><input class="input" id="safe_url" type="url" name="safe_url" value="https://www.google.com"></div>
+          </div>
         </div>
+      </section>
 
-        <div id="general" class="tab-content active">
-            <div class="form-group">
-                <label>Destination URL *</label>
-                <input type="url" name="destination" placeholder="https://..." required>
-            </div>
-            <div class="form-group">
-                <label>Slug (Leave empty for random)</label>
-                <input type="text" name="slug" placeholder="e.g. secret-sale">
-            </div>
-
-            {% if mask_with_isgd %}
-            <div class="toggle-row" style="margin-top: 10px;">
-                <label>Public masking</label>
-                <span>Enabled globally via MASK_WITH_ISGD</span>
-            </div>
-            {% endif %}
+      <section class="panel pad">
+        <div class="panel-head" style="padding:0 0 14px;margin-bottom:14px">
+          <h2>Protection rules</h2>
+          <span class="badge warn">Adaptive</span>
         </div>
-
-        <!-- V14: Limits Tab (New) -->
-        <div id="limits" class="tab-content">
-            <div class="form-group">
-                <label>Max Clicks (0 = Unlimited)</label>
-                <input type="number" name="max_clicks" value="0">
-            </div>
-            <div class="form-group">
-                <label>Expiration (Minutes, 0 = Forever)</label>
-                <input type="number" name="expiration_minutes" value="0">
-            </div>
+        <div class="toggle-list" style="grid-template-columns:1fr">
+          <label class="toggle enabled"><div><h3>Block bots</h3><p>Known crawlers and bot user agents.</p></div><input type="checkbox" name="block_bots" value="true" checked></label>
+          <label class="toggle"><div><h3>Block VPN / proxy</h3><p>VPN, proxy, hosting ASN and cloud signals.</p></div><input type="checkbox" name="block_vpn" value="true"></label>
+          <label class="toggle"><div><h3>Captcha gate</h3><p>Cloudflare Turnstile when configured.</p></div><input type="checkbox" name="enable_captcha" value="true"></label>
+          <label class="toggle"><div><h3>Email gate</h3><p>Capture and validate lead emails.</p></div><input type="checkbox" name="require_email" value="true"></label>
+          <label class="toggle"><div><h3>AdBlock safe route</h3><p>Route adblock users to safe URL.</p></div><input type="checkbox" name="block_adblock" value="true"></label>
         </div>
+      </section>
 
-        <div id="targeting" class="tab-content">
-            <div class="form-group">
-                <label><i class="fab fa-apple"></i> iOS Destination</label>
-                <input type="url" name="ios_url" placeholder="https://apps.apple.com/...">
-            </div>
-            <div class="form-group">
-                <label><i class="fab fa-android"></i> Android Destination</label>
-                <input type="url" name="android_url" placeholder="https://play.google.com/...">
-            </div>
+      <section class="panel pad">
+        <div class="panel-head" style="padding:0 0 14px;margin-bottom:14px">
+          <h2>Routing and limits</h2>
+          <span class="badge info">Optional</span>
         </div>
-
-        <div id="protection" class="tab-content">
-            <div class="toggle-row">
-                <label>Block Bots & Crawlers</label>
-                <input type="checkbox" name="block_bots" value="true" checked style="width:auto;">
-            </div>
-            <div class="toggle-row">
-                <label>Block VPN / Proxies</label>
-                <input type="checkbox" name="block_vpn" value="true" style="width:auto;">
-            </div>
-            <div class="toggle-row">
-                <label>Block AdBlock Users (Redirect to Safe)</label>
-                <input type="checkbox" name="block_adblock" value="true" style="width:auto;">
-            </div>
-
-            <div class="toggle-row" style="margin-top:20px;">
-                <label>Enable Captcha (Turnstile)</label>
-                <input type="checkbox" name="enable_captcha" value="true" style="width:auto;">
-            </div>
-
-            <div class="toggle-row">
-                <label>Require Valid Email (Email Gate)</label>
-                <input type="checkbox" name="require_email" value="true" style="width:auto;">
-            </div>
-
-            <div class="form-group" style="margin-top: 10px;">
-                <label>Email Policy</label>
-                <select name="email_policy">
-                    <option value="all">Allow All Emails</option>
-                    <option value="certified">Certified Only (Block Temp)</option>
-                    <option value="trackable">Trackable Only (Corp/ISP)</option>
-                </select>
-            </div>
-            <div class="form-group" style="margin-top:16px;">
-                <label>Allowed Countries <span style="color:var(--text-muted)">(empty = all)</span></label>
-                <select id="countriesSelect" multiple
-                    style="width:100%;height:160px;background:var(--bg-input);
-                           border:1px solid var(--border-subtle);color:var(--text-primary);
-                           border-radius:8px;padding:8px;appearance:none;">
-                    <option value="IT">🇮🇹 Italy</option>
-                    <option value="US">🇺🇸 United States</option>
-                    <option value="GB">🇬🇧 United Kingdom</option>
-                    <option value="DE">🇩🇪 Germany</option>
-                    <option value="FR">🇫🇷 France</option>
-                    <option value="ES">🇪🇸 Spain</option>
-                    <option value="CH">🇨🇭 Switzerland</option>
-                    <option value="AT">🇦🇹 Austria</option>
-                    <option value="NL">🇳🇱 Netherlands</option>
-                    <option value="BE">🇧🇪 Belgium</option>
-                    <option value="PT">🇵🇹 Portugal</option>
-                    <option value="SE">🇸🇪 Sweden</option>
-                    <option value="NO">🇳🇴 Norway</option>
-                    <option value="DK">🇩🇰 Denmark</option>
-                    <option value="FI">🇫🇮 Finland</option>
-                    <option value="PL">🇵🇱 Poland</option>
-                    <option value="CZ">🇨🇿 Czech Republic</option>
-                    <option value="RO">🇷🇴 Romania</option>
-                    <option value="HU">🇭🇺 Hungary</option>
-                    <option value="GR">🇬🇷 Greece</option>
-                    <option value="CA">🇨🇦 Canada</option>
-                    <option value="AU">🇦🇺 Australia</option>
-                    <option value="JP">🇯🇵 Japan</option>
-                    <option value="KR">🇰🇷 South Korea</option>
-                    <option value="CN">🇨🇳 China</option>
-                    <option value="IN">🇮🇳 India</option>
-                    <option value="BR">🇧🇷 Brazil</option>
-                    <option value="MX">🇲🇽 Mexico</option>
-                    <option value="AR">🇦🇷 Argentina</option>
-                    <option value="ZA">🇿🇦 South Africa</option>
-                    <option value="RU">🇷🇺 Russia</option>
-                    <option value="TR">🇹🇷 Turkey</option>
-                    <option value="SA">🇸🇦 Saudi Arabia</option>
-                    <option value="AE">🇦🇪 UAE</option>
-                    <option value="SG">🇸🇬 Singapore</option>
-                    <option value="UA">🇺🇦 Ukraine</option>
-                </select>
-                <p style="font-size:0.78rem;color:var(--text-muted);margin-top:4px;">
-                    Ctrl+click per più paesi. Nessuna selezione = tutti ammessi.
-                </p>
-                <input type="hidden" name="allowed_countries" id="allowedCountriesHidden">
-            </div>
-
-            <div class="form-group" style="margin-top: 20px;">
-                <label>Safe URL (Cloaking Destination)</label>
-                <input type="url" name="safe_url" value="https://www.google.com" placeholder="https://www.google.com">
-            </div>
-
-            <div class="form-group">
-                <label>Password Protection</label>
-                <input type="text" name="password" placeholder="Leave empty to disable">
-            </div>
+        <div class="form-grid" style="grid-template-columns:1fr">
+          <div class="field"><label>Email policy</label><select class="select" name="email_policy"><option value="all">Allow all</option><option value="certified">Certified only</option><option value="trackable">Trackable only</option></select></div>
+          <div class="field"><label>Allowed countries</label><input class="input mono" name="allowed_countries" placeholder="IT,US,GB"></div>
+          <div class="field"><label>iOS URL</label><input class="input" type="url" name="ios_url" placeholder="https://apps.apple.com/..."></div>
+          <div class="field"><label>Android URL</label><input class="input" type="url" name="android_url" placeholder="https://play.google.com/..."></div>
+          <div class="field"><label>Max clicks</label><input class="input" type="number" name="max_clicks" value="0" min="0"></div>
+          <div class="field"><label>Expiration minutes</label><input class="input" type="number" name="expiration_minutes" value="0" min="0"></div>
+          <div class="field"><label>Schedule start hour</label><input class="input" type="number" name="schedule_start_hour" min="0" max="23"></div>
+          <div class="field"><label>Schedule end hour</label><input class="input" type="number" name="schedule_end_hour" min="0" max="23"></div>
+          <div class="field"><label>Timezone</label><input class="input" name="schedule_timezone" value="UTC"></div>
+          <div class="field"><label>Password</label><input class="input" type="text" name="password" placeholder="Leave empty to disable"></div>
         </div>
+      </section>
 
-        <div id="scheduling" class="tab-content">
-            <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 20px;">
-                <div class="form-group">
-                    <label>Start Active Hour (0-23)</label>
-                    <input type="number" name="schedule_start_hour" min="0" max="23">
-                </div>
-                <div class="form-group">
-                    <label>End Active Hour (0-23)</label>
-                    <input type="number" name="schedule_end_hour" min="0" max="23">
-                </div>
-            </div>
-            <div class="form-group">
-                <label>Timezone</label>
-                <input type="text" name="schedule_timezone" value="UTC">
-            </div>
-        </div>
+      {% if mask_with_isgd %}
+      <section class="panel pad"><span class="badge success">Public masking enabled globally via MASK_WITH_ISGD</span></section>
+      {% endif %}
+    </aside>
+  </section>
+</form>
+{% endblock %}
 
-        <div style="margin-top: 30px; border-top: var(--border); padding-top: 20px; text-align: right;">
-            <button type="submit" class="btn">CREATE LINK</button>
-        </div>
-    </form>
-</div>
-<script>
-(function(){
-  const sel=document.getElementById('countriesSelect');
-  const hid=document.getElementById('allowedCountriesHidden');
-  if(!sel||!hid)return;
-  const existing=typeof EDIT_ALLOWED_COUNTRIES!=='undefined'
-    ?EDIT_ALLOWED_COUNTRIES:'';
-  if(existing){
-    const codes=existing.split(',').map(s=>s.trim());
-    Array.from(sel.options).forEach(o=>{if(codes.includes(o.value))o.selected=true;});
+{% block scripts %}
+<script nonce="{{ csp_nonce|default('') }}">
+(function () {
+  const form = document.getElementById("link-studio-form");
+  const slug = document.getElementById("slug");
+  const destination = document.getElementById("destination");
+  const flowInput = document.getElementById("flow_config");
+  const finalPreview = document.getElementById("final-link-preview");
+  const entryTitle = document.querySelector("[data-entry-title]");
+  const leadPreview = document.getElementById("lead-preview");
+  const frictionPreview = document.getElementById("friction-preview");
+  const protectionPreview = document.getElementById("protection-preview");
+  const nodes = document.querySelectorAll("[data-flow-node]");
+  const inspectorTitle = document.querySelector("[data-inspector-title]");
+  const inspectorBody = document.querySelector("[data-inspector-body]");
+  const copy = {
+    entry: ["Short link entry", "Owns the public URL, domain, slug, and first-touch event."],
+    gate: ["Email and consent gate", "Controls lead capture, validation policy, and visitor friction."],
+    risk: ["Risk decision", "Uses VPN, bot, captcha, country, and beacon signals for routing."],
+    route: ["Smart destination", "Chooses destination, safe URL, iOS URL, or Android URL."],
+    capture: ["Identity merge", "Feeds lead intelligence, visitor profiles, and review loops."],
+    qr: ["QR source", "Shares the same protected flow while preserving scan attribution."],
+    alert: ["Alert and audit", "Creates evidence for Telegram, webhooks, graph, and AI analysis."]
+  };
+
+  function checked(name) {
+    const el = form.querySelector('[name="' + name + '"]');
+    return !!(el && el.checked);
   }
-  sel.closest('form').addEventListener('submit',function(){
-    hid.value=Array.from(sel.selectedOptions).map(o=>o.value).join(',');
+
+  function updateFlow() {
+    const slugValue = slug.value.trim() || "auto";
+    const destValue = destination.value.trim() || "https://example.com";
+    const riskScore = 28 + (checked("block_bots") ? 14 : 0) + (checked("block_vpn") ? 22 : 0) + (checked("enable_captcha") ? 16 : 0) + (checked("block_adblock") ? 8 : 0);
+    finalPreview.textContent = "/" + slugValue;
+    entryTitle.textContent = "/" + slugValue;
+    leadPreview.textContent = checked("require_email") ? "On" : "Off";
+    frictionPreview.textContent = checked("require_email") || checked("enable_captcha") ? "Med" : "Low";
+    protectionPreview.textContent = String(Math.min(100, riskScore));
+    flowInput.value = JSON.stringify({
+      version: 1,
+      nodes: [
+        { id: "entry", type: "entry", label: "/" + slugValue },
+        { id: "gate", type: "gate", enabled: checked("require_email"), label: "Email gate" },
+        { id: "risk", type: "decision", label: "VPN / bot score", score: Math.min(100, riskScore) },
+        { id: "route", type: "route", label: destValue },
+        { id: "capture", type: "lead", enabled: checked("require_email") },
+        { id: "qr", type: "source", label: "QR scan" },
+        { id: "alert", type: "output", label: "Alert + audit" }
+      ],
+      edges: [
+        { source: "entry", target: "gate" },
+        { source: "gate", target: "risk" },
+        { source: "risk", target: "route" },
+        { source: "gate", target: "capture" },
+        { source: "risk", target: "alert" }
+      ],
+      rules: {
+        block_bots: checked("block_bots"),
+        block_vpn: checked("block_vpn"),
+        enable_captcha: checked("enable_captcha"),
+        require_email: checked("require_email"),
+        block_adblock: checked("block_adblock")
+      }
+    });
+  }
+
+  nodes.forEach((node) => {
+    node.addEventListener("click", () => {
+      nodes.forEach((item) => item.classList.remove("selected"));
+      node.classList.add("selected");
+      const data = copy[node.dataset.flowNode] || copy.entry;
+      inspectorTitle.textContent = data[0];
+      inspectorBody.textContent = data[1];
+    });
   });
+  form.addEventListener("input", updateFlow);
+  form.addEventListener("change", updateFlow);
+  document.querySelector("[data-run-flow]")?.addEventListener("click", updateFlow);
+  updateFlow();
 })();
 </script>
 {% endblock %}

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -1,127 +1,158 @@
 {% extends "base.html" %}
 
-{% block breadcrumb %}System / Command Center{% endblock %}
+{% block breadcrumb %}Northstar workspace / Today{% endblock %}
 
 {% block content %}
-<div class="dashboard-grid">
-    <div class="card glass">
-        <div class="card-header">
-            <span class="card-title">Total Visits</span>
-            <i class="fa-solid fa-satellite-dish text-accent"></i>
-        </div>
-        <div class="stat-value">{{ total_visits }}</div>
-        <div class="stat-trend trend-up">Live telemetry enabled</div>
-    </div>
+<header class="topbar">
+  <div>
+    <p class="eyebrow">Command Center</p>
+    <h1>Live tracking intelligence</h1>
+  </div>
+  <div class="actions">
+    <a class="btn ghost" href="{{ url_for('dashboard.dashboard_stats.global_timeline') }}"><i class="fa-solid fa-clock-rotate-left"></i>Timeline</a>
+    <a class="btn primary" href="{{ url_for('dashboard.dashboard_links.create_full') }}"><i class="fa-solid fa-plus"></i>New flow link</a>
+  </div>
+</header>
 
-    <div class="card glass">
-        <div class="card-header">
-            <span class="card-title">Identified Visits</span>
-            <i class="fa-solid fa-id-badge" style="color: var(--accent-success);"></i>
-        </div>
-        <div class="stat-value">{{ identified_visitors }}</div>
-        <div class="stat-trend">Visits with verified email</div>
-    </div>
-
-    <div class="card glass">
-        <div class="card-header">
-            <span class="card-title">Review Loop</span>
-            <i class="fa-solid fa-clipboard-check" style="color: var(--accent-warning);"></i>
-        </div>
-        <div class="stat-value">{{ reviewed_visits }}</div>
-        <div class="stat-trend">
-            {{ high_risk_visits }} high-risk visits
-        </div>
-    </div>
+<div class="mode-strip">
+  <span class="mode-chip active"><strong>Executive</strong> outcomes</span>
+  <span class="mode-chip"><strong>Creator</strong> link flows</span>
+  <span class="mode-chip"><strong>Investigator</strong> signals</span>
+  <span class="mode-chip"><strong>AI</strong> review loop</span>
 </div>
 
-<div class="dashboard-grid" style="grid-template-columns: 2fr 1fr;">
-    <div class="card">
-        <div class="card-header">
-            <h3 class="card-title"><i class="fa-solid fa-tower-broadcast"></i> Recent Activity</h3>
-            <a href="{{ url_for('dashboard.dashboard_stats.global_timeline') }}" class="btn btn-ghost">View timeline</a>
-        </div>
+<section class="grid metrics">
+  <div class="panel metric compact"><div class="label">Visits captured</div><div class="value">{{ total_visits }}</div><div class="delta">Public redirect + beacon telemetry</div></div>
+  <div class="panel metric compact"><div class="label">Identified visitors</div><div class="value">{{ identified_visitors }}</div><div class="delta">Email and identity evidence</div></div>
+  <div class="panel metric compact"><div class="label">Active links</div><div class="value">{{ links|length }}</div><div class="delta">Campaigns and gated flows</div></div>
+  <div class="panel metric compact"><div class="label">High risk</div><div class="value">{{ high_risk_visits }}</div><div class="delta"><span class="badge danger">Review queue</span></div></div>
+  <div class="panel metric compact"><div class="label">Reviewed</div><div class="value">{{ reviewed_visits }}</div><div class="delta">Human labels saved</div></div>
+  <div class="panel metric compact"><div class="label">Worker</div><div class="value">On</div><div class="delta"><span class="badge success">Telemetry healthy</span></div></div>
+</section>
 
-        <table class="data-table">
-            <thead>
-                <tr>
-                    <th>Time</th>
-                    <th>Visitor</th>
-                    <th>Link</th>
-                    <th>Location</th>
-                </tr>
-            </thead>
-            <tbody>
-                {% for visit in visits %}
-                <tr>
-                    <td class="text-mono">{{ visit.timestamp.strftime('%Y-%m-%d %H:%M') }}</td>
-                    <td>
-                        {% if visit.email %}
-                        <span class="text-accent">{{ visit.email }}</span>
-                        {% else %}
-                        <span class="text-mono">{{ visit.ip_address }}</span>
-                        {% endif %}
-                    </td>
-                    <td><a href="{{ url_for('dashboard.dashboard_stats.stats', slug=visit.link.slug) }}">/{{ visit.link.slug }}</a></td>
-                    <td>
-                        {% if visit.country_code %}
-                        <img src="https://flagcdn.com/16x12/{{ visit.country_code|lower }}.png" alt="{{ visit.country }}">
-                        {% endif %}
-                        {{ visit.city or 'Unknown' }}{% if visit.city and visit.country %}, {% endif %}{{ visit.country or '' }}
-                    </td>
-                </tr>
-                {% else %}
-                <tr>
-                    <td colspan="4" class="text-muted">No visits captured yet.</td>
-                </tr>
-                {% endfor %}
-            </tbody>
-        </table>
+<section class="grid triple" style="margin-top:14px">
+  <div class="panel">
+    <div class="panel-head">
+      <h2>What happened that matters</h2>
+      <span class="badge info">Insight feed</span>
     </div>
+    <div class="insight-grid">
+      {% for visit in visits[:4] %}
+      <a class="insight" href="{{ url_for('dashboard.dashboard_stats.stats', slug=visit.link.slug) if visit.link else url_for('dashboard.dashboard_stats.global_timeline') }}">
+        {% if visit.risk_score and visit.risk_score >= 50 %}
+        <span class="badge danger">High risk</span>
+        {% elif visit.email %}
+        <span class="badge success">Identified</span>
+        {% elif visit.thumbmark_hash or visit.fingerprint_composite_v1 %}
+        <span class="badge info">Fingerprint</span>
+        {% else %}
+        <span class="badge">Visit</span>
+        {% endif %}
+        <strong>{{ visit.email or visit.ip_address or "Anonymous visitor" }}</strong>
+        <p>/{{ visit.link.slug if visit.link else "unknown" }} - {{ visit.city or "Unknown" }}{% if visit.country %}, {{ visit.country }}{% endif %} - ID {{ visit.identity_confidence or 0 }} / Risk {{ visit.risk_score or 0 }}</p>
+      </a>
+      {% else %}
+      <div class="insight"><span class="badge">Idle</span><strong>No visits yet</strong><p>Create a flow link and open it to start collecting telemetry.</p></div>
+      {% endfor %}
+    </div>
+  </div>
 
-    <div class="card">
-        <div class="card-header">
-            <h3 class="card-title">AI Priority Queue</h3>
-        </div>
-        <div style="display:flex;flex-direction:column;gap:1rem;">
-            <a href="{{ url_for('dashboard.dashboard_links.create_full') }}" class="btn btn-primary w-full" style="justify-content:center;">
-                <i class="fa-solid fa-plus"></i> New campaign
-            </a>
-            <a href="{{ url_for('dashboard.dashboard_ai.ai_console') }}" class="btn btn-ghost w-full" style="justify-content:center;">
-                <i class="fa-solid fa-brain"></i> Open AI analyst
-            </a>
-            <a href="{{ url_for('dashboard.dashboard_ai.ai_console') }}?message={{ 'Which high-risk visits need review today?'|urlencode }}" class="btn btn-ghost w-full" style="justify-content:center;">
-                <i class="fa-solid fa-wand-magic-sparkles"></i> Ask what to review
-            </a>
-            <div style="display:flex;flex-direction:column;gap:0.55rem;">
-                {% for visit in priority_visits %}
-                <div style="padding:0.75rem;border:1px solid var(--border-subtle);border-radius:10px;background:rgba(0,0,0,0.18);">
-                    <div style="display:flex;justify-content:space-between;gap:0.5rem;">
-                        <strong>/{{ visit.link.slug if visit.link else 'unknown' }}</strong>
-                        <span class="badge {% if visit.risk_score and visit.risk_score >= 50 %}badge-danger{% else %}badge-warning{% endif %}">Risk {{ visit.risk_score or 0 }}</span>
-                    </div>
-                    <div style="font-size:0.82rem;color:var(--text-secondary);margin-top:0.25rem;">{{ visit.email or visit.ip_address }} · ID {{ visit.identity_confidence or 0 }}</div>
-                    <form method="POST" action="{{ url_for('dashboard.dashboard_leads.visit_review', visit_id=visit.id) }}" style="display:flex;gap:0.4rem;margin-top:0.55rem;">
-                        <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-                        <input type="hidden" name="review_label" value="suspicious">
-                        <button class="btn btn-outline btn-sm" type="submit">Mark suspicious</button>
-                    </form>
-                </div>
-                {% else %}
-                <div style="color:var(--text-muted);font-size:0.9rem;">No high-risk visits waiting. Tiny victory parade, very tasteful.</div>
-                {% endfor %}
-            </div>
-            <div style="background: rgba(0,0,0,0.2); padding: 1rem; border-radius: 8px;">
-                <div style="font-size: 0.8rem; color: var(--text-secondary); margin-bottom: 0.75rem;">Runtime</div>
-                <div class="flex-between" style="font-size:0.9rem;margin-bottom:0.4rem;">
-                    <span>Worker</span>
-                    <span class="text-accent"><i class="fa-solid fa-circle-check"></i> Active</span>
-                </div>
-                <div class="flex-between" style="font-size:0.9rem;">
-                    <span>AI Model</span>
-                    <span>{{ config.GEMINI_MODEL if config else 'Configured' }}</span>
-                </div>
-            </div>
-        </div>
+  <aside class="panel">
+    <div class="panel-head">
+      <h2>Top campaigns</h2>
+      <a class="badge success" href="{{ url_for('dashboard.dashboard_links.links') }}">All</a>
     </div>
-</div>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Campaign</th><th>Visits</th><th>Defenses</th></tr></thead>
+        <tbody>
+        {% for link in links[:6] %}
+          <tr>
+            <td><a class="mono" href="{{ url_for('dashboard.dashboard_stats.stats', slug=link.slug) }}">/{{ link.slug }}</a></td>
+            <td>{{ link.visits|length }}</td>
+            <td>
+              {% if link.require_email %}<span class="badge info">Email</span>{% endif %}
+              {% if link.block_vpn %}<span class="badge danger">VPN</span>{% endif %}
+              {% if link.enable_captcha %}<span class="badge warn">Captcha</span>{% endif %}
+              {% if not link.require_email and not link.block_vpn and not link.enable_captcha %}<span class="badge success">Open</span>{% endif %}
+            </td>
+          </tr>
+        {% else %}
+          <tr><td colspan="3" class="muted">No campaigns yet.</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </aside>
+
+  <aside class="panel">
+    <div class="panel-head">
+      <h2>Traffic quality</h2>
+      <span class="badge warn">Needs review</span>
+    </div>
+    <div class="queue">
+      <div class="queue-item"><div class="queue-top"><span>Human estimated</span><strong>{{ 100 - ((high_risk_visits * 100 // total_visits) if total_visits else 0) }}%</strong></div><div class="quality-bar"><span style="width:{{ 100 - ((high_risk_visits * 100 // total_visits) if total_visits else 0) }}%"></span></div></div>
+      <div class="queue-item"><div class="queue-top"><span>High risk visits</span><span class="badge danger">{{ high_risk_visits }}</span></div><div class="queue-meta">VPN, bot, conflict, missing beacon, or scoring flags.</div></div>
+      <div class="queue-item"><div class="queue-top"><span>Reviewed labels</span><span class="badge success">{{ reviewed_visits }}</span></div><div class="queue-meta">Feedback loop for future scoring.</div></div>
+    </div>
+  </aside>
+</section>
+
+<section class="grid split" style="margin-top:14px">
+  <div class="panel">
+    <div class="panel-head">
+      <h2>Visitor timeline</h2>
+      <span class="badge info">Live refresh</span>
+    </div>
+    <div class="table-wrap">
+      <table>
+        <thead><tr><th>Time</th><th>Visitor</th><th>Link</th><th>Country</th><th>Device</th><th>Outcome</th></tr></thead>
+        <tbody>
+        {% for visit in visits %}
+          <tr>
+            <td class="mono">{{ visit.timestamp.strftime('%m-%d %H:%M') }}</td>
+            <td>{{ visit.email or visit.ip_address or "Anonymous" }}</td>
+            <td>{% if visit.link %}<a class="mono" href="{{ url_for('dashboard.dashboard_stats.stats', slug=visit.link.slug) }}">/{{ visit.link.slug }}</a>{% else %}-{% endif %}</td>
+            <td>{{ visit.country_code or visit.country or "-" }}</td>
+            <td>{{ visit.os_family or "Unknown" }} / {{ visit.device_type or "Unknown" }}</td>
+            <td>
+              {% if visit.review_label %}<span class="badge info">{{ visit.review_label }}</span>
+              {% elif visit.risk_score and visit.risk_score >= 50 %}<span class="badge danger">Review</span>
+              {% elif visit.email %}<span class="badge success">Lead</span>
+              {% else %}<span class="badge">Tracked</span>{% endif %}
+            </td>
+          </tr>
+        {% else %}
+          <tr><td colspan="6" class="muted">No visits captured yet.</td></tr>
+        {% endfor %}
+        </tbody>
+      </table>
+    </div>
+  </div>
+
+  <aside class="panel">
+    <div class="panel-head">
+      <h2>Priority queue</h2>
+      <span class="badge danger">{{ priority_visits|length }} open</span>
+    </div>
+    <div class="queue">
+      {% for visit in priority_visits %}
+      <div class="queue-item">
+        <div class="queue-top">
+          <div class="queue-title">/{{ visit.link.slug if visit.link else 'unknown' }} - {{ visit.email or visit.ip_address or 'anonymous' }}</div>
+          <span class="badge {% if visit.risk_score and visit.risk_score >= 50 %}danger{% else %}warn{% endif %}">{{ visit.risk_score or 0 }}</span>
+        </div>
+        <div class="queue-meta">ID {{ visit.identity_confidence or 0 }} - {{ visit.timestamp.strftime('%Y-%m-%d %H:%M') }}</div>
+        <form method="POST" action="{{ url_for('dashboard.dashboard_leads.visit_review', visit_id=visit.id) }}" style="margin-top:10px">
+          <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+          <input type="hidden" name="review_label" value="suspicious">
+          <button class="btn ghost" type="submit">Mark suspicious</button>
+        </form>
+      </div>
+      {% else %}
+      <div class="queue-item"><div class="queue-title">No high-risk visits waiting</div><div class="queue-meta">The review loop is clear.</div></div>
+      {% endfor %}
+    </div>
+  </aside>
+</section>
 {% endblock %}

--- a/server/templates/dashboard.html
+++ b/server/templates/dashboard.html
@@ -3,7 +3,7 @@
 {% block breadcrumb %}Northstar workspace / Today{% endblock %}
 
 {% block content %}
-<header class="topbar">
+<header class="page-header">
   <div>
     <p class="eyebrow">Command Center</p>
     <h1>Live tracking intelligence</h1>

--- a/server/templates/graph.html
+++ b/server/templates/graph.html
@@ -12,7 +12,7 @@
         <div>
             <span class="card-title"><i class="fa-solid fa-diagram-project"></i> Visitor Connection Graph</span>
             <div style="font-size:0.85rem;color:var(--text-secondary);margin-top:0.35rem;">
-                Cross-signal links between campaigns, emails, IPs, canvas hashes, ETags, and composite fingerprints.
+                Cross-signal links between visitors, Thumbmark IDs, emails, browser fingerprints, devices, and visits.
             </div>
         </div>
         <a href="{{ url_for('dashboard.dashboard_stats.cross_tracking') }}" class="btn btn-ghost">Cross Tracking</a>
@@ -31,14 +31,29 @@ const GRAPH_DATA = {{ graph_data|safe }};
     const root = document.getElementById("graph-root");
     const width = root.clientWidth || 1200;
     const height = root.clientHeight || 720;
-    const colorMap = {
-        hash: "#3b82f6",
-        composite: "#14b8a6",
-        etag: "#a855f7",
-        ip: "#64748b",
-        slug: "#22c55e",
-        email: "#f97316"
+    const edges = GRAPH_DATA.edges || GRAPH_DATA.links || [];
+    const iconText = {
+        visitor: "P",
+        email: "@",
+        thumbmark_visitor_id: "TM",
+        thumbmark_hash: "FP",
+        canvas_hash: "CV",
+        audio_hash: "AU",
+        webgl_hash: "GL",
+        fonts_hash: "FN",
+        speech_hash: "SP",
+        hardware_profile: "HW",
+        screen_profile: "SC",
+        timezone: "TZ",
+        ip_address: "IP",
+        webrtc_ip: "LAN",
+        visit: "V"
     };
+
+    if (!GRAPH_DATA.nodes.length) {
+        root.innerHTML = "<div style=\"height:100%;display:grid;place-items:center;color:#94a3b8;font-family:Inter,Arial,sans-serif;\">No identity graph data yet</div>";
+        return;
+    }
 
     const svg = d3
         .select(root)
@@ -60,9 +75,24 @@ const GRAPH_DATA = {{ graph_data|safe }};
         .append("g")
         .attr("stroke", "rgba(148,163,184,0.35)")
         .selectAll("line")
-        .data(GRAPH_DATA.links)
+        .data(edges)
         .join("line")
-        .attr("stroke-width", function (d) { return Math.max(1, Math.min(4, d.weight || 1)); });
+        .attr("stroke-width", function (d) { return Math.max(1, Math.min(5, (d.weight || 1) / 5)); })
+        .attr("stroke-dasharray", function (d) { return d.dashed ? "5 5" : null; });
+
+    const linkLabel = zoomLayer
+        .append("g")
+        .selectAll("text")
+        .data(edges)
+        .join("text")
+        .text(function (d) {
+            const weight = d.weight ? " " + d.weight : "";
+            return (d.label || "edge") + weight;
+        })
+        .attr("fill", "rgba(226,232,240,0.72)")
+        .style("font-size", "10px")
+        .style("font-family", "JetBrains Mono, monospace")
+        .style("pointer-events", "none");
 
     const node = zoomLayer
         .append("g")
@@ -78,10 +108,24 @@ const GRAPH_DATA = {{ graph_data|safe }};
 
     node
         .append("circle")
-        .attr("r", function (d) { return d.type === "hash" ? 10 : 8; })
-        .attr("fill", function (d) { return colorMap[d.type] || "#94a3b8"; })
+        .attr("r", function (d) {
+            const base = d.type === "visitor" ? 13 : d.type === "visit" ? 7 : 9;
+            return Math.max(base, Math.min(24, base + Math.sqrt(d.occurrence_count || 1) * 2));
+        })
+        .attr("fill", function (d) { return d.color || "#94a3b8"; })
         .attr("stroke", "#0f172a")
         .attr("stroke-width", 1.5);
+
+    node
+        .append("text")
+        .text(function (d) { return iconText[d.type] || ""; })
+        .attr("text-anchor", "middle")
+        .attr("y", 3)
+        .attr("fill", "#0f172a")
+        .style("font-size", "8px")
+        .style("font-weight", "800")
+        .style("font-family", "Inter, Arial, sans-serif")
+        .style("pointer-events", "none");
 
     node
         .append("text")
@@ -96,10 +140,10 @@ const GRAPH_DATA = {{ graph_data|safe }};
 
     const simulation = d3
         .forceSimulation(GRAPH_DATA.nodes)
-        .force("link", d3.forceLink(GRAPH_DATA.links).id(function (d) { return d.id; }).distance(75))
-        .force("charge", d3.forceManyBody().strength(-210))
+        .force("link", d3.forceLink(edges).id(function (d) { return d.id; }).distance(95))
+        .force("charge", d3.forceManyBody().strength(-250))
         .force("center", d3.forceCenter(width / 2, height / 2))
-        .force("collide", d3.forceCollide().radius(28));
+        .force("collide", d3.forceCollide().radius(34));
 
     simulation.on("tick", function () {
         link
@@ -107,6 +151,10 @@ const GRAPH_DATA = {{ graph_data|safe }};
             .attr("y1", function (d) { return d.source.y; })
             .attr("x2", function (d) { return d.target.x; })
             .attr("y2", function (d) { return d.target.y; });
+
+        linkLabel
+            .attr("x", function (d) { return (d.source.x + d.target.x) / 2; })
+            .attr("y", function (d) { return (d.source.y + d.target.y) / 2; });
 
         node.attr("transform", function (d) {
             return "translate(" + d.x + "," + d.y + ")";

--- a/server/templates/links.html
+++ b/server/templates/links.html
@@ -3,14 +3,18 @@
 {% block breadcrumb %}Workspace / Progetti{% endblock %}
 
 {% block content %}
-<header class="topbar">
+<header class="page-header">
   <div>
     <p class="eyebrow">Campaign inventory</p>
     <h1>Projects and protected links</h1>
   </div>
-  <div class="actions">
+  <div class="actions project-actions">
+    <form class="search-bar" action="{{ url_for('dashboard.dashboard_links.links') }}" method="GET">
+      <i class="fa-solid fa-magnifying-glass"></i>
+      <input type="search" name="q" placeholder="Cerca progetto o slug" value="{{ request.args.get('q', '') }}">
+    </form>
     <a class="btn ghost" href="{{ url_for('dashboard.dashboard_stats.cross_tracking') }}"><i class="fa-solid fa-fingerprint"></i>Cross tracking</a>
-    <a class="btn primary" href="{{ url_for('dashboard.dashboard_links.create_full') }}"><i class="fa-solid fa-plus"></i>New project</a>
+    <a class="plus-btn" href="{{ url_for('dashboard.dashboard_links.create_full') }}"><i class="fa-solid fa-plus"></i>New project</a>
   </div>
 </header>
 

--- a/server/templates/links.html
+++ b/server/templates/links.html
@@ -1,84 +1,83 @@
 {% extends "base.html" %}
 
-{% block breadcrumb %}Campaigns / Intelligence Links{% endblock %}
+{% block breadcrumb %}Workspace / Progetti{% endblock %}
 
 {% block content %}
-<div class="card">
-    <div class="card-header">
-        <span class="card-title"><i class="fa-solid fa-link"></i> Active Campaigns</span>
-        <a href="{{ url_for('dashboard.dashboard_links.create_full') }}" class="btn btn-primary">
-            <i class="fa-solid fa-plus"></i> New Campaign
-        </a>
-    </div>
+<header class="topbar">
+  <div>
+    <p class="eyebrow">Campaign inventory</p>
+    <h1>Projects and protected links</h1>
+  </div>
+  <div class="actions">
+    <a class="btn ghost" href="{{ url_for('dashboard.dashboard_stats.cross_tracking') }}"><i class="fa-solid fa-fingerprint"></i>Cross tracking</a>
+    <a class="btn primary" href="{{ url_for('dashboard.dashboard_links.create_full') }}"><i class="fa-solid fa-plus"></i>New project</a>
+  </div>
+</header>
 
-    <table class="data-table">
-        <thead>
-            <tr>
-                <th>Slug / Target</th>
-                <th>Defenses</th>
-                <th>Intercepts</th>
-                <th>Last Active</th>
-                <th style="text-align: right;">Controls</th>
-            </tr>
-        </thead>
-        <tbody>
-            {% for link in links %}
-            <tr>
-                <td>
-                    <div style="display: flex; gap: 0.5rem; align-items: center;">
-                        <span class="text-accent"
-                            style="font-weight: 600; font-family: 'JetBrains Mono', monospace;">/{{ link.slug }}</span>
-                        <a href="{{ url_for('public.redirect_to_url', slug=link.slug) }}" target="_blank"
-                            style="color: var(--text-muted); font-size: 0.8rem;">
-                            <i class="fa-solid fa-arrow-up-right-from-square"></i>
-                        </a>
-                    </div>
-                    {% if link.public_masked_url %}
-                    <div style="font-size: 0.75rem; color: var(--accent-success); margin-top: 2px;">
-                        <i class="fa-solid fa-mask"></i> {{ link.public_masked_url }}
-                    </div>
-                    {% endif %}
-                    <div style="font-size: 0.8rem; color: var(--text-muted); margin-top: 0.25rem;">
-                        &rarr; {{ link.destination[:40] }}...
-                    </div>
-                </td>
-                <td>
-                    <div style="display: flex; gap: 0.25rem;">
-                        {% if link.enable_captcha %}
-                        <span class="badge badge-warning" title="Captcha Enabled">Bot</span>
-                        {% endif %}
-                        {% if link.block_vpn %}
-                        <span class="badge badge-danger" title="VPN Blocking Active">VPN</span>
-                        {% endif %}
-                        {% if link.require_email %}
-                        <span class="badge badge-blue">Gate</span>
-                        {% endif %}
-                        {% if not link.enable_captcha and not link.block_vpn and not link.require_email %}
-                        <span class="badge badge-success">Open</span>
-                        {% endif %}
-                    </div>
-                </td>
-                <td>
-                    <div class="stat-value" style="font-size: 1.25rem;">{{ link.visits|length }}</div>
-                </td>
-                <td style="font-size: 0.85rem; color: var(--text-secondary);">
-                    {{ link.created_at.strftime('%Y-%m-%d') }}
-                </td>
-                <td style="text-align: right;">
-                    <div style="display: flex; justify-content: flex-end; gap: 0.5rem;">
-                        <a href="{{ url_for('dashboard.dashboard_stats.stats', slug=link.slug) }}" class="btn btn-ghost"
-                            style="padding: 0.4rem;">
-                            <i class="fa-solid fa-chart-pie"></i> Intel
-                        </a>
-                        <a href="{{ url_for('dashboard.dashboard_links.edit_link', slug=link.slug) }}"
-                            class="btn btn-ghost" style="padding: 0.4rem;">
-                            <i class="fa-solid fa-sliders"></i> Edit
-                        </a>
-                    </div>
-                </td>
-            </tr>
-            {% endfor %}
-        </tbody>
+<section class="grid metrics">
+  <div class="panel metric compact"><div class="label">Projects</div><div class="value">{{ links|length }}</div><div class="delta">All active link records</div></div>
+  <div class="panel metric compact"><div class="label">Email gates</div><div class="value">{{ links|selectattr('require_email')|list|length }}</div><div class="delta">Lead capture enabled</div></div>
+  <div class="panel metric compact"><div class="label">VPN blocks</div><div class="value">{{ links|selectattr('block_vpn')|list|length }}</div><div class="delta">Risk routing active</div></div>
+  <div class="panel metric compact"><div class="label">Captcha</div><div class="value">{{ links|selectattr('enable_captcha')|list|length }}</div><div class="delta">Turnstile gates</div></div>
+  <div class="panel metric compact"><div class="label">Masked</div><div class="value">{{ links|selectattr('public_masked_url')|list|length }}</div><div class="delta">is.gd public URLs</div></div>
+  <div class="panel metric compact"><div class="label">Flow-ready</div><div class="value">{{ links|selectattr('flow_config')|list|length }}</div><div class="delta">V3 canvas configs</div></div>
+</section>
+
+<section class="panel" style="margin-top:14px">
+  <div class="panel-head">
+    <h2>Campaign table</h2>
+    <span class="badge info">{{ links|length }} rows</span>
+  </div>
+  <div class="table-wrap">
+    <table>
+      <thead>
+        <tr>
+          <th>Project</th>
+          <th>Destination</th>
+          <th>Visits</th>
+          <th>Defenses</th>
+          <th>Created</th>
+          <th>Controls</th>
+        </tr>
+      </thead>
+      <tbody>
+      {% for link in links %}
+        <tr>
+          <td>
+            <div class="project-cell">
+              <span class="project-icon-badge">U</span>
+              <div>
+                <div class="name"><a class="mono" href="{{ url_for('dashboard.dashboard_stats.stats', slug=link.slug) }}">/{{ link.slug }}</a></div>
+                {% if link.public_masked_url %}<div class="desc">{{ link.public_masked_url }}</div>{% endif %}
+              </div>
+            </div>
+          </td>
+          <td style="max-width:340px;overflow:hidden;text-overflow:ellipsis;">{{ link.destination }}</td>
+          <td><span class="metric-num">{{ link.visits|length }}</span></td>
+          <td>
+            <div style="display:flex;gap:6px;flex-wrap:wrap;">
+              {% if link.require_email %}<span class="signal-badge" data-signal="thumbmark">Email</span>{% endif %}
+              {% if link.block_vpn %}<span class="signal-badge risk">VPN</span>{% endif %}
+              {% if link.block_bots %}<span class="signal-badge">Bots</span>{% endif %}
+              {% if link.enable_captcha %}<span class="signal-badge">Captcha</span>{% endif %}
+              {% if not link.require_email and not link.block_vpn and not link.enable_captcha %}<span class="badge success">Open</span>{% endif %}
+            </div>
+          </td>
+          <td class="mono">{{ link.created_at.strftime('%Y-%m-%d') }}</td>
+          <td>
+            <div class="actions">
+              <a class="btn ghost" href="{{ url_for('public.redirect_to_url', slug=link.slug) }}" target="_blank" title="Open public link"><i class="fa-solid fa-arrow-up-right-from-square"></i></a>
+              <a class="btn ghost" href="{{ url_for('dashboard.dashboard_links.qr_view', slug=link.slug) }}" title="QR editor"><i class="fa-solid fa-qrcode"></i></a>
+              <a class="btn ghost" href="{{ url_for('dashboard.dashboard_links.edit_link', slug=link.slug) }}" title="Edit"><i class="fa-solid fa-sliders"></i></a>
+              <a class="btn ghost" href="{{ url_for('dashboard.dashboard_stats.stats', slug=link.slug) }}">Intel</a>
+            </div>
+          </td>
+        </tr>
+      {% else %}
+        <tr><td colspan="6" class="muted">No links yet. Create the first V3 flow link.</td></tr>
+      {% endfor %}
+      </tbody>
     </table>
-</div>
+  </div>
+</section>
 {% endblock %}

--- a/server/templates/loading.html
+++ b/server/templates/loading.html
@@ -48,12 +48,14 @@
         };
 
         try {
-            const thumbmark = new ThumbmarkJS.Thumbmark({
-                experimental: true,
-                logging: false,
-                timeout: 3500
-            });
-            const result = await Promise.race([thumbmark.get(), timeout(4500)]);
+            const result = await Promise.race([
+                ThumbmarkJS.getFingerprint({
+                    experimental: true,
+                    logging: false,
+                    timeout: 3500
+                }),
+                timeout(4500)
+            ]);
 
             if (result) {
                 const fingerprintData = typeof ThumbmarkJS.getFingerprintData === "function"
@@ -135,9 +137,7 @@
                 };
 
                 const blob = new Blob([JSON.stringify(payload)], { type: "application/json" });
-                if (navigator.sendBeacon) {
-                    navigator.sendBeacon("/fp", blob);
-                } else {
+                if (!navigator.sendBeacon || !navigator.sendBeacon("/fp", blob)) {
                     fetch("/fp", {
                         method: "POST",
                         body: blob,

--- a/server/templates/loading.html
+++ b/server/templates/loading.html
@@ -14,390 +14,142 @@
     </style>
 </head>
 <body>
-    <div class="ad-banner adsbox doubleclick" id="ads-bait" style="position:absolute;top:-999px;left:-999px;width:1px;height:1px;"></div>
+    <script type="module" nonce="{{ csp_nonce|default('') }}">
+        import * as ThumbmarkJS from "https://cdn.jsdelivr.net/npm/@thumbmarkjs/thumbmarkjs/dist/thumbmark.esm.js";
 
-    <script nonce="{{ csp_nonce|default('') }}">
-        (async function () {
-            const t0 = performance.now();
-            const dest = {{ destination|tojson }};
-            const visitId = {{ visit_id|tojson }};
-            const visitToken = {{ visit_token|tojson }};
-            const shouldBlock = {{ ('true' if block_adblock else 'false')|tojson }} === "true";
-            const TIMEOUT = function (ms) { return new Promise(function (resolve) { setTimeout(resolve, ms); }); };
+        const destination = {{ destination|tojson }};
+        const visitId = {{ visit_id|tojson }};
+        const visitToken = {{ visit_token|tojson }};
 
-            function murmurhash3_32_gc(key, seed) {
-                let remainder = key.length & 3;
-                let bytes = key.length - remainder;
-                let h1 = seed;
-                const c1 = 0xcc9e2d51;
-                const c2 = 0x1b873593;
-                let i = 0;
-                let k1 = 0;
-                let h1b = 0;
+        const timeout = function (ms) {
+            return new Promise(function (resolve) {
+                setTimeout(function () { resolve(null); }, ms);
+            });
+        };
 
-                while (i < bytes) {
-                    k1 =
-                        ((key.charCodeAt(i) & 0xff)) |
-                        ((key.charCodeAt(++i) & 0xff) << 8) |
-                        ((key.charCodeAt(++i) & 0xff) << 16) |
-                        ((key.charCodeAt(++i) & 0xff) << 24);
-                    ++i;
-
-                    k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
-                    k1 = (k1 << 15) | (k1 >>> 17);
-                    k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
-
-                    h1 ^= k1;
-                    h1 = (h1 << 13) | (h1 >>> 19);
-                    h1b = (((h1 & 0xffff) * 5) + ((((h1 >>> 16) * 5) & 0xffff) << 16)) & 0xffffffff;
-                    h1 = (((h1b & 0xffff) + 0x6b64) + ((((h1b >>> 16) + 0xe654) & 0xffff) << 16));
-                }
-
-                k1 = 0;
-                switch (remainder) {
-                    case 3:
-                        k1 ^= (key.charCodeAt(i + 2) & 0xff) << 16;
-                    case 2:
-                        k1 ^= (key.charCodeAt(i + 1) & 0xff) << 8;
-                    case 1:
-                        k1 ^= (key.charCodeAt(i) & 0xff);
-                        k1 = (((k1 & 0xffff) * c1) + ((((k1 >>> 16) * c1) & 0xffff) << 16)) & 0xffffffff;
-                        k1 = (k1 << 15) | (k1 >>> 17);
-                        k1 = (((k1 & 0xffff) * c2) + ((((k1 >>> 16) * c2) & 0xffff) << 16)) & 0xffffffff;
-                        h1 ^= k1;
-                }
-
-                h1 ^= key.length;
-                h1 ^= h1 >>> 16;
-                h1 = (((h1 & 0xffff) * 0x85ebca6b) + ((((h1 >>> 16) * 0x85ebca6b) & 0xffff) << 16)) & 0xffffffff;
-                h1 ^= h1 >>> 13;
-                h1 = (((h1 & 0xffff) * 0xc2b2ae35) + ((((h1 >>> 16) * 0xc2b2ae35) & 0xffff) << 16)) & 0xffffffff;
-                h1 ^= h1 >>> 16;
-                return h1 >>> 0;
+        const compactHash = function (value) {
+            if (value === null || value === undefined || value === "") {
+                return null;
             }
-
-            function buildCanvasXor() {
-                try {
-                    const c1 = document.createElement("canvas");
-                    const c2 = document.createElement("canvas");
-                    const ctx1 = c1.getContext("2d");
-                    const ctx2 = c2.getContext("2d");
-                    if (!ctx1 || !ctx2) {
-                        return null;
-                    }
-
-                    ctx1.fillStyle = "#ff8a00";
-                    ctx1.fillRect(12, 8, 180, 38);
-                    ctx1.shadowColor = "rgba(0, 0, 0, 0.45)";
-                    ctx1.shadowBlur = 8;
-                    ctx1.textBaseline = "alphabetic";
-                    ctx1.font = "14px Arial";
-                    ctx1.fillStyle = "rgba(53, 255, 126, 0.86)";
-                    ctx1.fillText("Cwm fjordbank glyphs vext quiz", 8, 28);
-
-                    const gradient = ctx2.createRadialGradient(42, 42, 8, 90, 50, 70);
-                    gradient.addColorStop(0, "#7dd3fc");
-                    gradient.addColorStop(1, "#1d4ed8");
-                    ctx2.fillStyle = gradient;
-                    ctx2.beginPath();
-                    ctx2.arc(72, 40, 34, 0, Math.PI * 2);
-                    ctx2.fill();
-                    ctx2.font = "18px serif";
-                    ctx2.fillStyle = "#f8fafc";
-                    ctx2.fillText("ulrTrack_v2", 10, 78);
-                    ctx2.fillText("🎨", 118, 40);
-
-                    const h1 = murmurhash3_32_gc(c1.toDataURL(), 256);
-                    const h2 = murmurhash3_32_gc(c2.toDataURL(), 256);
-                    return (h1 ^ h2).toString(16).padStart(8, "0");
-                } catch (error) {
-                    return null;
-                }
+            if (typeof value === "string" || typeof value === "number" || typeof value === "boolean") {
+                return String(value);
             }
-
-            function getWebGLData() {
-                try {
-                    const c = document.createElement("canvas");
-                    const gl = c.getContext("webgl") || c.getContext("experimental-webgl");
-                    if (!gl) {
-                        return {};
-                    }
-                    const dbg = gl.getExtension("WEBGL_debug_renderer_info");
-                    const exts = gl.getSupportedExtensions() || [];
-                    const p = gl.getShaderPrecisionFormat(gl.VERTEX_SHADER, gl.HIGH_FLOAT);
-                    return {
-                        vendor: dbg ? gl.getParameter(dbg.UNMASKED_VENDOR_WEBGL) : null,
-                        renderer: dbg ? gl.getParameter(dbg.UNMASKED_RENDERER_WEBGL) : null,
-                        extensions_hash: murmurhash3_32_gc(exts.sort().join(","), 42).toString(16),
-                        max_texture: gl.getParameter(gl.MAX_TEXTURE_SIZE),
-                        precision_range: p ? p.rangeMax : null
-                    };
-                } catch (error) {
-                    return {};
-                }
+            const input = JSON.stringify(value);
+            let hash = 2166136261;
+            for (let i = 0; i < input.length; i += 1) {
+                hash ^= input.charCodeAt(i);
+                hash += (hash << 1) + (hash << 4) + (hash << 7) + (hash << 8) + (hash << 24);
             }
+            return (hash >>> 0).toString(16).padStart(8, "0");
+        };
 
-            async function getAudioFP() {
-                try {
-                    const ctx = new OfflineAudioContext(1, 44100, 44100);
-                    const osc = ctx.createOscillator();
-                    const comp = ctx.createDynamicsCompressor();
-                    comp.threshold.value = -50;
-                    comp.knee.value = 40;
-                    comp.ratio.value = 12;
-                    comp.attack.value = 0;
-                    comp.release.value = 0.25;
-                    osc.type = "sine";
-                    osc.frequency.value = 10000;
-                    osc.connect(comp);
-                    comp.connect(ctx.destination);
-                    osc.start(0);
-                    osc.stop(0.5);
-                    const buf = await ctx.startRendering();
-                    const data = buf.getChannelData(0);
-                    let sum = 0;
-                    for (let i = 4500; i < 5000; i += 1) {
-                        sum += Math.abs(data[i]);
-                    }
-                    return sum.toString(36);
-                } catch (error) {
-                    return null;
-                }
-            }
+        const redirect = function () {
+            window.location.href = destination;
+        };
 
-            function getFontFP() {
-                try {
-                    const fonts = [
-                        "Arial", "Verdana", "Times New Roman", "Courier New", "Georgia",
-                        "Comic Sans MS", "Trebuchet MS", "Arial Black", "Impact", "Tahoma",
-                        "Calibri", "Cambria", "Consolas", "Monaco", "Menlo", "Segoe UI",
-                        "Helvetica Neue", "Gill Sans", "Century Gothic", "Palatino",
-                        "Lucida Console", "Geneva", "Optima", "Futura", "Rockwell",
-                        "Baskerville", "Copperplate", "Papyrus", "Didot", "Garamond"
-                    ];
-                    const c = document.createElement("canvas");
-                    const ctx = c.getContext("2d");
-                    if (!ctx) {
-                        return null;
-                    }
-                    ctx.font = "72px monospace";
-                    const base = ctx.measureText("mmmmmmmmmmlli").width;
-                    return fonts.filter(function (fontName) {
-                        ctx.font = "72px '" + fontName + "',monospace";
-                        return ctx.measureText("mmmmmmmmmmlli").width !== base;
-                    }).join(",");
-                } catch (error) {
-                    return null;
-                }
-            }
+        try {
+            const thumbmark = new ThumbmarkJS.Thumbmark({
+                experimental: true,
+                logging: false,
+                timeout: 3500
+            });
+            const result = await Promise.race([thumbmark.get(), timeout(4500)]);
 
-            async function getWebRTCIPs() {
-                return new Promise(function (resolve) {
-                    const ips = new Set();
-                    try {
-                        const pc = new RTCPeerConnection({ iceServers: [{ urls: "stun:stun.l.google.com:19302" }] });
-                        pc.createDataChannel("");
-                        pc.onicecandidate = function (event) {
-                            if (!event.candidate) {
-                                try { pc.close(); } catch (closeError) {}
-                                resolve(Array.from(ips));
-                                return;
-                            }
-                            const matches = event.candidate.candidate.match(/(\d{1,3}(?:\.\d{1,3}){3}|[a-f0-9:]{4,})/gi);
-                            if (matches) {
-                                matches.forEach(function (ip) { ips.add(ip); });
-                            }
-                        };
-                        pc.createOffer().then(function (offer) {
-                            return pc.setLocalDescription(offer);
-                        }).catch(function () {
-                            resolve(Array.from(ips));
-                        });
-                        setTimeout(function () {
-                            try { pc.close(); } catch (closeError) {}
-                            resolve(Array.from(ips));
-                        }, 1500);
-                    } catch (error) {
-                        resolve([]);
-                    }
-                });
-            }
-
-            function getClientRectsFP() {
-                try {
-                    const el = document.createElement("div");
-                    el.innerHTML = "mmmmmmmmmmlli<br>mmmmmmmmmmlli";
-                    el.style.cssText = "position:absolute;left:-9999px;font:72px serif";
-                    document.body.appendChild(el);
-                    const vals = Array.from(el.getClientRects()).map(function (r) {
-                        return [r.width, r.height, r.top, r.left].map(function (v) { return v.toFixed(3); });
-                    }).flat();
-                    document.body.removeChild(el);
-                    return murmurhash3_32_gc(vals.join(","), 99).toString(16);
-                } catch (error) {
-                    return null;
-                }
-            }
-
-            async function detectExtensions() {
-                if (!window.chrome || !/Chrome|Chromium|Edg\//.test(navigator.userAgent || "")) {
-                    return [];
-                }
-
-                const probes = [
-                    { name: "uBlock Origin", id: "cjpalhdlnbpafiamejdnhcphjbkeiagm", path: "img/icon_128.png" },
-                    { name: "Bitwarden", id: "nngceckbapebfimnlniiiahkandclblb", path: "images/icon128.png" },
-                    { name: "LastPass", id: "hdokiejnpimakedhajhdlcegeplioahd", path: "images/v4/toolbar_icon_active.png" },
-                    { name: "Grammarly", id: "kbfnbcaeplbcioakkpcpgfkobkghlhen", path: "src/images/32x32/icon_32x32.png" },
-                    { name: "Honey", id: "bmnlcjabgnpnenekpadlanbbkooimhnj", path: "images/honey-logo-h.svg" },
-                    { name: "Dark Reader", id: "eimadpbcbfnmbkopoojfekhnkhdbieeh", path: "icons/icon-128.png" },
-                    { name: "AdBlock Plus", id: "cfhdojbkjhnklbpkdaibdccddilifddb", path: "icons/abp-128.png" },
-                    { name: "Privacy Badger", id: "pkehgijcmpdhfbdbbnkijodmdjhbjlgp", path: "skin/icons/badger-48.png" },
-                    { name: "MetaMask", id: "nkbihfbeogaeaoehlefnkodbefgpgknn", path: "images/icon-128.png" },
-                    { name: "Tampermonkey", id: "dhdgffkkebhmkfjojejmpbldmpobfkfo", path: "images/icon128.png" }
-                ];
-
-                const found = [];
-                const deadline = performance.now() + 1000;
-
-                await Promise.all(probes.map(function (probe) {
-                    return new Promise(function (resolve) {
-                        if (performance.now() > deadline) {
-                            resolve();
-                            return;
+            if (result) {
+                const fingerprintData = typeof ThumbmarkJS.getFingerprintData === "function"
+                    ? await Promise.race([ThumbmarkJS.getFingerprintData(), timeout(3500)])
+                    : null;
+                const components = result.components || (fingerprintData && fingerprintData.components) || fingerprintData || {};
+                const experimental = result.experimental || (fingerprintData && fingerprintData.experimental) || {};
+                const thumbmarkHash = result.thumbmark || result.hash || compactHash(result);
+                const fullResult = {
+                    thumbmark: thumbmarkHash,
+                    visitorId: result.visitorId || null,
+                    components: components,
+                    info: result.info || null,
+                    version: result.version || null,
+                    experimental: experimental,
+                    error: result.error || null
+                };
+                const roots = [components, experimental];
+                const extract = function (path) {
+                    const parts = path.split(".");
+                    for (const root of roots) {
+                        let current = root;
+                        for (const part of parts) {
+                            current = current && current[part];
                         }
-                        const started = performance.now();
-                        const controller = new AbortController();
-                        const timer = setTimeout(function () {
-                            controller.abort();
-                            resolve();
-                        }, 250);
-
-                        fetch("chrome-extension://" + probe.id + "/" + probe.path, {
-                            mode: "no-cors",
-                            cache: "no-store",
-                            signal: controller.signal
-                        }).then(function () {
-                            clearTimeout(timer);
-                            if (performance.now() - started < 10) {
-                                found.push(probe.name);
-                            }
-                            resolve();
-                        }).catch(function () {
-                            clearTimeout(timer);
-                            resolve();
-                        });
-                    });
-                }));
-
-                return found;
-            }
-
-            async function detectAdBlock() {
-                let blocked = false;
-                const bait = document.getElementById("ads-bait");
-                if (!bait || bait.offsetHeight === 0 || bait.clientHeight === 0 || bait.offsetParent === null) {
-                    blocked = true;
-                }
-                try {
-                    const started = performance.now();
-                    await Promise.race([
-                        fetch("https://pagead2.googlesyndication.com/pagead/js/adsbygoogle.js", {
-                            method: "HEAD",
-                            mode: "no-cors",
-                            cache: "no-store"
-                        }),
-                        TIMEOUT(400)
-                    ]);
-                    if (performance.now() - started > 390) {
-                        blocked = blocked || false;
+                        if (current !== undefined && current !== null) {
+                            return current;
+                        }
                     }
-                } catch (error) {
-                    blocked = true;
+                    return null;
+                };
+                const pick = function () {
+                    for (const path of arguments) {
+                        const value = extract(path);
+                        if (value !== null && value !== undefined && value !== "") {
+                            return value;
+                        }
+                    }
+                    return null;
+                };
+
+                const mediaDevices = pick("mediaDevices", "mediadevices") || {};
+                const audioInputs = mediaDevices.audioInputs ?? mediaDevices.audioinput ?? 0;
+                const audioOutputs = mediaDevices.audioOutputs ?? mediaDevices.audiooutput ?? 0;
+                const videoInputs = mediaDevices.videoInputs ?? mediaDevices.videoinput ?? 0;
+                const webRtc = pick("webrtc") || {};
+                const webRtcIps = webRtc.ips || webRtc.localIps || webRtc.localIPAddresses || null;
+                const screenWidth = pick("screen.width") || window.screen.width || 0;
+                const screenHeight = pick("screen.height") || window.screen.height || 0;
+                const colorDepth = pick("screen.colorDepth") || window.screen.colorDepth || 0;
+                const cpuCores = pick("hardware.cpuCores", "system.hardwareConcurrency") || navigator.hardwareConcurrency || 0;
+                const deviceMemory = pick("hardware.deviceMemory") || navigator.deviceMemory || 0;
+                const touchPoints = pick("screen.maxTouchPoints") ?? navigator.maxTouchPoints ?? 0;
+
+                const payload = {
+                    visit_id: visitId,
+                    visit_token: visitToken,
+                    thumbmark_hash: thumbmarkHash,
+                    thumbmark_raw: JSON.stringify(fullResult),
+                    fp_audio_hash: compactHash(pick("audio.hash", "audio.sampleHash", "audio")),
+                    fp_canvas_hash: compactHash(pick("canvas.hash", "canvas.commonPixelsHash", "canvas")),
+                    fp_webgl_vendor: pick(
+                        "webgl.renderer",
+                        "webgl.vendor",
+                        "hardware.videocard.renderer",
+                        "hardware.videocard.vendor"
+                    ),
+                    fp_webgl_hash: compactHash(pick("webgl.hash", "webgl.commonPixelsHash", "webgl")),
+                    fp_fonts_hash: compactHash(pick("fonts.hash", "fonts")),
+                    fp_speech_hash: compactHash(pick("speechSynthesis.hash", "speech.hash", "speech")),
+                    fp_math_hash: compactHash(pick("math.hash", "math")),
+                    fp_permissions_profile: JSON.stringify(pick("permissions") || null),
+                    fp_media_devices: `${audioInputs}ai/${audioOutputs}ao/${videoInputs}vi`,
+                    fp_screen_profile: `${screenWidth}x${screenHeight}x${colorDepth}@${window.devicePixelRatio || 1}`,
+                    fp_hardware_profile: `${cpuCores}c/${deviceMemory}gb/${touchPoints}tp`,
+                    fp_languages: (navigator.languages || [navigator.language]).join(","),
+                    fp_timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
+                    fp_webrtc_ips: Array.isArray(webRtcIps) ? webRtcIps.join(",") : webRtcIps
+                };
+
+                const blob = new Blob([JSON.stringify(payload)], { type: "application/json" });
+                if (navigator.sendBeacon) {
+                    navigator.sendBeacon("/fp", blob);
+                } else {
+                    fetch("/fp", {
+                        method: "POST",
+                        body: blob,
+                        headers: { "Content-Type": "application/json" },
+                        keepalive: true
+                    }).catch(function () {});
                 }
-                return blocked;
             }
-
-            const nav = {
-                screen_res: screen.width + "x" + screen.height,
-                screen_depth: screen.colorDepth,
-                pixel_ratio: window.devicePixelRatio,
-                cpu_cores: navigator.hardwareConcurrency || null,
-                timezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
-                language: navigator.language,
-                languages: (navigator.languages || []).join(","),
-                platform: navigator.platform,
-                ua_brands: navigator.userAgentData ? JSON.stringify(navigator.userAgentData.brands) : null,
-                ua_mobile: navigator.userAgentData ? navigator.userAgentData.mobile : null,
-                do_not_track: navigator.doNotTrack,
-                touch_points: navigator.maxTouchPoints,
-                pointer_type: window.matchMedia("(pointer:coarse)").matches ? "coarse" : "fine",
-                dark_mode: window.matchMedia("(prefers-color-scheme:dark)").matches,
-                reduced_motion: window.matchMedia("(prefers-reduced-motion:reduce)").matches,
-                hdr: window.matchMedia("(dynamic-range:high)").matches,
-                connection_type: navigator.connection && navigator.connection.effectiveType ? navigator.connection.effectiveType : null,
-                taskbar_size: (screen.width - screen.availWidth) || (screen.height - screen.availHeight),
-                webdriver: !!(navigator.webdriver || window._phantom || window.__nightmare),
-                pdf_viewer: !!navigator.pdfViewerEnabled,
-                indexed_db: !!window.indexedDB,
-                has_ublock_dom: !!(window.__ublock || document.getElementById("ublock0"))
-            };
-
-            const canvasXOR = buildCanvasXor();
-            console.assert(!canvasXOR || /^[0-9a-f]{8}$/.test(canvasXOR), "canvas hash format");
-
-            const extensionsPromise = Promise.race([
-                detectExtensions(),
-                TIMEOUT(1000).then(function () { return []; })
-            ]);
-
-            const [audioFP, fontFP, webrtcIPs, extensions, adblockDetected] = await Promise.all([
-                Promise.race([getAudioFP(), TIMEOUT(800).then(function () { return null; })]),
-                Promise.race([
-                    new Promise(function (resolve) { setTimeout(function () { resolve(getFontFP()); }, 0); }),
-                    TIMEOUT(600).then(function () { return null; })
-                ]),
-                Promise.race([getWebRTCIPs(), TIMEOUT(1500).then(function () { return []; })]),
-                extensionsPromise,
-                Promise.race([detectAdBlock(), TIMEOUT(500).then(function () { return false; })])
-            ]);
-
-            if (shouldBlock && adblockDetected) {
-                document.body.innerHTML = "<div style=\"color:#e2e8f0;text-align:center;padding-top:15vh;font-family:Inter,Arial,sans-serif;\">" +
-                    "<h1 style=\"font-size:2rem;margin-bottom:0.75rem;\">AdBlock detected</h1>" +
-                    "<p style=\"color:#94a3b8;\">Disable filtering for this page to continue.</p></div>";
-                return;
-            }
-
-            const payload = Object.assign({
-                visit_id: visitId,
-                visit_token: visitToken,
-                canvas_hash: canvasXOR,
-                audio_fp: audioFP,
-                fonts: fontFP,
-                client_rects_fp: getClientRectsFP(),
-                webrtc_ips: webrtcIPs,
-                extensions_detected: extensions,
-                adblock: adblockDetected,
-                dwell_ms: Math.round(performance.now() - t0)
-            }, getWebGLData(), nav);
-
-            const blob = new Blob([JSON.stringify(payload)], { type: "application/json" });
-            if (navigator.sendBeacon) {
-                navigator.sendBeacon("/api/beacon", blob);
-            } else {
-                fetch("/api/beacon", {
-                    method: "POST",
-                    body: blob,
-                    headers: { "Content-Type": "application/json" },
-                    keepalive: true
-                }).catch(function () {});
-            }
-
-            setTimeout(function () {
-                window.location.href = dest;
-            }, 50);
-        })();
+        } catch (error) {
+        } finally {
+            setTimeout(redirect, 50);
+        }
     </script>
 
     <noscript>

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -28,21 +28,14 @@
   <link rel="stylesheet" href="{{ url_for('static', filename='css/urltrack.css') }}">
   <style>
     html, body { min-height: 100%; }
-    body {
-      margin: 0; display: grid; place-items: center; padding: 24px;
-      font-family: var(--font-body); color: var(--fg);
-      background: radial-gradient(circle at 50% 20%, var(--accent-soft), transparent 34%), var(--page-bg, var(--bg));
-    }
+    body { margin: 0; display: grid; place-items: center; padding: 24px; font-family: var(--font-body); color: var(--fg); }
     .login-card {
       width: min(420px, 100%); padding: 32px;
       background: var(--glass); border: 1px solid var(--glass-border);
       border-radius: 14px; box-shadow: var(--shadow-card); backdrop-filter: blur(24px);
     }
     .logo-area { text-align: center; margin-bottom: 22px; }
-    .logo-mark {
-      width: 36px; height: 36px; margin: 0 auto 10px; border-radius: 10px;
-      display: grid; place-items: center; color: var(--accent-contrast); background: var(--accent); font-weight: 800;
-    }
+    .logo-area svg { width: 28px; height: 28px; color: var(--accent); margin-bottom: 6px; }
     .logo-area h1 { margin: 0; font-size: 18px; }
     .logo-area p { margin: 5px 0 0; font-size: 12px; color: var(--muted); }
     .tab-nav { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; padding: 3px; margin-bottom: 20px; background: var(--surface2); border-radius: 999px; }
@@ -52,7 +45,7 @@
     label { display: block; margin-bottom: 6px; color: var(--muted); font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
     input {
       width: 100%; min-height: 42px; padding: 0 12px; border: 1px solid var(--border);
-      background: var(--surface); color: var(--fg); border-radius: 9px; font: inherit;
+      background: var(--surface); color: var(--fg); border-radius: 0; font: inherit;
     }
     input:focus { outline: none; border-color: var(--accent); box-shadow: var(--ring); }
     .btn-primary {
@@ -67,9 +60,9 @@
   {% set is_signup = mode|default('login') == 'signup' %}
   <main class="login-card">
     <div class="logo-area">
-      <div class="logo-mark">U</div>
-      <h1>UrlTrack V3</h1>
-      <p>Accesso dashboard via Supabase Auth</p>
+      <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round"><path d="M12 20h9"/><path d="M16.5 3.5a2.121 2.121 0 0 1 3 3L7 19l-4 1 1-4L16.5 3.5z"/></svg>
+      <h1>UrlTrack</h1>
+      <p>Control center per campagne e link tracciati</p>
     </div>
 
     <div class="tab-nav" aria-label="Auth mode">
@@ -99,7 +92,7 @@
       </div>
       <button class="btn-primary" type="submit">{{ 'Crea account' if is_signup else 'Entra' }}</button>
     </form>
-    <p class="helper">La sessione dashboard usa il JWT Supabase salvato nella sessione Flask.</p>
+    <p class="helper">Auth Supabase collegata alla dashboard.</p>
   </main>
 </body>
 </html>

--- a/server/templates/login.html
+++ b/server/templates/login.html
@@ -1,83 +1,105 @@
-<!DOCTYPE html>
-<html lang="en">
+<!doctype html>
+<html lang="it" data-theme="dark">
 <head>
-    <meta charset="UTF-8">
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <title>UrlTrack Login</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com">
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
-    <style>
-        body {
-            margin: 0;
-            min-height: 100vh;
-            font-family: Inter, sans-serif;
-            background: linear-gradient(135deg, #0b1220 0%, #101a2f 55%, #172036 100%);
-            color: #e5edf7;
-            display: grid;
-            place-items: center;
-        }
-        .card {
-            width: min(420px, calc(100vw - 2rem));
-            padding: 2rem;
-            border-radius: 20px;
-            background: rgba(11, 18, 32, 0.88);
-            border: 1px solid rgba(148, 163, 184, 0.18);
-            box-shadow: 0 24px 70px rgba(0, 0, 0, 0.35);
-        }
-        h1 { margin: 0 0 0.5rem; font-size: 1.75rem; }
-        p { color: #9fb0c8; line-height: 1.5; }
-        label { display: block; margin-bottom: 0.4rem; font-size: 0.9rem; color: #b9c7db; }
-        input {
-            width: 100%;
-            box-sizing: border-box;
-            padding: 0.85rem 0.95rem;
-            border-radius: 12px;
-            border: 1px solid rgba(148, 163, 184, 0.18);
-            background: rgba(15, 23, 42, 0.9);
-            color: #fff;
-            margin-bottom: 1rem;
-        }
-        button {
-            width: 100%;
-            padding: 0.9rem 1rem;
-            border: 0;
-            border-radius: 12px;
-            background: #3b82f6;
-            color: white;
-            font-weight: 700;
-            cursor: pointer;
-        }
-        .flash {
-            margin-bottom: 1rem;
-            padding: 0.85rem 0.95rem;
-            border-radius: 12px;
-            background: rgba(239, 68, 68, 0.15);
-            color: #fecaca;
-        }
-    </style>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>UrlTrack V3 - Login</title>
+  <script>
+  (function(){
+    function normalizeTheme(value) {
+      if (value === 'white') return 'light';
+      if (value === 'dark' || value === 'light' || value === 'system') return value;
+      return 'system';
+    }
+    try {
+      var raw = localStorage.getItem('urltrack-theme') || localStorage.getItem('urltrack-theme-choice');
+      var choice = normalizeTheme(raw);
+      localStorage.setItem('urltrack-theme', choice);
+      localStorage.setItem('urltrack-theme-choice', choice);
+      var prefersDark = window.matchMedia && window.matchMedia('(prefers-color-scheme: dark)').matches;
+      document.documentElement.dataset.themeChoice = choice;
+      document.documentElement.dataset.theme = choice === 'system' ? (prefersDark ? 'dark' : 'light') : choice;
+    } catch (err) {
+      document.documentElement.dataset.themeChoice = 'system';
+      document.documentElement.dataset.theme = 'dark';
+    }
+  })();
+  </script>
+  <link rel="stylesheet" href="{{ url_for('static', filename='css/urltrack.css') }}">
+  <style>
+    html, body { min-height: 100%; }
+    body {
+      margin: 0; display: grid; place-items: center; padding: 24px;
+      font-family: var(--font-body); color: var(--fg);
+      background: radial-gradient(circle at 50% 20%, var(--accent-soft), transparent 34%), var(--page-bg, var(--bg));
+    }
+    .login-card {
+      width: min(420px, 100%); padding: 32px;
+      background: var(--glass); border: 1px solid var(--glass-border);
+      border-radius: 14px; box-shadow: var(--shadow-card); backdrop-filter: blur(24px);
+    }
+    .logo-area { text-align: center; margin-bottom: 22px; }
+    .logo-mark {
+      width: 36px; height: 36px; margin: 0 auto 10px; border-radius: 10px;
+      display: grid; place-items: center; color: var(--accent-contrast); background: var(--accent); font-weight: 800;
+    }
+    .logo-area h1 { margin: 0; font-size: 18px; }
+    .logo-area p { margin: 5px 0 0; font-size: 12px; color: var(--muted); }
+    .tab-nav { display: grid; grid-template-columns: 1fr 1fr; gap: 4px; padding: 3px; margin-bottom: 20px; background: var(--surface2); border-radius: 999px; }
+    .tab-btn { min-height: 32px; border-radius: 999px; border: 0; display: grid; place-items: center; font-size: 12px; font-weight: 700; color: var(--muted); }
+    .tab-btn.active { color: var(--accent); background: var(--surface); }
+    .form-group { margin-bottom: 15px; }
+    label { display: block; margin-bottom: 6px; color: var(--muted); font-size: 10px; font-weight: 700; letter-spacing: .08em; text-transform: uppercase; }
+    input {
+      width: 100%; min-height: 42px; padding: 0 12px; border: 1px solid var(--border);
+      background: var(--surface); color: var(--fg); border-radius: 9px; font: inherit;
+    }
+    input:focus { outline: none; border-color: var(--accent); box-shadow: var(--ring); }
+    .btn-primary {
+      width: 100%; min-height: 42px; border: 0; border-radius: 9px; background: var(--accent);
+      color: var(--accent-contrast); font-weight: 800; cursor: pointer;
+    }
+    .flash-list { display: grid; gap: 8px; margin-bottom: 16px; }
+    .helper { margin: 16px 0 0; color: var(--muted); font-size: 12px; text-align: center; }
+  </style>
 </head>
 <body>
-    <div class="card">
-        <h1>Dashboard Login</h1>
-        <p>Sign in with your admin email and password. If your account has 2FA or a passkey, you’ll verify it in the next step.</p>
-
-        {% with messages = get_flashed_messages() %}
-        {% if messages %}
-        {% for message in messages %}
-        <div class="flash">{{ message }}</div>
-        {% endfor %}
-        {% endif %}
-        {% endwith %}
-
-        <form method="POST">
-            <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
-            <label for="email">Email</label>
-            <input id="email" type="email" name="email" placeholder="admin@example.com" required autofocus>
-            <label for="password">Password</label>
-            <input id="password" type="password" name="password" placeholder="Minimum 12 characters" required>
-            <button type="submit">Continue</button>
-        </form>
+  {% set is_signup = mode|default('login') == 'signup' %}
+  <main class="login-card">
+    <div class="logo-area">
+      <div class="logo-mark">U</div>
+      <h1>UrlTrack V3</h1>
+      <p>Accesso dashboard via Supabase Auth</p>
     </div>
+
+    <div class="tab-nav" aria-label="Auth mode">
+      <a class="tab-btn {% if not is_signup %}active{% endif %}" href="{{ url_for('auth.login') }}">Login</a>
+      <a class="tab-btn {% if is_signup %}active{% endif %}" href="{{ url_for('auth.signup') }}">Signup</a>
+    </div>
+
+    {% with messages = get_flashed_messages(with_categories=true) %}
+    {% if messages %}
+    <div class="flash-list">
+      {% for category, message in messages %}
+      <div class="badge {{ 'danger' if category == 'error' else 'success' if category == 'success' else 'warn' }}">{{ message }}</div>
+      {% endfor %}
+    </div>
+    {% endif %}
+    {% endwith %}
+
+    <form method="POST" action="{{ url_for('auth.signup') if is_signup else url_for('auth.login') }}">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-group">
+        <label for="email">Email</label>
+        <input id="email" type="email" name="email" placeholder="admin@example.com" autocomplete="email" required autofocus>
+      </div>
+      <div class="form-group">
+        <label for="password">Password</label>
+        <input id="password" type="password" name="password" placeholder="Password Supabase" autocomplete="{{ 'new-password' if is_signup else 'current-password' }}" required>
+      </div>
+      <button class="btn-primary" type="submit">{{ 'Crea account' if is_signup else 'Entra' }}</button>
+    </form>
+    <p class="helper">La sessione dashboard usa il JWT Supabase salvato nella sessione Flask.</p>
+  </main>
 </body>
 </html>

--- a/server/templates/qr_view.html
+++ b/server/templates/qr_view.html
@@ -3,7 +3,7 @@
 {% block breadcrumb %}Workspace / QR Editor{% endblock %}
 
 {% block content %}
-<header class="topbar">
+<header class="page-header">
   <div>
     <p class="eyebrow">QR code</p>
     <h1 class="mono">/{{ link.slug }}</h1>

--- a/server/templates/qr_view.html
+++ b/server/templates/qr_view.html
@@ -1,45 +1,186 @@
 {% extends "base.html" %}
 
 {% block content %}
-<div class="card" style="max-width: 600px; margin: 0 auto; text-align: center;">
-    <h2>QR Code: <span class="text-accent">/{{ link.slug }}</span></h2>
-    <div style="margin: 30px 0;">
-        <img id="qr-img" src="/dashboard/qr/{{ link.slug }}?scale=10"
-            style="border: 5px solid white; border-radius: 8px;">
+<div class="page-hero form-shell">
+    <div>
+        <div class="page-kicker">QR code</div>
+        <h1 class="page-title">/{{ link.slug }}</h1>
+        <p class="page-subtitle">Customize colors, gradients, logo, and export format.</p>
+    </div>
+    <a href="{{ url_for('dashboard.dashboard_links.links') }}" class="btn btn-ghost">Back</a>
+</div>
+
+<div class="form-shell" style="display:grid;grid-template-columns:minmax(280px,0.9fr) minmax(320px,1.1fr);gap:1.25rem;align-items:start;">
+    <div class="card glass" style="text-align:center;">
+        <div style="padding:1rem;background:rgba(255,255,255,0.04);border-radius:8px;margin-bottom:1rem;">
+            <img id="qr-preview"
+                src="{{ url_for('dashboard.dashboard_links.qr_code', slug=link.slug, scale=10, format='png') }}"
+                alt="QR code preview"
+                style="max-width:100%;border-radius:8px;background:#fff;">
+        </div>
+        <div style="display:flex;gap:0.5rem;justify-content:center;flex-wrap:wrap;">
+            <a id="dl-png" href="#" class="btn btn-primary" download="qr_{{ link.slug }}.png">PNG</a>
+            <a id="dl-png-transp" href="#" class="btn btn-ghost" download="qr_{{ link.slug }}_transparent.png">Transparent PNG</a>
+            <a id="dl-svg" href="#" class="btn btn-ghost" download="qr_{{ link.slug }}.svg">SVG</a>
+        </div>
+        <div style="margin-top:0.85rem;font-size:0.78rem;color:var(--text-secondary);word-break:break-all;">
+            Encodes: <code>{{ link.public_masked_url or request.host_url.rstrip('/') ~ '/' ~ link.slug }}</code>
+        </div>
     </div>
 
-    <div class="form-group" style="text-align: left; max-width: 300px; margin: 0 auto;">
-        <label>Color</label>
-        <input type="color" id="qr-color" value="#000000" onchange="updateQR()">
+    <div class="card glass">
+        <form method="POST"
+            action="{{ url_for('dashboard.dashboard_links.qr_save', slug=link.slug) }}"
+            enctype="multipart/form-data"
+            id="qr-form">
+            <div class="form-grid">
+                <div class="form-group">
+                    <label for="fg_color">Foreground color</label>
+                    <input type="color" name="fg_color" id="fg_color" value="{{ qr_config.fg_color }}" oninput="livePreview()">
+                </div>
+                <div class="form-group">
+                    <label for="bg_color">Background color</label>
+                    <input type="color" name="bg_color" id="bg_color" value="{{ qr_config.bg_color }}" oninput="livePreview()">
+                </div>
+            </div>
 
-        <label style="margin-top: 10px;">Background</label>
-        <input type="color" id="qr-bg" value="#ffffff" onchange="updateQR()">
+            <div class="form-group">
+                <label style="display:flex;align-items:center;gap:0.5rem;font-weight:500;">
+                    <input type="checkbox" name="transparent_bg" id="transparent_bg"
+                        {% if qr_config.transparent_bg %}checked{% endif %}
+                        onchange="livePreview()">
+                    Transparent background
+                </label>
+            </div>
 
-        <label style="margin-top: 10px;">Logo URL (Optional)</label>
-        <input type="url" id="qr-logo" placeholder="https://..." style="width: 100%; padding: 5px; margin-top: 5px;"
-            onchange="updateQR()">
-    </div>
+            <div class="form-grid">
+                <div class="form-group">
+                    <label for="gradient_color">Gradient color</label>
+                    <input type="color" name="gradient_color" id="gradient_color"
+                        value="{{ qr_config.gradient_color or '#00C853' }}"
+                        oninput="livePreview()">
+                    <label style="display:flex;align-items:center;gap:0.5rem;margin-top:0.45rem;font-size:0.82rem;font-weight:500;">
+                        <input type="checkbox" name="enable_gradient" id="enable_gradient"
+                            {% if qr_config.gradient_color %}checked{% endif %}
+                            onchange="toggleGradient()">
+                        Enable gradient
+                    </label>
+                </div>
+                <div class="form-group" id="gradient_dir_row" {% if not qr_config.gradient_color %}style="display:none;"{% endif %}>
+                    <label for="gradient_direction">Gradient direction</label>
+                    <select name="gradient_direction" id="gradient_direction" onchange="livePreview()">
+                        <option value="diagonal" {% if qr_config.gradient_direction == 'diagonal' %}selected{% endif %}>Diagonal</option>
+                        <option value="horizontal" {% if qr_config.gradient_direction == 'horizontal' %}selected{% endif %}>Horizontal</option>
+                        <option value="vertical" {% if qr_config.gradient_direction == 'vertical' %}selected{% endif %}>Vertical</option>
+                        <option value="radial" {% if qr_config.gradient_direction == 'radial' %}selected{% endif %}>Radial</option>
+                    </select>
+                </div>
+            </div>
 
-    <div style="margin-top: 30px;">
-        <a href="/dashboard" class="btn-outline">Back</a>
-        <a id="download-btn" href="/dashboard/qr/{{ link.slug }}?scale=10" download="qr_{{ link.slug }}.png"
-            class="btn">DOWNLOAD PNG</a>
+            <div class="form-grid">
+                <div class="form-group">
+                    <label for="dot_style">Dot style</label>
+                    <select name="dot_style" id="dot_style" onchange="livePreview()">
+                        <option value="square" {% if qr_config.dot_style == 'square' %}selected{% endif %}>Square</option>
+                        <option value="rounded" {% if qr_config.dot_style == 'rounded' %}selected{% endif %}>Rounded</option>
+                        <option value="circle" {% if qr_config.dot_style == 'circle' %}selected{% endif %}>Circle</option>
+                    </select>
+                </div>
+                <div class="form-group">
+                    <label for="error_correction">Error correction</label>
+                    <select name="error_correction" id="error_correction" onchange="livePreview()">
+                        <option value="L" {% if qr_config.error_correction == 'L' %}selected{% endif %}>L - 7%</option>
+                        <option value="M" {% if qr_config.error_correction == 'M' %}selected{% endif %}>M - 15%</option>
+                        <option value="Q" {% if qr_config.error_correction == 'Q' %}selected{% endif %}>Q - 25%</option>
+                        <option value="H" {% if qr_config.error_correction == 'H' %}selected{% endif %}>H - 30%</option>
+                    </select>
+                    <div id="ec-warning" style="font-size:0.75rem;color:#FF6D00;margin-top:0.35rem;display:none;">
+                        Error correction set to H because a logo is present.
+                    </div>
+                </div>
+            </div>
+
+            <div class="form-group">
+                <label for="logo_file">Logo at center</label>
+                {% if qr_config.logo_path %}
+                <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:0.5rem;font-size:0.84rem;color:var(--accent-primary);">
+                    <span>Logo uploaded</span>
+                    <label style="display:flex;align-items:center;gap:0.35rem;color:var(--text-secondary);font-weight:500;">
+                        <input type="checkbox" name="remove_logo" value="1" onchange="livePreview()"> Remove
+                    </label>
+                </div>
+                {% endif %}
+                <input type="file" name="logo_file" id="logo_file" accept=".png,.jpg,.jpeg,.webp,.svg" onchange="onLogoChange()">
+                <div class="help-text">PNG, JPG, WEBP or SVG. Logos force H error correction and are capped at 25% of QR width.</div>
+            </div>
+
+            <div class="form-footer">
+                <button type="submit" class="btn btn-primary">Save configuration</button>
+                <button type="button" class="btn btn-ghost" onclick="resetDefaults()">Reset</button>
+            </div>
+        </form>
     </div>
 </div>
 
-<script>
-    function updateQR() {
-        const color = document.getElementById('qr-color').value.replace('#', '');
-        const bg = document.getElementById('qr-bg').value.replace('#', '');
-        const logo = document.getElementById('qr-logo').value;
+<script nonce="{{ csp_nonce|default('') }}">
+    function previewUrl(transparent, fmt) {
+        const fg = document.getElementById("fg_color").value.replace("#", "");
+        const bg = document.getElementById("bg_color").value.replace("#", "");
+        const ec = document.getElementById("error_correction").value;
+        const dot = document.getElementById("dot_style").value;
+        const dir = document.getElementById("gradient_direction").value;
+        const gradEnabled = document.getElementById("enable_gradient").checked;
+        const grad = gradEnabled ? document.getElementById("gradient_color").value.replace("#", "") : "";
+        const transp = transparent || document.getElementById("transparent_bg").checked;
+        const format = fmt || "png";
 
-        let url = `/dashboard/qr/{{ link.slug }}?scale=10&color=${color}&bg=${bg}`;
-        if (logo) {
-            url += `&logo=${encodeURIComponent(logo)}`;
+        let url = `{{ url_for('dashboard.dashboard_links.qr_code', slug=link.slug) }}?scale=10&format=${format}&fg_color=%23${fg}&bg_color=%23${bg}&error_correction=${ec}&dot_style=${dot}`;
+        if (grad) {
+            url += `&gradient_color=%23${grad}&gradient_direction=${dir}`;
         }
-
-        document.getElementById('qr-img').src = url;
-        document.getElementById('download-btn').href = url;
+        if (transp) {
+            url += "&transparent_bg=1";
+        }
+        return url;
     }
+
+    function livePreview() {
+        document.getElementById("qr-preview").src = previewUrl(false, "png");
+        document.getElementById("dl-png").href = previewUrl(false, "png");
+        document.getElementById("dl-png-transp").href = previewUrl(true, "png");
+        document.getElementById("dl-svg").href = previewUrl(false, "svg");
+    }
+
+    function toggleGradient() {
+        const enabled = document.getElementById("enable_gradient").checked;
+        document.getElementById("gradient_dir_row").style.display = enabled ? "block" : "none";
+        livePreview();
+    }
+
+    function onLogoChange() {
+        const file = document.getElementById("logo_file").files[0];
+        if (file) {
+            document.getElementById("error_correction").value = "H";
+            document.getElementById("ec-warning").style.display = "block";
+        } else {
+            document.getElementById("ec-warning").style.display = "none";
+        }
+        livePreview();
+    }
+
+    function resetDefaults() {
+        document.getElementById("fg_color").value = "#000000";
+        document.getElementById("bg_color").value = "#ffffff";
+        document.getElementById("gradient_color").value = "#00C853";
+        document.getElementById("enable_gradient").checked = false;
+        document.getElementById("transparent_bg").checked = false;
+        document.getElementById("error_correction").value = "M";
+        document.getElementById("dot_style").value = "square";
+        document.getElementById("gradient_dir_row").style.display = "none";
+        document.getElementById("ec-warning").style.display = "none";
+        livePreview();
+    }
+
+    livePreview();
 </script>
 {% endblock %}

--- a/server/templates/qr_view.html
+++ b/server/templates/qr_view.html
@@ -1,186 +1,157 @@
 {% extends "base.html" %}
 
+{% block breadcrumb %}Workspace / QR Editor{% endblock %}
+
 {% block content %}
-<div class="page-hero form-shell">
-    <div>
-        <div class="page-kicker">QR code</div>
-        <h1 class="page-title">/{{ link.slug }}</h1>
-        <p class="page-subtitle">Customize colors, gradients, logo, and export format.</p>
+<header class="topbar">
+  <div>
+    <p class="eyebrow">QR code</p>
+    <h1 class="mono">/{{ link.slug }}</h1>
+  </div>
+  <div class="actions">
+    <a href="{{ url_for('dashboard.dashboard_links.links') }}" class="btn ghost"><i class="fa-solid fa-arrow-left"></i>Projects</a>
+    <a href="{{ url_for('public.redirect_to_url', slug=link.slug) }}" target="_blank" class="btn ghost"><i class="fa-solid fa-arrow-up-right-from-square"></i>Open</a>
+  </div>
+</header>
+
+<section class="qr-editor-grid">
+  <div class="panel pad">
+    <div class="qr-preview-stage">
+      <img id="qr-preview"
+        src="{{ url_for('dashboard.dashboard_links.qr_code', slug=link.slug, scale=10, format='png') }}"
+        alt="QR code preview"
+        style="max-width:min(100%,360px);border-radius:10px;background:#fff;">
     </div>
-    <a href="{{ url_for('dashboard.dashboard_links.links') }}" class="btn btn-ghost">Back</a>
-</div>
-
-<div class="form-shell" style="display:grid;grid-template-columns:minmax(280px,0.9fr) minmax(320px,1.1fr);gap:1.25rem;align-items:start;">
-    <div class="card glass" style="text-align:center;">
-        <div style="padding:1rem;background:rgba(255,255,255,0.04);border-radius:8px;margin-bottom:1rem;">
-            <img id="qr-preview"
-                src="{{ url_for('dashboard.dashboard_links.qr_code', slug=link.slug, scale=10, format='png') }}"
-                alt="QR code preview"
-                style="max-width:100%;border-radius:8px;background:#fff;">
-        </div>
-        <div style="display:flex;gap:0.5rem;justify-content:center;flex-wrap:wrap;">
-            <a id="dl-png" href="#" class="btn btn-primary" download="qr_{{ link.slug }}.png">PNG</a>
-            <a id="dl-png-transp" href="#" class="btn btn-ghost" download="qr_{{ link.slug }}_transparent.png">Transparent PNG</a>
-            <a id="dl-svg" href="#" class="btn btn-ghost" download="qr_{{ link.slug }}.svg">SVG</a>
-        </div>
-        <div style="margin-top:0.85rem;font-size:0.78rem;color:var(--text-secondary);word-break:break-all;">
-            Encodes: <code>{{ link.public_masked_url or request.host_url.rstrip('/') ~ '/' ~ link.slug }}</code>
-        </div>
+    <div class="actions" style="justify-content:center;margin-top:14px">
+      <a id="dl-png" href="#" class="btn primary" download="qr_{{ link.slug }}.png">PNG</a>
+      <a id="dl-png-transp" href="#" class="btn ghost" download="qr_{{ link.slug }}_transparent.png">Transparent PNG</a>
+      <a id="dl-svg" href="#" class="btn ghost" download="qr_{{ link.slug }}.svg">SVG</a>
     </div>
-
-    <div class="card glass">
-        <form method="POST"
-            action="{{ url_for('dashboard.dashboard_links.qr_save', slug=link.slug) }}"
-            enctype="multipart/form-data"
-            id="qr-form">
-            <div class="form-grid">
-                <div class="form-group">
-                    <label for="fg_color">Foreground color</label>
-                    <input type="color" name="fg_color" id="fg_color" value="{{ qr_config.fg_color }}" oninput="livePreview()">
-                </div>
-                <div class="form-group">
-                    <label for="bg_color">Background color</label>
-                    <input type="color" name="bg_color" id="bg_color" value="{{ qr_config.bg_color }}" oninput="livePreview()">
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label style="display:flex;align-items:center;gap:0.5rem;font-weight:500;">
-                    <input type="checkbox" name="transparent_bg" id="transparent_bg"
-                        {% if qr_config.transparent_bg %}checked{% endif %}
-                        onchange="livePreview()">
-                    Transparent background
-                </label>
-            </div>
-
-            <div class="form-grid">
-                <div class="form-group">
-                    <label for="gradient_color">Gradient color</label>
-                    <input type="color" name="gradient_color" id="gradient_color"
-                        value="{{ qr_config.gradient_color or '#00C853' }}"
-                        oninput="livePreview()">
-                    <label style="display:flex;align-items:center;gap:0.5rem;margin-top:0.45rem;font-size:0.82rem;font-weight:500;">
-                        <input type="checkbox" name="enable_gradient" id="enable_gradient"
-                            {% if qr_config.gradient_color %}checked{% endif %}
-                            onchange="toggleGradient()">
-                        Enable gradient
-                    </label>
-                </div>
-                <div class="form-group" id="gradient_dir_row" {% if not qr_config.gradient_color %}style="display:none;"{% endif %}>
-                    <label for="gradient_direction">Gradient direction</label>
-                    <select name="gradient_direction" id="gradient_direction" onchange="livePreview()">
-                        <option value="diagonal" {% if qr_config.gradient_direction == 'diagonal' %}selected{% endif %}>Diagonal</option>
-                        <option value="horizontal" {% if qr_config.gradient_direction == 'horizontal' %}selected{% endif %}>Horizontal</option>
-                        <option value="vertical" {% if qr_config.gradient_direction == 'vertical' %}selected{% endif %}>Vertical</option>
-                        <option value="radial" {% if qr_config.gradient_direction == 'radial' %}selected{% endif %}>Radial</option>
-                    </select>
-                </div>
-            </div>
-
-            <div class="form-grid">
-                <div class="form-group">
-                    <label for="dot_style">Dot style</label>
-                    <select name="dot_style" id="dot_style" onchange="livePreview()">
-                        <option value="square" {% if qr_config.dot_style == 'square' %}selected{% endif %}>Square</option>
-                        <option value="rounded" {% if qr_config.dot_style == 'rounded' %}selected{% endif %}>Rounded</option>
-                        <option value="circle" {% if qr_config.dot_style == 'circle' %}selected{% endif %}>Circle</option>
-                    </select>
-                </div>
-                <div class="form-group">
-                    <label for="error_correction">Error correction</label>
-                    <select name="error_correction" id="error_correction" onchange="livePreview()">
-                        <option value="L" {% if qr_config.error_correction == 'L' %}selected{% endif %}>L - 7%</option>
-                        <option value="M" {% if qr_config.error_correction == 'M' %}selected{% endif %}>M - 15%</option>
-                        <option value="Q" {% if qr_config.error_correction == 'Q' %}selected{% endif %}>Q - 25%</option>
-                        <option value="H" {% if qr_config.error_correction == 'H' %}selected{% endif %}>H - 30%</option>
-                    </select>
-                    <div id="ec-warning" style="font-size:0.75rem;color:#FF6D00;margin-top:0.35rem;display:none;">
-                        Error correction set to H because a logo is present.
-                    </div>
-                </div>
-            </div>
-
-            <div class="form-group">
-                <label for="logo_file">Logo at center</label>
-                {% if qr_config.logo_path %}
-                <div style="display:flex;align-items:center;gap:0.75rem;margin-bottom:0.5rem;font-size:0.84rem;color:var(--accent-primary);">
-                    <span>Logo uploaded</span>
-                    <label style="display:flex;align-items:center;gap:0.35rem;color:var(--text-secondary);font-weight:500;">
-                        <input type="checkbox" name="remove_logo" value="1" onchange="livePreview()"> Remove
-                    </label>
-                </div>
-                {% endif %}
-                <input type="file" name="logo_file" id="logo_file" accept=".png,.jpg,.jpeg,.webp,.svg" onchange="onLogoChange()">
-                <div class="help-text">PNG, JPG, WEBP or SVG. Logos force H error correction and are capped at 25% of QR width.</div>
-            </div>
-
-            <div class="form-footer">
-                <button type="submit" class="btn btn-primary">Save configuration</button>
-                <button type="button" class="btn btn-ghost" onclick="resetDefaults()">Reset</button>
-            </div>
-        </form>
+    <div class="muted mono" style="margin-top:12px;word-break:break-all;text-align:center;">
+      {{ link.public_masked_url or request.host_url.rstrip('/') ~ '/' ~ link.slug }}
     </div>
-</div>
+  </div>
 
+  <div class="panel pad">
+    <form method="POST"
+      action="{{ url_for('dashboard.dashboard_links.qr_save', slug=link.slug) }}"
+      enctype="multipart/form-data"
+      id="qr-form">
+      <input type="hidden" name="csrf_token" value="{{ csrf_token() }}">
+      <div class="form-grid">
+        <div class="field">
+          <label for="fg_color">Foreground</label>
+          <input class="input" type="color" name="fg_color" id="fg_color" value="{{ qr_config.fg_color }}" oninput="livePreview()">
+        </div>
+        <div class="field">
+          <label for="bg_color">Background</label>
+          <input class="input" type="color" name="bg_color" id="bg_color" value="{{ qr_config.bg_color }}" oninput="livePreview()">
+        </div>
+        <div class="field">
+          <label for="gradient_color">Gradient</label>
+          <input class="input" type="color" name="gradient_color" id="gradient_color" value="{{ qr_config.gradient_color or '#00C853' }}" oninput="livePreview()">
+        </div>
+        <div class="field">
+          <label for="gradient_direction">Gradient direction</label>
+          <select class="select" name="gradient_direction" id="gradient_direction" onchange="livePreview()">
+            <option value="diagonal" {% if qr_config.gradient_direction == 'diagonal' %}selected{% endif %}>Diagonal</option>
+            <option value="horizontal" {% if qr_config.gradient_direction == 'horizontal' %}selected{% endif %}>Horizontal</option>
+            <option value="vertical" {% if qr_config.gradient_direction == 'vertical' %}selected{% endif %}>Vertical</option>
+            <option value="radial" {% if qr_config.gradient_direction == 'radial' %}selected{% endif %}>Radial</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="dot_style">Dot style</label>
+          <select class="select" name="dot_style" id="dot_style" onchange="livePreview()">
+            <option value="square" {% if qr_config.dot_style == 'square' %}selected{% endif %}>Square</option>
+            <option value="rounded" {% if qr_config.dot_style == 'rounded' %}selected{% endif %}>Rounded</option>
+            <option value="circle" {% if qr_config.dot_style == 'circle' %}selected{% endif %}>Circle</option>
+          </select>
+        </div>
+        <div class="field">
+          <label for="error_correction">Error correction</label>
+          <select class="select" name="error_correction" id="error_correction" onchange="livePreview()">
+            <option value="L" {% if qr_config.error_correction == 'L' %}selected{% endif %}>L - 7%</option>
+            <option value="M" {% if qr_config.error_correction == 'M' %}selected{% endif %}>M - 15%</option>
+            <option value="Q" {% if qr_config.error_correction == 'Q' %}selected{% endif %}>Q - 25%</option>
+            <option value="H" {% if qr_config.error_correction == 'H' %}selected{% endif %}>H - 30%</option>
+          </select>
+        </div>
+      </div>
+
+      <div class="toggle-list" style="grid-template-columns:repeat(2,minmax(0,1fr));margin-top:14px">
+        <label class="toggle {% if qr_config.transparent_bg %}enabled{% endif %}">
+          <div><h3>Transparent background</h3><p>Useful for design overlays.</p></div>
+          <input type="checkbox" name="transparent_bg" id="transparent_bg" {% if qr_config.transparent_bg %}checked{% endif %} onchange="livePreview()">
+        </label>
+        <label class="toggle {% if qr_config.gradient_color %}enabled{% endif %}">
+          <div><h3>Enable gradient</h3><p>Uses the selected second color.</p></div>
+          <input type="checkbox" name="enable_gradient" id="enable_gradient" {% if qr_config.gradient_color %}checked{% endif %} onchange="livePreview()">
+        </label>
+      </div>
+
+      <div class="field" style="margin-top:14px">
+        <label for="logo_file">Logo at center</label>
+        {% if qr_config.logo_path %}
+        <div class="badge info" style="margin-bottom:8px">Logo uploaded</div>
+        <label class="badge warn" style="margin-bottom:8px"><input type="checkbox" name="remove_logo" value="1" onchange="livePreview()"> Remove logo</label>
+        {% endif %}
+        <input class="input" type="file" name="logo_file" id="logo_file" accept=".png,.jpg,.jpeg,.webp,.svg" onchange="onLogoChange()">
+        <p class="muted">PNG, JPG, WEBP or SVG. Logos force H error correction.</p>
+      </div>
+
+      <div class="actions" style="margin-top:18px">
+        <button type="submit" class="btn primary">Save configuration</button>
+        <button type="button" class="btn ghost" onclick="resetDefaults()">Reset</button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}
+
+{% block scripts %}
 <script nonce="{{ csp_nonce|default('') }}">
-    function previewUrl(transparent, fmt) {
-        const fg = document.getElementById("fg_color").value.replace("#", "");
-        const bg = document.getElementById("bg_color").value.replace("#", "");
-        const ec = document.getElementById("error_correction").value;
-        const dot = document.getElementById("dot_style").value;
-        const dir = document.getElementById("gradient_direction").value;
-        const gradEnabled = document.getElementById("enable_gradient").checked;
-        const grad = gradEnabled ? document.getElementById("gradient_color").value.replace("#", "") : "";
-        const transp = transparent || document.getElementById("transparent_bg").checked;
-        const format = fmt || "png";
-
-        let url = `{{ url_for('dashboard.dashboard_links.qr_code', slug=link.slug) }}?scale=10&format=${format}&fg_color=%23${fg}&bg_color=%23${bg}&error_correction=${ec}&dot_style=${dot}`;
-        if (grad) {
-            url += `&gradient_color=%23${grad}&gradient_direction=${dir}`;
-        }
-        if (transp) {
-            url += "&transparent_bg=1";
-        }
-        return url;
-    }
-
-    function livePreview() {
-        document.getElementById("qr-preview").src = previewUrl(false, "png");
-        document.getElementById("dl-png").href = previewUrl(false, "png");
-        document.getElementById("dl-png-transp").href = previewUrl(true, "png");
-        document.getElementById("dl-svg").href = previewUrl(false, "svg");
-    }
-
-    function toggleGradient() {
-        const enabled = document.getElementById("enable_gradient").checked;
-        document.getElementById("gradient_dir_row").style.display = enabled ? "block" : "none";
-        livePreview();
-    }
-
-    function onLogoChange() {
-        const file = document.getElementById("logo_file").files[0];
-        if (file) {
-            document.getElementById("error_correction").value = "H";
-            document.getElementById("ec-warning").style.display = "block";
-        } else {
-            document.getElementById("ec-warning").style.display = "none";
-        }
-        livePreview();
-    }
-
-    function resetDefaults() {
-        document.getElementById("fg_color").value = "#000000";
-        document.getElementById("bg_color").value = "#ffffff";
-        document.getElementById("gradient_color").value = "#00C853";
-        document.getElementById("enable_gradient").checked = false;
-        document.getElementById("transparent_bg").checked = false;
-        document.getElementById("error_correction").value = "M";
-        document.getElementById("dot_style").value = "square";
-        document.getElementById("gradient_dir_row").style.display = "none";
-        document.getElementById("ec-warning").style.display = "none";
-        livePreview();
-    }
-
-    livePreview();
+function previewUrl(transparent, fmt) {
+  const fg = document.getElementById("fg_color").value.replace("#", "");
+  const bg = document.getElementById("bg_color").value.replace("#", "");
+  const ec = document.getElementById("error_correction").value;
+  const dot = document.getElementById("dot_style").value;
+  const dir = document.getElementById("gradient_direction").value;
+  const gradEnabled = document.getElementById("enable_gradient").checked;
+  const grad = gradEnabled ? document.getElementById("gradient_color").value.replace("#", "") : "";
+  const transp = transparent || document.getElementById("transparent_bg").checked;
+  const format = fmt || "png";
+  let url = `{{ url_for('dashboard.dashboard_links.qr_code', slug=link.slug) }}?scale=10&format=${format}&fg_color=%23${fg}&bg_color=%23${bg}&error_correction=${ec}&dot_style=${dot}`;
+  if (grad) url += `&gradient_color=%23${grad}&gradient_direction=${dir}`;
+  if (transp) url += "&transparent_bg=1";
+  return url;
+}
+function livePreview() {
+  document.getElementById("qr-preview").src = previewUrl(false, "png");
+  document.getElementById("dl-png").href = previewUrl(false, "png");
+  document.getElementById("dl-png-transp").href = previewUrl(true, "png");
+  document.getElementById("dl-svg").href = previewUrl(false, "svg");
+  document.querySelectorAll(".toggle").forEach((toggle) => {
+    const input = toggle.querySelector("input[type='checkbox']");
+    if (input) toggle.classList.toggle("enabled", input.checked);
+  });
+}
+function onLogoChange() {
+  if (document.getElementById("logo_file").files[0]) {
+    document.getElementById("error_correction").value = "H";
+  }
+  livePreview();
+}
+function resetDefaults() {
+  document.getElementById("fg_color").value = "#000000";
+  document.getElementById("bg_color").value = "#ffffff";
+  document.getElementById("gradient_color").value = "#00C853";
+  document.getElementById("enable_gradient").checked = false;
+  document.getElementById("transparent_bg").checked = false;
+  document.getElementById("error_correction").value = "M";
+  document.getElementById("dot_style").value = "square";
+  livePreview();
+}
+livePreview();
 </script>
 {% endblock %}

--- a/server/worker.py
+++ b/server/worker.py
@@ -9,7 +9,7 @@ from datetime import datetime, timedelta, timezone
 from zoneinfo import ZoneInfo
 
 import requests
-from sqlalchemy import func
+from sqlalchemy import func, or_
 
 from .extensions import db, log_queue
 from .models import Link, Visit
@@ -60,7 +60,7 @@ def _fire_webhook(webhook_url: str, webhook_secret: str, visit_payload: dict) ->
         headers = {"Content-Type": "application/json"}
         if webhook_secret:
             signature = hmac.new(webhook_secret.encode("utf-8"), body, hashlib.sha256).hexdigest()
-            headers["X-UlrTrack-Signature"] = signature
+            headers["X-UrlTrack-Signature"] = signature
         requests.post(webhook_url, data=body, headers=headers, timeout=5)
     except Exception as exc:
         print(f"Webhook delivery error: {exc}")
@@ -183,12 +183,39 @@ def _upsert_lead(app, visit: Visit) -> None:
 
     try:
         lead = None
+
+        def _lead_by_canvas(canvas_hash):
+            if not canvas_hash:
+                return None
+            lead_match = Lead.query.filter(Lead.all_canvas_hashes.contains(f'"{canvas_hash}"')).first()
+            if lead_match:
+                return lead_match
+            return Lead.query.filter_by(primary_canvas_hash=canvas_hash).first()
+
         if visit.email:
             lead = Lead.query.filter_by(email=visit.email).first()
-        if not lead and visit.canvas_hash:
-            lead = Lead.query.filter(Lead.all_canvas_hashes.contains(f'"{visit.canvas_hash}"')).first()
-            if not lead:
-                lead = Lead.query.filter_by(primary_canvas_hash=visit.canvas_hash).first()
+        if not lead:
+            lead = _lead_by_canvas(visit.canvas_hash)
+        if not lead and (visit.visitor_id or visit.thumbmark_visitor_id):
+            identity_filters = []
+            if visit.visitor_id:
+                identity_filters.append(Visit.visitor_id == visit.visitor_id)
+            if visit.thumbmark_visitor_id:
+                identity_filters.append(Visit.thumbmark_visitor_id == visit.thumbmark_visitor_id)
+            related_visits = (
+                Visit.query.filter(Visit.id != visit.id)
+                .filter(or_(*identity_filters))
+                .order_by(Visit.timestamp.desc())
+                .limit(25)
+                .all()
+            )
+            for related in related_visits:
+                if related.email:
+                    lead = Lead.query.filter_by(email=related.email).first()
+                if not lead:
+                    lead = _lead_by_canvas(related.canvas_hash)
+                if lead:
+                    break
 
         def _append(json_str, value):
             try:

--- a/server/worker.py
+++ b/server/worker.py
@@ -38,6 +38,8 @@ def _build_visit_payload(visit: Visit) -> dict:
         "city": visit.city,
         "email": visit.email,
         "canvas_hash": visit.canvas_hash,
+        "thumbmark_hash": visit.thumbmark_hash,
+        "visitor_id": visit.visitor_id,
         "etag": visit.etag,
         "is_vpn": visit.is_vpn,
         "is_suspicious": visit.is_suspicious,
@@ -487,6 +489,7 @@ def _handle_task(app, task):
                     visit,
                     missing_beacon=not bool(visit.beacon_received_at),
                     secret=app.config.get("FINGERPRINT_SECRET"),
+                    use_thumbmark_api=bool(task.get("thumbmark_api", True)),
                 )
                 db.session.commit()
                 _upsert_lead(app, visit)

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -1,4 +1,5 @@
 import json
+from pathlib import Path
 
 
 def _create_visit(app):
@@ -168,6 +169,53 @@ def test_thumbmark_fp_endpoint_stores_payload_and_enqueues(app, client, monkeypa
         assert stored.cpu_cores == 8
         assert stored.ram_gb == 16
         assert stored.beacon_received_at is not None
+
+
+def test_loading_template_uses_thumbmark_public_api():
+    template = (Path(__file__).resolve().parents[1] / "server/templates/loading.html").read_text(encoding="utf-8")
+    assert "new ThumbmarkJS.Thumbmark" not in template
+    assert "ThumbmarkJS.getFingerprint" in template
+
+
+def test_thumbmark_api_request_keeps_api_key_out_of_body_and_authorization(app, monkeypatch):
+    from server.extensions import db
+    from server.models import Link, Visit
+    from server.services import thumbmark
+
+    captured = {}
+
+    class Response:
+        status_code = 200
+
+        def json(self):
+            return {"visitorId": "tm-api-visitor", "confidence": 0.7}
+
+    def fake_post(url, *, headers, json, timeout):
+        captured["headers"] = headers
+        captured["json"] = json
+        return Response()
+
+    monkeypatch.setattr(thumbmark.requests, "post", fake_post)
+
+    with app.app_context():
+        app.config["THUMBMARK_API_KEY"] = "secret-key"
+        link = Link(slug="tm-api", destination="https://example.com")
+        db.session.add(link)
+        db.session.commit()
+        visit = Visit(
+            link_id=link.id,
+            thumbmark_hash="tm-hash",
+            thumbmark_raw='{"components":{"canvas":"abc"},"version":"1.0"}',
+        )
+        db.session.add(visit)
+        db.session.commit()
+
+        result = thumbmark.call_thumbmark_api(visit)
+
+        assert result["visitorId"] == "tm-api-visitor"
+        assert captured["headers"]["x-api-key"] == "secret-key"
+        assert "Authorization" not in captured["headers"]
+        assert captured["json"]["options"].get("api_key") is None
 
 
 def test_thumbmark_signals_match_same_visitor(app):

--- a/tests/test_beacon.py
+++ b/tests/test_beacon.py
@@ -119,6 +119,101 @@ def test_beacon_missing_token_returns_403(app, client):
     assert response.status_code == 403
 
 
+def test_thumbmark_fp_endpoint_stores_payload_and_enqueues(app, client, monkeypatch):
+    from server.extensions import db
+    from server.models import Visit
+    from server.routes import public as public_routes
+    from server.utils import sign_visit_token
+
+    class QueueRecorder:
+        def __init__(self):
+            self.items = []
+
+        def put(self, item):
+            self.items.append(item)
+
+    queue = QueueRecorder()
+    monkeypatch.setattr(public_routes, "log_queue", queue)
+    visit_id = _create_visit(app)
+    token = sign_visit_token(visit_id)
+
+    response = client.post(
+        "/fp",
+        json={
+            "visit_id": visit_id,
+            "visit_token": token,
+            "thumbmark_hash": "tm-hash-1",
+            "thumbmark_raw": '{"thumbmark":"tm-hash-1","components":{}}',
+            "fp_canvas_hash": "canvas-tm",
+            "fp_audio_hash": "audio-tm",
+            "fp_webgl_hash": "webgl-tm",
+            "fp_screen_profile": "1920x1080x24@2",
+            "fp_hardware_profile": "8c/16gb/0tp",
+            "fp_languages": "it-IT,en-US",
+            "fp_timezone": "Europe/Rome",
+        },
+    )
+
+    assert response.status_code == 204
+    assert queue.items == [{"type": "enrich_visit", "visit_id": visit_id, "notify": False, "thumbmark_api": True}]
+
+    with app.app_context():
+        stored = db.session.get(Visit, visit_id)
+        assert stored.thumbmark_hash == "tm-hash-1"
+        assert stored.fp_canvas_hash == "canvas-tm"
+        assert stored.canvas_hash == "canvas-tm"
+        assert stored.audio_fp == "audio-tm"
+        assert stored.screen_res == "1920x1080"
+        assert stored.pixel_ratio == 2.0
+        assert stored.cpu_cores == 8
+        assert stored.ram_gb == 16
+        assert stored.beacon_received_at is not None
+
+
+def test_thumbmark_signals_match_same_visitor(app):
+    from server.extensions import db
+    from server.models import Link, Visit, VisitorSignal
+    from server.services.scoring import apply_visit_scoring
+
+    with app.app_context():
+        link = Link(slug="thumbmark-match", destination="https://example.com")
+        db.session.add(link)
+        db.session.commit()
+        first = Visit(
+            link_id=link.id,
+            ip_address="1.1.1.1",
+            thumbmark_hash="shared-thumbmark",
+            fp_canvas_hash="shared-canvas",
+            fp_audio_hash="shared-audio",
+            fp_webgl_hash="shared-webgl",
+        )
+        second = Visit(
+            link_id=link.id,
+            ip_address="1.1.1.2",
+            thumbmark_hash="shared-thumbmark",
+            fp_canvas_hash="shared-canvas",
+            fp_audio_hash="shared-audio",
+            fp_webgl_hash="shared-webgl",
+        )
+        db.session.add_all([first, second])
+        db.session.commit()
+
+        apply_visit_scoring(first)
+        apply_visit_scoring(second)
+        db.session.commit()
+
+        assert first.visitor_id
+        assert second.visitor_id == first.visitor_id
+        assert second.identity_confidence >= 60
+        signal = VisitorSignal.query.filter_by(
+            visitor_id=first.visitor_id,
+            signal_type="thumbmark_hash",
+            signal_value="shared-thumbmark",
+        ).first()
+        assert signal is not None
+        assert signal.occurrence_count == 2
+
+
 def test_api_invalid_visit_id_returns_404_not_500(app, client, auth):
     from server.utils import sign_visit_token
 

--- a/tests/test_dashboard_cross_tracking.py
+++ b/tests/test_dashboard_cross_tracking.py
@@ -164,3 +164,36 @@ def test_cross_tracking_filters_by_min_risk(app, client, auth):
     assert response.status_code == 200
     assert b"hot@example.com" in response.data
     assert b"safe@example.com" not in response.data
+
+
+def test_identity_graph_renders_thumbmark_signal_nodes(app, client, auth):
+    from server.extensions import db
+    from server.models import Link, Visit
+    from server.services.scoring import apply_visit_scoring
+
+    auth.login()
+    with app.app_context():
+        link = Link(slug="graph-thumbmark", destination="https://example.com")
+        db.session.add(link)
+        db.session.commit()
+        visit = Visit(
+            link_id=link.id,
+            ip_address="9.9.9.9",
+            thumbmark_hash="graph-thumbmark-hash",
+            fp_canvas_hash="graph-canvas",
+            fp_audio_hash="graph-audio",
+            fp_webgl_hash="graph-webgl",
+            identity_confidence=80,
+        )
+        db.session.add(visit)
+        db.session.commit()
+        apply_visit_scoring(visit)
+        db.session.commit()
+
+    response = client.get("/dashboard/graph")
+
+    assert response.status_code == 200
+    assert b"thumbmark_hash" in response.data
+    assert b"canvas_hash" in response.data
+    assert b"has fingerprint" in response.data
+    assert b"occurrence_count" in response.data

--- a/tests/test_leads.py
+++ b/tests/test_leads.py
@@ -1,3 +1,6 @@
+import json
+
+
 def test_enrich_visit_upserts_lead(app, monkeypatch):
     from server import worker
     from server.extensions import db
@@ -66,6 +69,47 @@ def test_lead_upsert_does_not_match_canvas_substrings(app, monkeypatch):
         assert existing.total_visits == 1
         assert created is not None
         assert created.id != existing_id
+
+
+def test_lead_upsert_matches_existing_lead_by_visitor_identity(app):
+    from server import worker
+    from server.extensions import db
+    from server.models import Lead, Link, Visit, Visitor
+
+    with app.app_context():
+        link = Link(slug="lead-visitor", destination="https://example.com")
+        visitor = Visitor(id="visitor-identity-1")
+        existing = Lead(
+            primary_canvas_hash="old-canvas",
+            all_canvas_hashes='["old-canvas"]',
+            all_ips='["1.1.1.1"]',
+            total_visits=1,
+        )
+        prior = Visit(
+            link=link,
+            visitor_id=visitor.id,
+            ip_address="1.1.1.1",
+            canvas_hash="old-canvas",
+            thumbmark_visitor_id="tm-visitor-1",
+        )
+        current = Visit(
+            link=link,
+            visitor_id=visitor.id,
+            ip_address="1.1.1.2",
+            canvas_hash="new-canvas",
+            thumbmark_visitor_id="tm-visitor-1",
+        )
+        db.session.add_all([link, visitor, existing, prior, current])
+        db.session.commit()
+        current_id = current.id
+        existing_id = existing.id
+
+        worker._upsert_lead(app, db.session.get(Visit, current_id))
+
+        updated = db.session.get(Lead, existing_id)
+        assert updated.total_visits == 2
+        assert json.loads(updated.all_canvas_hashes) == ["old-canvas", "new-canvas"]
+        assert Lead.query.count() == 1
 
 
 def test_leads_dashboard_detail_and_update(app, client, auth):

--- a/tests/test_links.py
+++ b/tests/test_links.py
@@ -101,6 +101,69 @@ def test_qr_missing_slug_returns_404(app, client, auth):
     assert response.status_code == 404
 
 
+def test_qr_code_supports_svg_and_custom_png(app, client, auth):
+    from server.extensions import db
+    from server.models import Link
+
+    auth.login()
+    with app.app_context():
+        link = Link(slug="qr-custom", destination="https://example.com")
+        db.session.add(link)
+        db.session.commit()
+
+    png_response = client.get(
+        "/dashboard/qr/qr-custom?fg_color=%2300C853&bg_color=%23ffffff&gradient_color=%2300BCD4&dot_style=circle"
+    )
+    assert png_response.status_code == 200
+    assert png_response.headers["Content-Type"] == "image/png"
+    assert png_response.data.startswith(b"\x89PNG")
+
+    svg_response = client.get("/dashboard/qr/qr-custom?format=svg&transparent_bg=1")
+    assert svg_response.status_code == 200
+    assert svg_response.headers["Content-Type"] == "image/svg+xml"
+    assert b"<svg" in svg_response.data
+
+
+def test_qr_save_persists_config(app, client, auth):
+    import json
+
+    from server.extensions import db
+    from server.models import Link
+
+    auth.login()
+    with app.app_context():
+        link = Link(slug="qr-save", destination="https://example.com")
+        db.session.add(link)
+        db.session.commit()
+
+    response = client.post(
+        "/dashboard/qr_save/qr-save",
+        data={
+            "fg_color": "#111111",
+            "bg_color": "#eeeeee",
+            "enable_gradient": "on",
+            "gradient_color": "#00C853",
+            "gradient_direction": "vertical",
+            "error_correction": "Q",
+            "dot_style": "rounded",
+            "transparent_bg": "on",
+        },
+        follow_redirects=False,
+    )
+    assert response.status_code == 302
+
+    with app.app_context():
+        link = Link.query.filter_by(slug="qr-save").first()
+        config = json.loads(link.qr_config)
+        assert config["fg_color"] == "#111111"
+        assert config["bg_color"] == "#EEEEEE"
+        assert config["gradient_color"] == "#00C853"
+        assert config["gradient_direction"] == "vertical"
+        assert config["error_correction"] == "Q"
+        assert config["dot_style"] == "rounded"
+        assert config["transparent_bg"] is True
+
+
 def test_edit_page_exposes_country_picker_and_safe_url(app, client, auth):
     from server.extensions import db
     from server.models import Link

--- a/tests/test_worker.py
+++ b/tests/test_worker.py
@@ -26,6 +26,25 @@ def test_send_telegram_text_falls_back_to_plain(monkeypatch):
     assert "\\" not in calls[1]["json"]["text"]
 
 
+def test_fire_webhook_uses_urltrack_signature_header(monkeypatch):
+    from server import worker
+
+    captured = {}
+
+    def fake_post(url, data, headers, timeout):
+        captured["url"] = url
+        captured["data"] = data
+        captured["headers"] = headers
+        captured["timeout"] = timeout
+
+    monkeypatch.setattr(worker.requests, "post", fake_post)
+
+    worker._fire_webhook("https://hooks.example/ingest", "secret", {"visit_id": 123})
+
+    assert captured["headers"]["X-UrlTrack-Signature"]
+    assert "X-UlrTrack-Signature" not in captured["headers"]
+
+
 def test_handle_task_preserves_existing_vpn_flags(app, monkeypatch):
     from server import worker
     from server.extensions import db


### PR DESCRIPTION
## What changed
- Add ThumbmarkJS collection on the redirect bounce page and persist `/fp` beacon data.
- Add `Visitor` / `VisitorSignal` schema, weighted signal matching, and selective Thumbmark API enrichment.
- Update the identity graph to render Thumbmark, canvas, audio, WebGL, device, timezone, IP, visit, and probable-match nodes.
- Add advanced QR customization with persisted `Link.qr_config`, PNG/SVG exports, colors, gradients, transparent background, dot styles, and centered logo upload.
- Add tests for `/fp`, Thumbmark signal matching, graph rendering, QR PNG/SVG generation, and QR config persistence.

## Impact
This preserves legacy beacon/scoring behavior while adding a persistent identity graph backed by weighted Thumbmark signals, plus a richer QR editor for existing tracked links.

## Validation
- `python3 -m pytest -q` -> `40 passed`
- Alembic upgrade on temporary SQLite DB completed successfully through `b79f4d9a66c1`
- Pillow import verified (`10.4.0` already present in requirements)
- Local QR server check: `/dashboard/qr_view/qr-demo` rendered editor controls; `/dashboard/qr/qr-demo?format=png` returned image/png; `/dashboard/qr/qr-demo?format=svg` returned valid SVG
- Earlier local browser check: tracking link redirected and `POST /fp` returned `204`; DB populated `thumbmark_hash`, `fp_canvas_hash`, `fp_audio_hash`, and `fp_webgl_hash`
